### PR TITLE
Fix pluralization in workflow list cell

### DIFF
--- a/ViewKit/Sources/Views/WorkflowList/WorkflowListCell.swift
+++ b/ViewKit/Sources/Views/WorkflowList/WorkflowListCell.swift
@@ -33,8 +33,13 @@ private extension WorkflowListCell {
   }
 
   var numberOfCommands: some View {
-    Text("\(workflow.commands.count) commands")
-      .foregroundColor(.secondary)
+    Group {
+    if workflow.commands.count > 1 {
+      Text("\(workflow.commands.count) commands")
+    } else if workflow.commands.count > 0 {
+      Text("\(workflow.commands.count) command")
+    }
+    }.foregroundColor(.secondary)
   }
 
   @ViewBuilder


### PR DESCRIPTION
- Say `command` if there is only one command present
  Say `commands` if there are multiple commands

Thanks to @timkurvers for pointing this out ❤️❤️
