### PR TITLE
Improve application display names

### DIFF
--- a/LogicFramework/Sources/Logic/CoreController.swift
+++ b/LogicFramework/Sources/Logic/CoreController.swift
@@ -76,7 +76,7 @@ public final class CoreController: NSObject, CoreControlling,
     self.installedApplications = fileIndexer.index(with: patterns, match: {
       $0.absoluteString.contains(".app")
     }, handler: applicationParser.process(_:))
-    .sorted(by: { $0.bundleName.lowercased() < $1.bundleName.lowercased() })
+    .sorted(by: { $0.displayName.lowercased() < $1.displayName.lowercased() })
   }
 
   @objc public func reloadContext() {

--- a/ModelKit/Sources/Application.swift
+++ b/ModelKit/Sources/Application.swift
@@ -12,6 +12,7 @@ public struct Application: Identifiable, Codable, Hashable {
   public let bundleIdentifier: String
   public let bundleName: String
   public let path: String
+  public private(set) var displayName: String = ""
 
   public init(id: String = UUID().uuidString,
               bundleIdentifier: String,
@@ -21,6 +22,7 @@ public struct Application: Identifiable, Codable, Hashable {
     self.bundleIdentifier = bundleIdentifier
     self.bundleName = bundleName
     self.path = path
+    self.displayName = FileManager().displayName(atPath: path)
   }
 
   enum CodingKeys: String, CodingKey {
@@ -37,6 +39,7 @@ public struct Application: Identifiable, Codable, Hashable {
     self.bundleIdentifier = try container.decode(String.self, forKey: .bundleIdentifier)
     self.bundleName = try container.decode(String.self, forKey: .bundleName)
     self.path = try container.decode(String.self, forKey: .path)
+    self.displayName = FileManager().displayName(atPath: path)
   }
 }
 

--- a/ModelKit/Sources/Command.swift
+++ b/ModelKit/Sources/Command.swift
@@ -28,7 +28,7 @@ public enum Command: Identifiable, Codable, Hashable {
   public var name: String {
     switch self {
     case .application(let command):
-      return command.name.isEmpty ? "Open \(command.application.bundleName)" : command.name
+      return command.name.isEmpty ? "Open \(command.application.displayName)" : command.name
     case .keyboard(let command):
       var keyboardShortcut = command.keyboardShortcut.modifiers?.compactMap({ $0.pretty }).joined() ?? ""
       keyboardShortcut += command.keyboardShortcut.key

--- a/ModelKit/Sources/Group.swift
+++ b/ModelKit/Sources/Group.swift
@@ -59,7 +59,7 @@ extension Group {
   static public func droppedApplication(id: String = UUID().uuidString,
                                         _ application: Application) -> Group {
     Group(id: id,
-          name: application.bundleName,
+          name: application.displayName,
           color: "#000",
           rule: Rule(bundleIdentifiers: [application.bundleIdentifier],
                      days: []),

--- a/ViewKit/Sources/Views/EditCommand/EditApplicationCommandView.swift
+++ b/ViewKit/Sources/Views/EditCommand/EditApplicationCommandView.swift
@@ -27,7 +27,7 @@ struct EditApplicationCommandView: View {
             command = ApplicationCommand(id: command.id, application: installedApplications[$0])
           })) {
             ForEach(0..<installedApplications.count, id: \.self) { index in
-              Text(installedApplications[index].bundleName).tag(index)
+              Text(installedApplications[index].displayName).tag(index)
             }
           }
         }.padding()

--- a/ViewKit/Sources/Views/EditGroup/EditGroup.swift
+++ b/ViewKit/Sources/Views/EditGroup/EditGroup.swift
@@ -100,7 +100,7 @@ private extension EditGroup {
         selectedApplicationIndex = $0
       })) {
         ForEach(0..<installedApplications.count, id: \.self) { index in
-          Text(installedApplications[index].bundleName).tag(index)
+          Text(installedApplications[index].displayName).tag(index)
         }
       }
     }
@@ -131,7 +131,7 @@ private extension EditGroup {
           VStack(spacing: 0) {
             HStack {
               IconView(icon: Icon(identifier: application.bundleIdentifier, path: application.path))
-              Text(application.bundleName)
+              Text(application.displayName)
               Spacer()
               Button("-", action: {
                 if let index = bundleIdentifiers.firstIndex(of: application.bundleIdentifier) {


### PR DESCRIPTION
Add computed display name for application to display the same kind
of information that the Finder does.

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/57446/102121980-20452500-3e45-11eb-9929-708ebce4b5da.png">

Fixes #177
