### PR TITLE
Feature ApplicationCommandController

### DIFF
--- a/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
+++ b/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
@@ -1,0 +1,89 @@
+import Cocoa
+
+public protocol ApplicationCommandControlling: AnyObject {
+  func run(_ command: ApplicationCommand) throws
+}
+
+public enum ApplicationCommandControllingError: Error {
+  case failedToLaunch(ApplicationCommand)
+  case failedToFindRunningApplication(ApplicationCommand)
+  case failedToActivate(ApplicationCommand)
+}
+
+class ApplicationCommandController: ApplicationCommandControlling {
+  let workspace: NSWorkspace
+
+  init(workspace: NSWorkspace = .shared) {
+    self.workspace = workspace
+  }
+
+  // MARK: Public methods
+
+  func run(_ command: ApplicationCommand) throws {
+    if applicationHasWindows(command.application) {
+      try activateApplication(command)
+    } else {
+      try launchApplication(command)
+    }
+  }
+
+  // MARK: Private methods
+
+  /// Verify if the current application has any open windows
+  ///
+  /// Check if the application has any windows by generating an collection of window owners
+  /// using `CGWindowListCopyWindowInfo`.
+  /// The collection is then match against the applications `bundleName`.
+  ///
+  /// - Parameter application: The application that the windows should belong to, the applications
+  ///                          bundle name is used for matching.
+  /// - Returns: Returns true if any windows belonging to the application
+  private func applicationHasWindows(_ application: Application) -> Bool {
+    let info = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] ?? []
+    let windowOwners = info.filter {
+      ($0[kCGWindowLayer as String] as? Int ?? 0) >= 0
+    }.compactMap({ $0[kCGWindowOwnerName as String] as? String })
+    // TODO: Verify that `application.name` is `bundleName` and not a localized version.
+    //       Matching is done using `bundleName`.
+    return windowOwners.contains(application.name)
+  }
+
+  /// Launch an application using the applications bundle identifier
+  /// Applications are launched using `NSWorkspace`
+  ///
+  /// - Parameter command: An application command which is used to resolve the applications
+  ///                      bundle identifier.
+  /// - Throws: If `NSWorkspace.launchApplication` returns `false`, the method will throw
+  ///           `ApplicationCommandControllingError.failedToLaunch`
+  private func launchApplication(_ command: ApplicationCommand) throws {
+    if !workspace.launchApplication(withBundleIdentifier: command.application.bundleIdentifier,
+                                    options: .default,
+                                    additionalEventParamDescriptor: nil,
+                                    launchIdentifier: nil) {
+      throw ApplicationCommandControllingError.failedToLaunch(command)
+    }
+  }
+
+  /// Activate an application using its bundle identifier.
+  ///
+  /// Activation is done by filtering an match inside `NSWorkspace`'s `.runningApplications`.
+  /// The first element that matches the bundle identifier will be used to activate the
+  /// application by simply calling `activate` on the `NSRunningApplication`.
+  /// `activate` is called with the options `.activateIgnoringOtherApps`
+  ///
+  /// - Parameter command: An application command which is used to resolve the applications
+  ///                      bundle identifier.
+  /// - Throws: If the method cannot match a running application then
+  ///           a `.failedToFindRunningApplication` will be thrown.
+  ///           If `.activate` should fail, then another error will be thrown: `.failedToActivate`
+  private func activateApplication(_ command: ApplicationCommand) throws {
+    guard let runningApplication = workspace.runningApplications
+            .first(where: { $0.bundleIdentifier == command.application.bundleIdentifier }) else {
+      throw ApplicationCommandControllingError.failedToFindRunningApplication(command)
+    }
+
+    if !runningApplication.activate(options: .activateIgnoringOtherApps) {
+      throw ApplicationCommandControllingError.failedToActivate(command)
+    }
+  }
+}

--- a/LogicFramework/Sources/Controllers/CommandController.swift
+++ b/LogicFramework/Sources/Controllers/CommandController.swift
@@ -1,28 +1,53 @@
 import Foundation
 
 public protocol CommandControllingDelegate: AnyObject {
+  func commandController(_ controller: CommandController, failedRunning command: Command,
+                         commands: [Command])
   func commandController(_ controller: CommandController, didFinishRunning commands: [Command])
 }
 
