### PR TITLE
Implement application rule manager in group edit view

### DIFF
--- a/App/Sources/KeyboardShortcuts/KeyboardShortcutsFeatureController.swift
+++ b/App/Sources/KeyboardShortcuts/KeyboardShortcutsFeatureController.swift
@@ -22,7 +22,8 @@ final class KeyboardShortcutsFeatureController: ActionController {
   weak var delegate: KeyboardShortcutsFeatureControllerDelegate?
 
   let groupsController: GroupsControlling
-  private let queue = DispatchQueue(label: "\(bundleIdentifier).KeyboardShortcutsFeatureController", qos: .userInteractive)
+  private let queue = DispatchQueue(label: "\(bundleIdentifier).KeyboardShortcutsFeatureController",
+                                    qos: .userInteractive)
 
   init(groupsController: GroupsControlling) {
     self.groupsController = groupsController

--- a/ViewKit/Sources/DesignTime/ApplicationPreviewProvider.swift
+++ b/ViewKit/Sources/DesignTime/ApplicationPreviewProvider.swift
@@ -1,5 +1,10 @@
 import ModelKit
 
 final class ApplicationPreviewProvider: StateController {
-  let state = [Application]()
+  let state: [Application] = [
+    Application.calendar(),
+    Application.finder(),
+    Application.messages(),
+    Application.music(),
+  ]
 }

--- a/ViewKit/Sources/Views/Factories/ViewFactory.swift
+++ b/ViewKit/Sources/Views/Factories/ViewFactory.swift
@@ -22,7 +22,10 @@ public class DesignTimeFactory: ViewFactory {
   }
 
   public func groupList() -> GroupList {
-    GroupList(factory: self, groupController: groupController, workflowController: workflowController)
+    GroupList(applicationProvider: applicationProvider,
+              factory: self,
+              groupController: groupController,
+              workflowController: workflowController)
   }
 
   public func workflowList(group: ModelKit.Group) -> WorkflowList {
@@ -75,6 +78,7 @@ public class AppViewFactory: ViewFactory {
 
   public func groupList() -> GroupList {
     GroupList(
+      applicationProvider: applicationProvider,
       factory: self,
       groupController: groupController,
       workflowController: workflowController)

--- a/ViewKit/Sources/Views/GroupList/GroupList.swift
+++ b/ViewKit/Sources/Views/GroupList/GroupList.swift
@@ -13,6 +13,7 @@ public struct GroupList: View {
   static let idealWidth: CGFloat = 300
 
   @EnvironmentObject var userSelection: UserSelection
+  let applicationProvider: ApplicationProvider
   let factory: ViewFactory
   @ObservedObject var groupController: GroupController
   let workflowController: WorkflowController
@@ -90,10 +91,22 @@ private extension GroupList {
     EditGroup(
       name: group.name,
       color: group.color,
-      editAction: { name, color in
+      bundleIdentifiers: group.rule?.bundleIdentifiers ?? [],
+      applicationProvider: applicationProvider.erase(),
+      editAction: { name, color, bundleIdentifers in
         var group = group
         group.name = name
         group.color = color
+
+        var rule = group.rule ?? Rule()
+
+        if !bundleIdentifers.isEmpty {
+          rule.bundleIdentifiers = bundleIdentifers
+          group.rule = rule
+        } else {
+          group.rule = nil
+        }
+
         groupController.perform(.updateGroup(group))
         editGroup = nil
       },


### PR DESCRIPTION
- Add application list inside the edit group to add and remove
  bundle identifiers from groups

Setting an application to a group scopes all workflows to only be allowed
to run when that bundle identifier owning application is active.

### Screenshot

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/57446/98159976-c82e1100-1edd-11eb-9b71-7689110d1853.png">

