### PR TITLE
Refactor ApplicationCommandController

### DIFF
--- a/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
+++ b/LogicFramework/Sources/Controllers/ApplicationCommandController.swift
@@ -75,11 +75,17 @@ class ApplicationCommandController: ApplicationCommandControlling {
   ///           If `.activate` should fail, then another error will be thrown: `.failedToActivate`
   private func activateApplication(_ command: ApplicationCommand) throws {
     guard let runningApplication = workspace.applications
-            .first(where: { $0.bundleIdentifier == command.application.bundleIdentifier }) else {
+            .first(where: { $0.bundleIdentifier?.lowercased() == command.application.bundleIdentifier.lowercased() }) else {
       throw ApplicationCommandControllingError.failedToFindRunningApplication(command)
     }
 
-    if !runningApplication.activate(options: .activateIgnoringOtherApps) {
+    var options: NSApplication.ActivationOptions = .activateIgnoringOtherApps
+
+    if workspace.frontApplication?.bundleIdentifier?.lowercased() == command.application.bundleIdentifier.lowercased() {
+      options.insert(.activateAllWindows)
+    }
+
+    if !runningApplication.activate(options: options) {
       throw ApplicationCommandControllingError.failedToActivate(command)
     }
   }

--- a/LogicFramework/Sources/Protocols/WorkspaceProviding.swift
+++ b/LogicFramework/Sources/Protocols/WorkspaceProviding.swift
@@ -3,6 +3,7 @@ import Cocoa
 public typealias WorkspaceCompletion = ((RunningApplication?, Error?) -> Void)
 public protocol WorkspaceProviding {
   var applications: [RunningApplication] { get }
+  var frontApplication: RunningApplication? { get }
 
   func launchApplication(withBundleIdentifier bundleIdentifier: String,
                          options: NSWorkspace.LaunchOptions,
@@ -21,6 +22,10 @@ public protocol WorkspaceProviding {
 extension NSWorkspace: WorkspaceProviding {
   public var applications: [RunningApplication] {
     return runningApplications
+  }
+
+  public var frontApplication: RunningApplication? {
+    return frontmostApplication
   }
 
   public func open(_ url: URL,

--- a/UnitTests/Sources/Mocks/WorkspaceProviderMock.swift
+++ b/UnitTests/Sources/Mocks/WorkspaceProviderMock.swift
@@ -5,6 +5,7 @@ class WorkspaceProviderMock: WorkspaceProviding {
   typealias OpenHandler = WorkspaceCompletion?
   typealias OpenResult = (runningApplication: RunningApplication?, error: OpenCommandControllingError?)
 
+  var frontApplication: RunningApplication?
   var applications: [RunningApplication]
   var launchApplicationResult: Bool
   var openFileResult: OpenResult?


### PR DESCRIPTION
- Improve matching by lowercasing `bundleIdentifier`
- Add `frontApplication` to `WorkflowProviding`
  This is implemented as `.frontmostApplication` on `NSWorkspace`
- Add additional options to `RunningApplication.activate` if the application
  is already the frontmost application

This builds on #53, so that PR should be merged before this one.