### PR TITLE
Use workspace to reopen application

### DIFF
--- a/App/Sources/Application/AppDelegate.swift
+++ b/App/Sources/Application/AppDelegate.swift
@@ -158,6 +158,6 @@ class AppDelegate: NSObject, NSApplicationDelegate,
   // MARK: MenubarControllerDelegate
 
     func menubarController(_ controller: MenubarController, didTapOpenApplication openApplicationMenuItem: NSMenuItem) {
-      NSApp.activate(ignoringOtherApps: true)
+      NSWorkspace.shared.open(Bundle.main.bundleURL)
     }
 }


### PR DESCRIPTION
To reopen the SwiftUI application, we activate using `NSWorkspace.open` and give it the bundle url.