### PR TITLE
Feature Hardened Runtime

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -44,6 +44,7 @@ targets:
         MARKETING_VERSION: 0.0.1
         PRODUCT_BUNDLE_IDENTIFIER: "com.zenangst.Keyboard-Cowboy"
         PRODUCT_NAME: "Keyboard Cowboy"
+        ENABLE_HARDENED_RUNTIME: true
     preBuildScripts:
       - path: XcodeGen/Scripts/swiftlint.sh
         name: SwiftLint


### PR DESCRIPTION
- Set `ENABLE_HARDENED_RUNTIME` to true in the Xcode project

This needs to be enabled in order to notarize the application
