### PR TITLE
Feature alert view when storage controller fails to load groups

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -23,7 +23,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       )
       self.controller = controller
     } catch let error {
-      assertionFailure(error.localizedDescription)
+      let alert = NSAlert()
+      alert.messageText = error.localizedDescription
+      if case .dataCorrupted(let context) = error as? DecodingError {
+        alert.informativeText = context.underlyingError?.localizedDescription ?? ""
+        alert.messageText = context.debugDescription
+      }
+      alert.runModal()
     }
   }
 }


### PR DESCRIPTION
- Add basic implementation for showing JSON errors when trying to load
  the `.keyboard-cowboy.json`

This is super basic but helps with development. We need to reiterate this feature to show end-user errors, not technical details before we release this to the public 😎 

<img width="372" alt="image" src="https://user-images.githubusercontent.com/57446/93941283-6602bd80-fd2e-11ea-9ff7-7a396e411f3d.png">
