### PR TITLE
Refactor features to be synchronous

### DIFF
--- a/App/Sources/Commands/CommandsFeatureController.swift
+++ b/App/Sources/Commands/CommandsFeatureController.swift
@@ -20,7 +20,6 @@ final class CommandsFeatureController: ActionController {
   let installedApplications: [Application]
   private let workspace: WorkspaceProviding
   private let commandController: CommandControlling
-  private let queue = DispatchQueue(label: "\(bundleIdentifier).CommandsFeatureController", qos: .userInteractive)
 
   init(commandController: CommandControlling,
        groupsController: GroupsControlling,
@@ -33,22 +32,19 @@ final class CommandsFeatureController: ActionController {
   }
 
   func perform(_ action: CommandListView.Action) {
-    queue.async { [weak self] in
-      guard let self = self else { return }
-      switch action {
-      case .createCommand(let command, let workflow):
-        self.createCommand(command, in: workflow)
-      case .updateCommand(let command, let workflow):
-        self.updateCommand(command, in: workflow)
-      case .deleteCommand(let command, let workflow):
-        self.deleteCommand(command, in: workflow)
-      case .moveCommand(let command, let offset, let workflow):
-        self.moveCommand(command, to: offset, in: workflow)
-      case .runCommand(let command):
-        self.run(command)
-      case .revealCommand(let command, _):
-        self.reveal(command)
-      }
+    switch action {
+    case .createCommand(let command, let workflow):
+      createCommand(command, in: workflow)
+    case .updateCommand(let command, let workflow):
+      updateCommand(command, in: workflow)
+    case .deleteCommand(let command, let workflow):
+      deleteCommand(command, in: workflow)
+    case .moveCommand(let command, let offset, let workflow):
+      moveCommand(command, to: offset, in: workflow)
+    case .runCommand(let command):
+      run(command)
+    case .revealCommand(let command, _):
+      reveal(command)
     }
   }
 

--- a/App/Sources/Groups/GroupsFeatureController.swift
+++ b/App/Sources/Groups/GroupsFeatureController.swift
@@ -11,7 +11,6 @@ final class GroupsFeatureController: ViewController,
   var applications = [Application]()
   let groupsController: GroupsControlling
   let userSelection: UserSelection
-  let queue = DispatchQueue(label: "\(bundleIdentifier).GroupsFeatureController", qos: .userInteractive)
 
   init(groupsController: GroupsControlling, applications: [Application],
        userSelection: UserSelection) {
@@ -27,22 +26,19 @@ final class GroupsFeatureController: ViewController,
   // MARK: ViewController
 
   func perform(_ action: GroupList.Action) {
-    queue.async { [weak self] in
-      guard let self = self else { return }
-      switch action {
-      case .createGroup:
-        self.newGroup()
-      case .deleteGroup(let group):
-        self.delete(group)
-      case .updateGroup(let group):
-        self.save(group)
-      case .dropFile(let urls):
-        for url in urls {
-          self.processUrl(url)
-        }
-      case .moveGroup(let from, let to):
-        self.move(from: from, to: to)
+    switch action {
+    case .createGroup:
+      newGroup()
+    case .deleteGroup(let group):
+      delete(group)
+    case .updateGroup(let group):
+      save(group)
+    case .dropFile(let urls):
+      for url in urls {
+        processUrl(url)
       }
+    case .moveGroup(let from, let to):
+      move(from: from, to: to)
     }
   }
 
@@ -51,11 +47,8 @@ final class GroupsFeatureController: ViewController,
   private func reload(_ groups: [ModelKit.Group], then handler: ((UserSelection) -> Void)? = nil) {
     groupsController.reloadGroups(groups)
     subject.send(groups)
-
-    DispatchQueue.main.async {
-      self.state = groups
-      handler?(self.userSelection)
-    }
+    self.state = groups
+    handler?(self.userSelection)
   }
 
   private func newGroup() {

--- a/App/Sources/KeyboardShortcuts/KeyboardShortcutsFeatureController.swift
+++ b/App/Sources/KeyboardShortcuts/KeyboardShortcutsFeatureController.swift
@@ -22,26 +22,21 @@ final class KeyboardShortcutsFeatureController: ActionController {
   weak var delegate: KeyboardShortcutsFeatureControllerDelegate?
 
   let groupsController: GroupsControlling
-  private let queue = DispatchQueue(label: "\(bundleIdentifier).KeyboardShortcutsFeatureController",
-                                    qos: .userInteractive)
 
   init(groupsController: GroupsControlling) {
     self.groupsController = groupsController
   }
 
   func perform(_ action: KeyboardShortcutList.Action) {
-    queue.async { [weak self] in
-      guard let self = self else { return }
-      switch action {
-      case .createKeyboardShortcut(let keyboardShortcut, let index, let workflow):
-        self.createKeyboardShortcut(keyboardShortcut, at: index, in: workflow)
-      case .updateKeyboardShortcut(let keyboardShortcut, let workflow):
-        self.updateKeyboardShortcut(keyboardShortcut, in: workflow)
-      case .deleteKeyboardShortcut(let keyboardShortcut, let workflow):
-        self.deleteKeyboardShortcut(keyboardShortcut, in: workflow)
-      case .moveCommand(let keyboardShortcut, let to, let workflow):
-        self.moveKeyboardShortcut(keyboardShortcut, to: to, in: workflow)
-      }
+    switch action {
+    case .createKeyboardShortcut(let keyboardShortcut, let index, let workflow):
+      createKeyboardShortcut(keyboardShortcut, at: index, in: workflow)
+    case .updateKeyboardShortcut(let keyboardShortcut, let workflow):
+      updateKeyboardShortcut(keyboardShortcut, in: workflow)
+    case .deleteKeyboardShortcut(let keyboardShortcut, let workflow):
+      deleteKeyboardShortcut(keyboardShortcut, in: workflow)
+    case .moveCommand(let keyboardShortcut, let to, let workflow):
+      moveKeyboardShortcut(keyboardShortcut, to: to, in: workflow)
     }
   }
 

--- a/App/Sources/Workflow/WorkflowFeatureController.swift
+++ b/App/Sources/Workflow/WorkflowFeatureController.swift
@@ -27,7 +27,6 @@ final class WorkflowFeatureController: ViewController,
   var applications = [Application]()
   let groupsController: GroupsControlling
   private var cancellables = [AnyCancellable]()
-  private let queue = DispatchQueue(label: "\(bundleIdentifier).WorkflowFeatureController", qos: .userInteractive)
 
   public init(state: Workflow,
               applications: [Application],
@@ -40,20 +39,17 @@ final class WorkflowFeatureController: ViewController,
   // MARK: ViewController
 
   func perform(_ action: WorkflowList.Action) {
-    queue.async { [weak self] in
-      guard let self = self else { return }
-      switch action {
-      case .createWorkflow(let group):
-        self.createWorkflow(in: group)
-      case .updateWorkflow(let workflow, let group):
-        self.updateWorkflow(workflow, in: group)
-      case .deleteWorkflow(let workflow, let group):
-        self.deleteWorkflow(workflow, in: group)
-      case .moveWorkflow(let workflow, let to, let group):
-        self.moveWorkflow(workflow, to: to, in: group)
-      case .drop(let urls, let workflow, let group):
-        self.drop(urls, workflow: workflow, in: group)
-      }
+    switch action {
+    case .createWorkflow(let group):
+      createWorkflow(in: group)
+    case .updateWorkflow(let workflow, let group):
+      updateWorkflow(workflow, in: group)
+    case .deleteWorkflow(let workflow, let group):
+      deleteWorkflow(workflow, in: group)
+    case .moveWorkflow(let workflow, let to, let group):
+      moveWorkflow(workflow, to: to, in: group)
+    case .drop(let urls, let workflow, let group):
+      drop(urls, workflow: workflow, in: group)
     }
   }
 


### PR DESCRIPTION
- In order to make the stack traces more readable and to make the
  code-paths simpler, internal dispatch queues have now been removed
  from the features.

We have no long running tasks when it comes to UI and we should try and
stick with the main thread as much as possible.

Async by default usually leads to trouble
