### PR TITLE
Fix Unit Tests on Catalina

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -26,6 +26,8 @@
 	<string>Needs permission to Apple Events in order to run Apple Scripts</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2019 zenangst. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>NSSupportsAutomaticTermination</key>
 	<true/>
 	<key>NSSupportsSuddenTermination</key>


### PR DESCRIPTION
Adding `NSApplication` as Principal class made the tests run. 
However, it seems like we have another problem. You generated snapshots on Big Sur and they don't match the ones I'm getting on Catalina, I guess because of different system fonts and colors:
<img width="1104" alt="Screenshot 2020-09-09 at 22 29 44" src="https://user-images.githubusercontent.com/10529867/92649871-f7643f80-f2eb-11ea-8cb3-9ab96d8aae4a.png">
