### PR TITLE
Various linting and syntax updates

### DIFF
--- a/LogicFramework/Sources/Keyboard commands/HotKeyController.swift
+++ b/LogicFramework/Sources/Keyboard commands/HotKeyController.swift
@@ -56,7 +56,8 @@ final class HotKeyController: HotKeyControlling {
     var result: Unmanaged<CGEvent>? = Unmanaged.passUnretained(event)
 
     if type == .keyDown {
-      Debug.print("⌨️ Workflows: \(workflows.compactMap({ $0.name }).joined(separator: ", ").replacingOccurrences(of: "Open ", with: "")): \(invocations)")
+      let output = workflows.compactMap({ $0.name }).joined(separator: ", ").replacingOccurrences(of: "Open ", with: "")
+      Debug.print("⌨️ Workflows: \(output): \(invocations)")
     }
 
     for workflow in workflows where invocations < workflow.keyboardShortcuts.count {

--- a/ViewKit/Sources/Extensions/Color+Extensions.swift
+++ b/ViewKit/Sources/Extensions/Color+Extensions.swift
@@ -7,7 +7,7 @@ extension Color {
       : string
     guard hex.count == 3 || hex.count == 6
     else {
-      self.init(.white)
+      self.init(NSColor.white)
       return
     }
     if hex.count == 3 {
@@ -18,7 +18,7 @@ extension Color {
     }
 
     guard let intCode = Int(hex, radix: 16) else {
-      self.init(.white)
+      self.init(NSColor.white)
       return
     }
 

--- a/ViewKit/Sources/Views/GroupList/GroupList.swift
+++ b/ViewKit/Sources/Views/GroupList/GroupList.swift
@@ -13,7 +13,7 @@ public struct GroupList: View {
   static let idealWidth: CGFloat = 300
 
   @EnvironmentObject var userSelection: UserSelection
-  @ObservedObject var controller: GroupController
+  @ObservedObject var groupController: GroupController
   @State private var editGroup: ModelKit.Group?
 
   public var body: some View {
@@ -25,7 +25,7 @@ public struct GroupList: View {
           providers.forEach {
             _ = $0.loadObject(ofClass: URL.self) { url, _ in
               guard let url = url else { return }
-              controller.action(.dropFile(url))()
+              groupController.action(.dropFile(url))()
             }
           }
           return true
@@ -41,7 +41,7 @@ public struct GroupList: View {
 private extension GroupList {
   var list: some View {
     List(selection: $userSelection.group) {
-      ForEach(controller.state, id: \.self) { group in
+      ForEach(groupController.state, id: \.self) { group in
         GroupListCell(
           name: Binding(get: { group.name }, set: { name in
             var group = group
@@ -56,7 +56,7 @@ private extension GroupList {
             var group = group
             group.name = name
             group.color = color
-            controller.perform(.updateGroup(group))
+            groupController.perform(.updateGroup(group))
           }
         )
         .onTapGesture(count: 2, perform: {
@@ -65,12 +65,13 @@ private extension GroupList {
         .contextMenu {
           Button("Show Info") { editGroup = group }
           Divider()
-          Button("Delete") { controller.action(.deleteGroup(group))() }
+          Button("Delete") { groupController.action(.deleteGroup(group))() }
         }
+        .fixedSize(horizontal: false, vertical: true)
         .tag(group)
       }.onMove(perform: { indices, newOffset in
         for i in indices {
-          controller.action(.moveGroup(from: i, to: newOffset))()
+          groupController.action(.moveGroup(from: i, to: newOffset))()
         }
       })
     }
@@ -82,7 +83,7 @@ private extension GroupList {
     HStack(spacing: 4) {
       RoundOutlinedButton(title: "+", color: Color(.secondaryLabelColor))
       Button("Add Group", action: {
-        controller.perform(.createGroup)
+        groupController.perform(.createGroup)
       })
       .buttonStyle(PlainButtonStyle())
     }.padding(8)
@@ -96,7 +97,7 @@ private extension GroupList {
         var group = group
         group.name = name
         group.color = color
-        controller.perform(.updateGroup(group))
+        groupController.perform(.updateGroup(group))
         editGroup = nil
         userSelection.group = group
       },
@@ -112,7 +113,7 @@ struct GroupList_Previews: PreviewProvider, TestPreviewProvider {
   }
 
   static var testPreview: some View {
-    GroupList(controller: PreviewController().erase())
+    GroupList(groupController: GroupPreviewController().erase())
       .frame(width: GroupList.idealWidth)
       .environmentObject(UserSelection())
   }

--- a/ViewKit/Sources/Views/MainView/MainView.swift
+++ b/ViewKit/Sources/Views/MainView/MainView.swift
@@ -51,26 +51,26 @@ private extension MainView {
                                   userSelection.group = nil
                                   userSelection.workflow = nil
                                   searchController.action(.search(newSearchText))()
-      }))
+                                 }))
         .frame(height: 48)
         .padding(.horizontal, 12)
         .padding(.top, 36)
-      GroupList(controller: groupController)
+      GroupList(groupController: groupController)
     }.edgesIgnoringSafeArea(.top)
   }
 
   @ViewBuilder
   var workflowList: some View {
-      if let group = userSelection.group,
-         !group.workflows.isEmpty {
-        WorkflowList(group: Binding(
-                      get: { group },
-                      set: {
-                        userSelection.group = $0
-                        userSelection.workflow = nil
-                      }),
-                     workflowController: workflowController)
-      }
+    if let group = userSelection.group,
+       !group.workflows.isEmpty {
+      WorkflowList(group: Binding(
+                    get: { group },
+                    set: {
+                      userSelection.group = $0
+                      userSelection.workflow = nil
+                    }),
+                   workflowController: workflowController)
+    }
   }
 
   @ViewBuilder

--- a/ViewKit/Sources/Views/Shared/PlayArrowView.swift
+++ b/ViewKit/Sources/Views/Shared/PlayArrowView.swift
@@ -6,9 +6,9 @@ struct PlayArrowView: View {
       Circle()
         .fill(Color(.controlAccentColor))
       Text("▶︎")
-        .foregroundColor(Color(.white))
+        .foregroundColor(Color(NSColor.white))
     }
-    .shadow(color: Color(.black).opacity(0.25), radius: 1, x: 1, y: 2)
+    .shadow(color: Color(NSColor.black).opacity(0.25), radius: 1, x: 1, y: 2)
     .frame(width: 16, height: 16, alignment: .center)
     .offset(x: 7, y: 7)
   }

--- a/ViewKit/Sources/Views/Workflow/WorkflowView.swift
+++ b/ViewKit/Sources/Views/Workflow/WorkflowView.swift
@@ -107,10 +107,10 @@ private extension WorkflowView {
         saveAction: { newCommand in
           commandController.action(.createCommand(newCommand))()
           newCommandVisible = false
-      },
-      cancelAction: {
-        newCommandVisible = false
-      },
+        },
+        cancelAction: {
+          newCommandVisible = false
+        },
         selection: Command.application(.init(application: Application.empty())),
         command: Command.application(.init(application: Application.empty())))
     })


### PR DESCRIPTION
- Add types for initializing colors to make it work when using macOS 11
  as deployment target
- Rename `controller` to `groupController` in `GroupList`
- Syntax formatting
- Fix linter warnings
