### PR TITLE
Fix crash on startup with empty workflows list

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -16,8 +16,10 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/App/Sources/Application/AppDelegate.swift
+++ b/App/Sources/Application/AppDelegate.swift
@@ -9,6 +9,7 @@ import ModelKit
 
 let bundleIdentifier = Bundle.main.bundleIdentifier!
 let launchArguments = LaunchArgumentsController<LaunchArgument>()
+let appDelegate = AppDelegate()
 
 class AppDelegate: NSObject, NSApplicationDelegate,
                    MenubarControllerDelegate,
@@ -20,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
   @Published var windowIsOpened: Bool = true
   private lazy var factory = ControllerFactory()
   lazy var permissionController = factory.permissionsController()
-  lazy var userData = UserSelection(hasPrivileges: permissionController.hasPrivileges())
+  lazy var userSelection = UserSelection(hasPrivileges: permissionController.hasPrivileges())
 
   static var internalChange: Bool = false
 
@@ -95,7 +96,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
   func createMainView(_ coreController: CoreControlling) -> MainView {
     IconController.installedApplications = coreController.installedApplications
     let featureFactory = FeatureFactory(coreController: coreController)
-    let context = featureFactory.applicationStack(userSelection: userData)
+    let context = featureFactory.applicationStack(userSelection: userSelection)
 
     let mainView = context.factory.mainView()
     self.groupFeatureController = context.groupsFeature

--- a/App/Sources/Application/KeyboardCowboyApp.swift
+++ b/App/Sources/Application/KeyboardCowboyApp.swift
@@ -6,30 +6,24 @@ struct KeyboardCowboyApp: App {
   // swiftlint:disable weak_delegate
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
   @Environment(\.scenePhase) var scenePhase
-  @State var content: AnyView?
-
-  let applicationName: String = "Keyboard Cowboy"
+  @State var content: MainView?
 
   var body: some Scene {
     WindowGroup {
-      ZStack {
+      Group {
         if appDelegate.permissionController.hasPrivileges() {
-          content.frame(minWidth: 800, minHeight: 520)
+          content
         } else {
-          ZStack {
-            Color(.windowBackgroundColor)
-            VStack {
-              Image("ApplicationIcon")
-                .resizable()
-                .frame(width: 256, height: 256)
-              Text(appDelegate.permissionController.informativeText)
-            }
-          }.frame(minWidth: 800, minHeight: 520)
+          PermissionsView()
         }
-      }.frame(minWidth: 800, minHeight: 520)
-      .onChange(of: scenePhase, perform: { _ in
-        content = appDelegate.mainView?.environmentObject(appDelegate.userData).erase()
+      }
+      .frame(minWidth: 800, minHeight: 520)
+      .onChange(of: scenePhase, perform: { phase in
+        if phase == .active {
+          content = appDelegate.mainView
+        }
       })
+      .environmentObject(appDelegate.userSelection)
     }
     .windowToolbarStyle(UnifiedWindowToolbarStyle())
     .commands {

--- a/App/Sources/Permissions/PermissionsView.swift
+++ b/App/Sources/Permissions/PermissionsView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct PermissionsView: View {
+  var body: some View {
+    ZStack {
+      Color(.windowBackgroundColor)
+      VStack {
+        Image("ApplicationIcon")
+          .resizable()
+          .frame(width: 256, height: 256)
+        Text(appDelegate.permissionController.informativeText)
+      }
+    }
+  }
+}

--- a/ViewKit/Sources/Views/GroupList/GroupList.swift
+++ b/ViewKit/Sources/Views/GroupList/GroupList.swift
@@ -26,7 +26,7 @@ public struct GroupList: View {
       List {
         ForEach(groupController.state, id: \.id) { group in
           NavigationLink(
-            destination: factory.workflowList(group: group, selectedWorkflow: userSelection.workflow),
+            destination: factory.workflowList(group: group, selectedWorkflow: userSelection.workflow).environmentObject(userSelection),
             tag: group, selection: Binding<ModelKit.Group?>(get: {
               userSelection.group
             }, set: { group in
@@ -52,7 +52,9 @@ public struct GroupList: View {
           .contextMenu {
             Button("Show Info") { editGroup = group }
             Divider()
-            Button("Delete") { groupController.action(.deleteGroup(group))() }
+            Button("Delete") {
+              groupController.action(.deleteGroup(group))()
+            }
           }
         }
         .onMove(perform: { indices, newOffset in

--- a/project.yml
+++ b/project.yml
@@ -39,9 +39,9 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
         CODE_SIGN_IDENTITY: "-"
-        CURRENT_PROJECT_VERSION: 2
+        CURRENT_PROJECT_VERSION: 3
         INFOPLIST_FILE: "App/Resources/Info.plist"
-        MARKETING_VERSION: 0.0.2
+        MARKETING_VERSION: 0.0.3
         PRODUCT_BUNDLE_IDENTIFIER: "com.zenangst.Keyboard-Cowboy"
         PRODUCT_NAME: "Keyboard Cowboy"
         ENABLE_HARDENED_RUNTIME: true


### PR DESCRIPTION
- Add `CFBundleShortVersionString` to plist to get proper versioning
- Refactor App setup to make it clear which state the apps has in terms
  of permissions
- Move permissions view code into a separate view
- Bump version to 0.0.3
- Add missing `environmentObject` to workflow list which caused the crash
