### PR TITLE
Move preview controllers into DesignTime folder

### DIFF
--- a/ViewKit/Sources/DesignTime/ApplicationPreviewProvider.swift
+++ b/ViewKit/Sources/DesignTime/ApplicationPreviewProvider.swift
@@ -1,0 +1,5 @@
+import ModelKit
+
+final class ApplicationPreviewProvider: StateController {
+  let state = [Application]()
+}

--- a/ViewKit/Sources/DesignTime/CommandPreviewController.swift
+++ b/ViewKit/Sources/DesignTime/CommandPreviewController.swift
@@ -1,0 +1,6 @@
+import ModelKit
+
+final class CommandPreviewController: ViewController {
+  let state = ModelFactory().workflowDetail().commands
+  func perform(_ action: CommandListView.Action) {}
+}

--- a/ViewKit/Sources/DesignTime/GroupPreviewController.swift
+++ b/ViewKit/Sources/DesignTime/GroupPreviewController.swift
@@ -1,0 +1,6 @@
+import ModelKit
+
+final class GroupPreviewController: ViewController {
+  let state = ModelFactory().groupList()
+  func perform(_ action: GroupList.Action) {}
+}

--- a/ViewKit/Sources/DesignTime/KeyboardShortcutPreviewController.swift
+++ b/ViewKit/Sources/DesignTime/KeyboardShortcutPreviewController.swift
@@ -1,0 +1,6 @@
+import ModelKit
+
+final class KeyboardShortcutPreviewController: ViewController {
+  let state: [ModelKit.KeyboardShortcut] = ModelFactory().keyboardShortcuts()
+  func perform(_ action: KeyboardShortcutListView.Action) {}
+}

--- a/ViewKit/Sources/DesignTime/OpenPanelPreviewController.swift
+++ b/ViewKit/Sources/DesignTime/OpenPanelPreviewController.swift
@@ -1,0 +1,6 @@
+import ModelKit
+
+final class OpenPanelPreviewController: ViewController {
+  let state = ""
+  func perform(_ action: OpenPanelAction) {}
+}

--- a/ViewKit/Sources/DesignTime/WorkflowPreviewController.swift
+++ b/ViewKit/Sources/DesignTime/WorkflowPreviewController.swift
@@ -1,0 +1,7 @@
+import ModelKit
+
+final class WorkflowPreviewController: ViewController {
+  let state = ModelFactory().workflowList().first
+  func perform(_ action: WorkflowList.Action) {}
+}
+

--- a/ViewKit/Sources/Views/Commands/CommandListView.swift
+++ b/ViewKit/Sources/Views/Commands/CommandListView.swift
@@ -96,17 +96,3 @@ struct CommandListView_Previews: PreviewProvider, TestPreviewProvider {
                     openPanelController: OpenPanelPreviewController().erase())
   }
 }
-
-private final class ApplicationPreviewProvider: StateController {
-  let state = [Application]()
-}
-
-private final class CommandPreviewController: ViewController {
-  let state = ModelFactory().workflowDetail().commands
-  func perform(_ action: CommandListView.Action) {}
-}
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}

--- a/ViewKit/Sources/Views/EditCommand/EditAppleScriptView.swift
+++ b/ViewKit/Sources/Views/EditCommand/EditAppleScriptView.swift
@@ -55,8 +55,3 @@ struct EditAppleScriptView_Previews: PreviewProvider, TestPreviewProvider {
         openPanelController: OpenPanelPreviewController().erase())
     }
 }
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}

--- a/ViewKit/Sources/Views/EditCommand/EditCommandView.swift
+++ b/ViewKit/Sources/Views/EditCommand/EditCommandView.swift
@@ -170,7 +170,7 @@ struct EditCommandView_Previews: PreviewProvider, TestPreviewProvider {
 
     return Group {
       ForEach(models) { model in
-        EditCommandView(applicationProvider: ApplicationProviderMock().erase(),
+        EditCommandView(applicationProvider: ApplicationPreviewProvider().erase(),
                         openPanelController: OpenPanelPreviewController().erase(),
                         saveAction: { _ in },
                         cancelAction: {},
@@ -180,13 +180,4 @@ struct EditCommandView_Previews: PreviewProvider, TestPreviewProvider {
       }
     }
   }
-}
-
-private class ApplicationProviderMock: StateController {
-  var state = [Application]()
-}
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
 }

--- a/ViewKit/Sources/Views/EditCommand/EditOpenFileCommandView.swift
+++ b/ViewKit/Sources/Views/EditCommand/EditOpenFileCommandView.swift
@@ -51,8 +51,3 @@ struct EditOpenFileCommandView_Previews: PreviewProvider, TestPreviewProvider {
       openPanelController: OpenPanelPreviewController().erase())
   }
 }
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}

