### PR TITLE
Fix nested keyboard shortcut bug

### DIFF
--- a/LogicFramework/Sources/Hotkeys/HotkeyController.swift
+++ b/LogicFramework/Sources/Hotkeys/HotkeyController.swift
@@ -25,7 +25,6 @@ public class HotkeyController: HotkeyControlling, HotkeyHandlerDelegate {
   private(set) public var hotkeys = Set<Hotkey>()
   public let hotkeyHandler: HotkeyHandling
   public let notificationCenter: NotificationControlling
-  internal static let signature = "Keyboard-Cowboy"
 
   init(hotkeyHandler: HotkeyHandling,
        notificationCenter: NotificationControlling = NotificationCenter.default) {
@@ -42,7 +41,7 @@ public class HotkeyController: HotkeyControlling, HotkeyHandlerDelegate {
   }
 
   public func register(_ hotkey: Hotkey) {
-    if hotkeyHandler.register(hotkey, withSignature: HotkeyController.signature) {
+    if hotkeyHandler.register(hotkey) {
       hotkeys.insert(hotkey)
       delegate?.hotkeyControlling(self, didRegisterKeyboardShortcut: hotkey.keyboardShortcut)
     } else {

--- a/LogicFramework/Sources/Workflows/WorkflowController.swift
+++ b/LogicFramework/Sources/Workflows/WorkflowController.swift
@@ -28,12 +28,18 @@ class WorkflowController: WorkflowControlling {
     groups.flatMap { $0.workflows }
       .filter {
         if keyboardShortcuts.count < $0.keyboardShortcuts.count {
-          let lhs = $0.keyboardShortcuts.compactMap { $0.rawValue }.joined()
-          let rhs = keyboardShortcuts.compactMap { $0.rawValue }.joined()
+          let lhs = $0.keyboardShortcuts.rawValue
+          let rhs = keyboardShortcuts.rawValue
           return lhs.starts(with: rhs)
         } else {
-          return $0.keyboardShortcuts == keyboardShortcuts
+          return $0.keyboardShortcuts.rawValue == keyboardShortcuts.rawValue
         }
       }
+  }
+}
+
+private extension Collection where Element == KeyboardShortcut {
+  var rawValue: String {
+    compactMap { $0.rawValue }.joined()
   }
 }

--- a/UnitTests/Sources/Controllers/HotkeyControllerTests.swift
+++ b/UnitTests/Sources/Controllers/HotkeyControllerTests.swift
@@ -21,7 +21,7 @@ class HotkeyControllerTests: XCTestCase {
         installHandlerExpectation.fulfill()
       case .register(let registeredHotkey, let signature):
         XCTAssertEqual(hotkey, registeredHotkey)
-        XCTAssertEqual(HotkeyController.signature, signature)
+        XCTAssertEqual("HotkeyHandlerMock", signature)
         registerExpectation.fulfill()
       case .sendKeyboardEvent:
         break
@@ -62,7 +62,7 @@ class HotkeyControllerTests: XCTestCase {
         installHandlerExpectation.fulfill()
       case .register(let registeredHotkey, let signature):
         XCTAssertEqual(hotkey, registeredHotkey)
-        XCTAssertEqual(HotkeyController.signature, signature)
+        XCTAssertEqual("HotkeyHandlerMock", signature)
         registerExpectation.fulfill()
       case .sendKeyboardEvent:
         break
@@ -103,7 +103,7 @@ class HotkeyControllerTests: XCTestCase {
         installHandlerExpectation.fulfill()
       case .register(let registeredHotkey, let signature):
         XCTAssertEqual(hotkey, registeredHotkey)
-        XCTAssertEqual(HotkeyController.signature, signature)
+        XCTAssertEqual("HotkeyHandlerMock", signature)
         registerExpectation.fulfill()
       case .sendKeyboardEvent:
         break

--- a/UnitTests/Sources/Mocks/HotkeyHandlerMock.swift
+++ b/UnitTests/Sources/Mocks/HotkeyHandlerMock.swift
@@ -6,6 +6,7 @@ class HotkeyHandlerMock: HotkeyHandling {
   typealias Handler = (State) -> Void
 
   weak var delegate: HotkeyHandlerDelegate?
+  var signature = "HotkeyHandlerMock"
   var hotkeySupplier: HotkeySupplying?
   var handler: Handler
   var registerResult: Bool
@@ -26,7 +27,7 @@ class HotkeyHandlerMock: HotkeyHandling {
     handler(.installHandler)
   }
 
-  func register(_ hotkey: Hotkey, withSignature signature: String) -> Bool {
+  func register(_ hotkey: Hotkey) -> Bool {
     handler(.register(hotkey, signature: signature))
     return registerResult
   }


### PR DESCRIPTION
- Fix bug where keyboard shortcuts cannot be matched because
  `KeyboardShortcut` has a unique identifier
- Refactor matching in `WorkflowController` to use `rawValue` on shortcut
  rather than the object uniqueness
- Improve hotkey registering by enforcing signature on `sendKeyboardEvent`

This bug affected nested bindings and was introduced when we added `id` on `KeyboardShortcut`. We can no longer rely on object uniqueness when resolving keyboard shortcut combinations but rather use the keyboard shortcuts joined raw value.