### PR TITLE
Improve group selection when removing groups

### DIFF
--- a/App/Sources/Features/GroupsFeatureController.swift
+++ b/App/Sources/Features/GroupsFeatureController.swift
@@ -91,7 +91,20 @@ final class GroupsFeatureController: ActionController,
 
   private func delete(_ group: ModelKit.Group) {
     var groups = groupsController.groups
-    try? groups.remove(group)
+
+    if let offset = groups.firstIndex(of: group) {
+      try? groups.remove(group)
+
+      // Select the "above" group when deleting the currently selected.
+      // In addition, select the first workflow in the group.
+      let nextIndex = max(0, offset - 1)
+      if groups.count > 0 {
+        let newSelectedGroup = groups[nextIndex]
+        groupSelection = newSelectedGroup.id
+        workflowSelection = newSelectedGroup.workflows.first?.id
+      }
+    }
+
     reload(groups)
   }
 


### PR DESCRIPTION
When removing a group, the previous/above group will be selected.
The workflow selection will also be set to the first workflow in the new group.

Fixes #179
