### PR TITLE
Improve adding new groups

### DIFF
--- a/ViewKit/Sources/Extensions/NSApp+Extensions.swift
+++ b/ViewKit/Sources/Extensions/NSApp+Extensions.swift
@@ -1,0 +1,36 @@
+import Cocoa
+
+enum ApplicationAction {
+  case toggleSidebar
+  case showSidebar
+}
+
+extension NSApplication {
+  private func invoke(_ action: Selector) {
+    keyWindow?.firstResponder?.tryToPerform(action, with: nil)
+  }
+
+  func tryToPerform(_ action: ApplicationAction) {
+
+    switch action {
+    case .toggleSidebar:
+      invoke(#selector(NSSplitViewController.toggleSidebar(_:)))
+    case .showSidebar:
+      let splitView = (keyWindow?.firstResponder as? NSWindow)?.contentView?.find(NSSplitView.self)
+      splitView?.subviews.first?.isHidden = false
+    }
+  }
+}
+
+extension NSView {
+  func find<T: NSView>(_ ofType: T.Type) -> T? {
+    if let test = subviews.first(where: { $0 is T }) as? T {
+      return test
+    } else {
+      for view in subviews {
+        return view.find(ofType)
+      }
+    }
+    return nil
+  }
+}

--- a/ViewKit/Sources/Views/Columns/SidebarToolbar.swift
+++ b/ViewKit/Sources/Views/Columns/SidebarToolbar.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SidebarToolbar: ToolbarContent {
   var body: some ToolbarContent {
     ToolbarItemGroup(placement: .primaryAction) {
-      Button(action: toggleSidebar,
+      Button(action: { NSApp.tryToPerform(.toggleSidebar) },
              label: {
               Image(systemName: "sidebar.left")
                 .renderingMode(.template)
@@ -11,10 +11,5 @@ struct SidebarToolbar: ToolbarContent {
              })
         .help("Toggle Sidebar")
     }
-  }
-
-  func toggleSidebar() {
-    NSApp.keyWindow?.firstResponder?.tryToPerform(
-      #selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
   }
 }

--- a/ViewKit/Sources/Views/GroupList/GroupListToolbar.swift
+++ b/ViewKit/Sources/Views/GroupList/GroupListToolbar.swift
@@ -7,6 +7,7 @@ struct GroupListToolbar: ToolbarContent {
   var body: some ToolbarContent {
     ToolbarItemGroup(placement: .automatic) {
       Button(action: {
+        NSApp.tryToPerform(.showSidebar)
         groupController.perform(.createGroup)
       }, label: {
         Image(systemName: "folder.badge.plus")


### PR DESCRIPTION
Improve the UX when adding groups while the sidebar his hidden

- Add new extension on `NSApplication` to encapsulate SwiftUI
  workarounds
- Show the sidebar when adding the a new group while the sidebar is
  initially hidden

Fixes #180