--- a/ViewKit/Sources/Views/EditCommand/EditShellScriptView.swift
+++ b/ViewKit/Sources/Views/EditCommand/EditShellScriptView.swift
@@ -55,8 +55,3 @@ struct EditShellScriptView_Previews: PreviewProvider, TestPreviewProvider {
       openPanelController: OpenPanelPreviewController().erase())
   }
 }
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}

--- a/ViewKit/Sources/Views/KeyboardShortcuts/KeyboardShortcutListView.swift
+++ b/ViewKit/Sources/Views/KeyboardShortcuts/KeyboardShortcutListView.swift
@@ -65,8 +65,3 @@ struct KeyboardShortcutListView_Previews: PreviewProvider, TestPreviewProvider {
     KeyboardShortcutListView(keyboardShortcutController: KeyboardShortcutPreviewController().erase())
   }
 }
-
-private final class KeyboardShortcutPreviewController: ViewController {
-  let state: [ModelKit.KeyboardShortcut] = ModelFactory().keyboardShortcuts()
-  func perform(_ action: KeyboardShortcutListView.Action) {}
-}

--- a/ViewKit/Sources/Views/MainView/MainView.swift
+++ b/ViewKit/Sources/Views/MainView/MainView.swift
@@ -142,33 +142,3 @@ struct MainView_Previews: PreviewProvider, TestPreviewProvider {
     }
   }
 }
-
-private final class ApplicationPreviewProvider: StateController {
-  let state = [Application]()
-}
-
-private final class CommandPreviewController: ViewController {
-  let state = ModelFactory().workflowDetail().commands
-  func perform(_ action: CommandListView.Action) {}
-}
-
-private final class GroupPreviewController: ViewController {
-  let state = ModelFactory().groupList()
-  func perform(_ action: GroupList.Action) {}
-}
-
-private final class WorkflowPreviewController: ViewController {
-  let state = ModelFactory().workflowList().first
-  func perform(_ action: WorkflowList.Action) {}
-}
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}
-
-private final class KeyboardShortcutPreviewController: ViewController {
-  let state: [ModelKit.KeyboardShortcut] = ModelFactory().keyboardShortcuts()
-
-  func perform(_ action: KeyboardShortcutListView.Action) {}
-}

--- a/ViewKit/Sources/Views/Workflow/WorkflowView.swift
+++ b/ViewKit/Sources/Views/Workflow/WorkflowView.swift
@@ -133,22 +133,3 @@ struct WorkflowView_Previews: PreviewProvider, TestPreviewProvider {
       .frame(height: 668)
   }
 }
-
-private final class ApplicationPreviewProvider: StateController {
-  let state = [Application]()
-}
-
-private final class CommandPreviewController: ViewController {
-  let state = ModelFactory().workflowDetail().commands
-  func perform(_ action: CommandListView.Action) {}
-}
-
-private final class KeyboardShortcutPreviewController: ViewController {
-  let state: [ModelKit.KeyboardShortcut] = ModelFactory().keyboardShortcuts()
-  func perform(_ action: KeyboardShortcutListView.Action) {}
-}
-
-private final class OpenPanelPreviewController: ViewController {
-  let state = ""
-  func perform(_ action: OpenPanelAction) {}
-}

--- a/ViewKit/Sources/Views/WorkflowList/WorkflowList.swift
+++ b/ViewKit/Sources/Views/WorkflowList/WorkflowList.swift
@@ -84,8 +84,3 @@ struct WorkflowList_Previews: PreviewProvider, TestPreviewProvider {
       .environmentObject(UserSelection())
   }
 }
-
-private final class WorkflowPreviewController: ViewController {
-  let state = ModelFactory().workflowList().first
-  func perform(_ action: WorkflowList.Action) {}
-}


### PR DESCRIPTION
- Move preview controllers into new folder `DesignTime`
- Remove duplicate implementations of preview controllers

Fixes #107
