### PR TITLE
Add Sparkle framework as a dependency

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -36,5 +36,7 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>SUPublicEDKey</key>
+	<string>ZxEpbxbd8TIwNev9bkzaLrHAaQUK/x0wBTHb4anScsc=</string>
 </dict>
 </plist>

--- a/XcodeGen/Base.xcconfig
+++ b/XcodeGen/Base.xcconfig
@@ -1,2 +1,2 @@
 CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
-LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @executable_path/../../Frameworks @loader_path/Frameworks @executable_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS)
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @executable_path/../../Frameworks @loader_path/Frameworks @executable_path/../Frameworks $(FRAMEWORK_SEARCH_PATHS) @loader_path/../Frameworks

--- a/project.yml
+++ b/project.yml
@@ -20,6 +20,9 @@ packages:
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
     from: 1.8.2
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    revision: "891afd44c7075e699924ed9b81d8dc94a5111dfd"
 targets:
   Keyboard-Cowboy:
     type: application
@@ -31,6 +34,7 @@ targets:
       - target: LogicFramework
       - package: DirectoryObserver
       - package: LaunchArguments
+      - package: Sparkle
     sources:
       - App
     settings:


### PR DESCRIPTION
- Add Sparkle framework as a dependency using Swift Package Manager
- Add SUPublicEDKey to the Info.plist for the application

There is still work to be done here but this adds the basic buildings blocks for
us to support Sparkle updates.

Reference issue: #125
