### PR TITLE
Feature streaming current command with Combine

### DIFF
--- a/LogicFramework/Sources/Controllers/AppleScriptController.swift
+++ b/LogicFramework/Sources/Controllers/AppleScriptController.swift
@@ -28,6 +28,7 @@ class AppleScriptController: AppleScriptControlling {
   private let subject = PassthroughSubject<Command, Error>()
 
   func run(_ source: ScriptCommand.Source) {
+    subject.send(.script(.appleScript(source)))
     let appleScript: NSAppleScript
     switch source {
     case .inline(let source):

--- a/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
+++ b/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
@@ -34,6 +34,7 @@ class ApplicationCommandController: ApplicationCommandControlling {
   // MARK: Public methods
 
   func run(_ command: ApplicationCommand) {
+    subject.send(.application(command))
     // Verify if the current application has any open windows
     if windowListProvider.windowOwners().contains(command.application.bundleName) {
       activateApplication(command)

--- a/LogicFramework/Sources/Controllers/KeyboardCommandController.swift
+++ b/LogicFramework/Sources/Controllers/KeyboardCommandController.swift
@@ -16,6 +16,7 @@ class KeyboardCommandController: KeyboardCommandControlling {
   private let subject = PassthroughSubject<Command, Error>()
 
   func run(_ command: KeyboardCommand) {
+    subject.send(.keyboard(command))
     subject.send(completion: .finished)
   }
 }

--- a/LogicFramework/Sources/Controllers/OpenCommandController.swift
+++ b/LogicFramework/Sources/Controllers/OpenCommandController.swift
@@ -40,6 +40,7 @@ class OpenCommandController: OpenCommandControlling {
   }
 
   func run(_ command: OpenCommand) {
+    subject.send(.open(command))
     let path = command.path.sanitizedPath
     let url = URL(fileURLWithPath: path)
     let config = NSWorkspace.OpenConfiguration()

--- a/LogicFramework/Sources/Controllers/ShellScriptController.swift
+++ b/LogicFramework/Sources/Controllers/ShellScriptController.swift
@@ -28,6 +28,7 @@ class ShellScriptController: ShellScriptControlling {
   let shellPath: String = "/bin/bash"
 
   func run(_ source: ScriptCommand.Source) {
+    subject.send(.script(.shell(source)))
     let command: String
     switch source {
     case .inline(let inline):

--- a/UnitTests/Sources/Mocks/ApplicationCommandControllerMock.swift
+++ b/UnitTests/Sources/Mocks/ApplicationCommandControllerMock.swift
@@ -16,6 +16,7 @@ class ApplicationCommandControllerMock: ApplicationCommandControlling {
   }
 
   func run(_ command: ApplicationCommand) {
+    subject.send(Command.application(command))
     handler(subject)
   }
 }

--- a/UnitTests/Sources/Mocks/CommandControllerDelegateMock.swift
+++ b/UnitTests/Sources/Mocks/CommandControllerDelegateMock.swift
@@ -3,6 +3,7 @@ import LogicFramework
 
 class CommandControllerDelegateMock: CommandControllingDelegate {
   enum Output {
+    case running(Command)
     case failedRunning(Command, commands: [Command])
     case finished([Command])
   }
@@ -16,11 +17,15 @@ class CommandControllerDelegateMock: CommandControllingDelegate {
 
   // MARK: CommandControllingDelegate
 
-  func commandController(_ controller: CommandController, failedRunning command: Command, commands: [Command]) {
-    handler(.failedRunning(command, commands: commands))
+  func commandController(_ controller: CommandController, runningCommand command: Command) {
+    handler(.running(command))
   }
 
   func commandController(_ controller: CommandController, didFinishRunning commands: [Command]) {
     handler(.finished(commands))
+  }
+
+  func commandController(_ controller: CommandController, failedRunning command: Command, commands: [Command]) {
+    handler(.failedRunning(command, commands: commands))
   }
 }


### PR DESCRIPTION
- Add new delegate method on `CommandControllingDelegate`
  `func commandController(: CommandController, runningCommand: Command)`
- Call `subject.send` in command controllers to stream the current
  running command

#51 should be merge into this branch before this gets merged as it aims to fix the streaming values issue.