### PR TITLE
Add @ViewBuilder attribute to body property

### DIFF
--- a/ViewKit/Sources/Views/Commands/CommandView.swift
+++ b/ViewKit/Sources/Views/Commands/CommandView.swift
@@ -8,6 +8,7 @@ struct CommandView: View {
   let runAction: (Command) -> Void
   let showContextualMenu: Bool
 
+  @ViewBuilder
   var body: some View {
     switch command {
     case .application:


### PR DESCRIPTION
This PR fixes a build issue I encountered. Apparently, on Catalina, we need to add the @ViewBuilder attribute to methods and properties that can return different types of Views.