### PR TITLE
Fix faulty name string in adding command dialog

### DIFF
--- a/ModelKit/Sources/Application.swift
+++ b/ModelKit/Sources/Application.swift
@@ -45,11 +45,11 @@ public extension Application {
     Application(id: id, bundleIdentifier: "", bundleName: "", path: "")
   }
 
-  static func messages(id: String = UUID().uuidString) -> Application {
+  static func messages(id: String = UUID().uuidString, name: String? = nil) -> Application {
     Application(
       id: id,
       bundleIdentifier: "com.apple.MobileSMS",
-      bundleName: "Messages",
+      bundleName: name ?? "Messages",
       path: "/System/Applications/Messages.app")
   }
 

--- a/ViewKit/Sources/Factories/ModelFactory.swift
+++ b/ViewKit/Sources/Factories/ModelFactory.swift
@@ -135,7 +135,7 @@ class ModelFactory {
   }
 
   func applicationCommand() -> Command {
-    Command.application(.init(application: Application.messages()))
+    Command.application(.init(application: Application.messages(name: "Application")))
   }
 
   func appleScriptCommand() -> Command {


### PR DESCRIPTION
Instead of saying referring to `Messages` when adding an application,
the sidebar will now say `Add application` to make it more clear
what kind of command the user is trying to add.

### Before

<img width="912" alt="Screen Shot 2020-12-01 at 20 50 30" src="https://user-images.githubusercontent.com/57446/100789786-34396180-3417-11eb-9bcb-7ecb7c2880b2.png">

### After

<img width="912" alt="Screen Shot 2020-12-01 at 20 50 41" src="https://user-images.githubusercontent.com/57446/100789794-38fe1580-3417-11eb-9e35-7b852e697b21.png">