-public protocol CommandControlling {
+public protocol CommandControlling: AnyObject {
   var delegate: CommandControllingDelegate? { get set }
-  func run(_ commands: [Command])
+  func run(_ commands: [Command]) throws
 }
 
 public class CommandController: CommandControlling {
   weak public var delegate: CommandControllingDelegate?
 
-  init() {}
+  let applicationCommandController: ApplicationCommandControlling
 
-  public func run(_ commands: [Command]) {
-    commands.forEach(run)
-    delegate?.commandController(self, didFinishRunning: commands)
+  init(applicationCommandController: ApplicationCommandControlling) {
+    self.applicationCommandController = applicationCommandController
   }
 
-  private func run(_ command: Command) {
+  // MARK: Public methods
+
+  public func run(_ commands: [Command]) throws {
+    do {
+      try commands.forEach(run)
+      delegate?.commandController(self, didFinishRunning: commands)
+    } catch let error {
+      if let applicationError = error as? ApplicationCommandControllingError {
+        switch applicationError {
+        case .failedToActivate(let command),
+             .failedToFindRunningApplication(let command),
+             .failedToLaunch(let command):
+          delegate?.commandController(
+            self,
+            failedRunning: .application(command),
+            commands: commands)
+        }
+        throw error
+      }
+    }
+  }
+
+  // MARK: Private methods
+
+  private func run(_ command: Command) throws {
     switch command {
-    case .application:
-      break
+    case .application(let command):
+      try applicationCommandController.run(command)
     case .keyboard:
       break
     case .open:

--- a/LogicFramework/Sources/Factories/ControllerFactory.swift
+++ b/LogicFramework/Sources/Factories/ControllerFactory.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public class ControllerFactory {
+  public func commandController(
+    applicationCommandController: ApplicationCommandControlling? = nil
+  ) -> CommandControlling {
+    let applicationCommandController = applicationCommandController ?? ApplicationCommandController()
+    return CommandController(applicationCommandController: applicationCommandController)
+  }
+}

--- a/UnitTests/Sources/Mocks/ApplicationCommandControllerMock.swift
+++ b/UnitTests/Sources/Mocks/ApplicationCommandControllerMock.swift
@@ -1,0 +1,15 @@
+import Foundation
+import LogicFramework
+
+class ApplicationCommandControllerMock: ApplicationCommandControlling {
+  typealias Handler = () throws -> Void
+  let handler: Handler
+
+  init(_ handler: @escaping Handler = {}) {
+    self.handler = handler
+  }
+
+  func run(_ command: ApplicationCommand) throws {
+    try handler()
+  }
+}

--- a/UnitTests/Sources/Mocks/CommandControllingDelegateMock.swift
+++ b/UnitTests/Sources/Mocks/CommandControllingDelegateMock.swift
@@ -1,0 +1,26 @@
+import Foundation
+import LogicFramework
+
+class CommandControllingDelegateMock: CommandControllingDelegate {
+  enum CommandControllingDelegateState {
+    case failedRunning(Command, commands: [Command])
+    case finished([Command])
+  }
+
+  typealias Handler = (CommandControllingDelegateState) -> Void
+  let handler: Handler
+
+  init(_ handler: @escaping Handler) {
+    self.handler = handler
+  }
+
+  // MARK: CommandControllingDelegate
+
+  func commandController(_ controller: CommandController, failedRunning command: Command, commands: [Command]) {
+    handler(.failedRunning(command, commands: commands))
+  }
+
+  func commandController(_ controller: CommandController, didFinishRunning commands: [Command]) {
+    handler(.finished(commands))
+  }
+}


### PR DESCRIPTION
- Add `ApplicationCommandController` for launching and activating
  applications
- Add `ControllerFactory` for creating a command controller
- Add failing test to `CommandControllerTests`
- Add `ApplicationCommandControllerMock`
- Move `CommandControllingDelegateMock` and improve implementation

**Note** that we still need to add tests for `ApplicationCommandController` because right now we only test the `CommandController` by providing a mocked class.
We need to figure out a good way to mock the Cocoa classes and make them conform somehow.