### PR TITLE
Add CommandController

### DIFF
--- a/LogicFramework/Sources/Controllers/CommandController.swift
+++ b/LogicFramework/Sources/Controllers/CommandController.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public protocol CommandControllingDelegate: AnyObject {
+  func commandController(_ controller: CommandController, didFinishRunning commands: [Command])
+}
+
+public protocol CommandControlling {
+  var delegate: CommandControllingDelegate? { get set }
+  func run(_ commands: [Command])
+}
+
+public class CommandController: CommandControlling {
+  weak public var delegate: CommandControllingDelegate?
+
+  init() {}
+
+  public func run(_ commands: [Command]) {
+    commands.forEach(run)
+    delegate?.commandController(self, didFinishRunning: commands)
+  }
+
+  private func run(_ command: Command) {
+    switch command {
+    case .application:
+      break
+    case .keyboard:
+      break
+    case .open:
+      break
+    case .script:
+      break
+    }
+  }
+}

--- a/LogicFramework/Sources/Factories/ModelFactory.swift
+++ b/LogicFramework/Sources/Factories/ModelFactory.swift
@@ -35,14 +35,18 @@ class ModelFactory {
     Rule(applications: [application()], days: days())
   }
 
+  func scriptCommand(_ kind: ScriptCommand.Kind) -> ScriptCommand {
+    ScriptCommand(kind: kind)
+  }
+
   func scriptCommands() -> [ScriptCommand] {
     let path = URL(fileURLWithPath: "/tmp/file")
     let script = "#!/usr/bin/env fish"
     return [
-      ScriptCommand(kind: .appleScript(.inline(script))),
-      ScriptCommand(kind: .appleScript(.path(path))),
-      ScriptCommand(kind: .shell(.inline(script))),
-      ScriptCommand(kind: .shell(.path(path)))
+      scriptCommand(.appleScript(.inline(script))),
+      scriptCommand(.appleScript(.path(path))),
+      scriptCommand(.shell(.inline(script))),
+      scriptCommand(.shell(.path(path)))
     ]
   }
 

--- a/UnitTests/Sources/Controllers/CommandControllerTests.swift
+++ b/UnitTests/Sources/Controllers/CommandControllerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import LogicFramework
+
+class CommandControllerTests: XCTestCase {
+  func testCommandControllerRunningCommands() {
+    let factory = ModelFactory()
+    let commands: [Command] = [
+      .application(factory.applicationCommand()),
+      .keyboard(factory.keyboardCommand()),
+      .open(factory.openCommand()),
+      .script(factory.scriptCommand(.appleScript(.inline(""))))
+    ]
+    let controller = CommandController()
+    let expectation = self.expectation(description: "Wait for commands to run")
+    let delegate = Delegate { finishedCommands in
+      XCTAssertEqual(commands, finishedCommands)
+      expectation.fulfill()
+    }
+
+    controller.delegate = delegate
+    controller.run(commands)
+    wait(for: [expectation], timeout: 10)
+  }
+}
+
+private class Delegate: CommandControllingDelegate {
+  typealias Handler = ([Command]) -> Void
+  let handler: Handler
+
+  init(_ handler: @escaping Handler) {
+    self.handler = handler
+  }
+
+  func commandController(_ controller: CommandController, didFinishRunning commands: [Command]) {
+    handler(commands)
+  }
+}


### PR DESCRIPTION
- Add initial implementation of `CommandController`
- The controller implements a very basic protocol called
  `CommandControlling`
- Add `CommandControllerTests`
- Add new method on `ModelFactory` for creating script commands

**Note** the implementation of `CommandController` does nothing for the
time being, it basically just sets up a delegate relation and calls
it when all commands are done running.