### PR TITLE
Add script for generating new releases using Sparkle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tmp
 Keyboard-Cowboy.xcodeproj/project.*
 Keyboard-Cowboy.xcodeproj/xcshareddata/xcschemes/*
 Keyboard-Cowboy.xcodeproj/xcuserdata/*
+Release/*.zip
+Release/*.app
+Release/.*

--- a/XcodeGen/Scripts/generate_release_env.sh
+++ b/XcodeGen/Scripts/generate_release_env.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo $BUILD_DIR > "$LOCROOT/Release/.build_dir"
+echo $MARKETING_VERSION > "$LOCROOT/Release/.marketing_version"

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>Keyboard Cowboy</title>
         <item>
             <title>0.4.1</title>
-            <pubDate>Sun, 20 Dec 2020 19:50:28 +0100</pubDate>
+            <pubDate>Mon, 21 Dec 2020 19:46:13 +0100</pubDate>
             <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/zenangst/KeyboardCowboy/releases/download/0.4.1/Keyboard.Cowboy.0.4.1.zip" sparkle:version="18" sparkle:shortVersionString="0.4.1" length="2871926" type="application/octet-stream"/>
+            <enclosure url="https://github.com/zenangst/KeyboardCowboy/releases/download/0.4.1/Keyboard.Cowboy.zip" sparkle:version="18" sparkle:shortVersionString="0.4.1" length="4916039" type="application/octet-stream"/>
         </item>
     </channel>
 </rss>

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,0 +1,10 @@
+cd Release
+MARKETING_VERSION=`cat .marketing_version`
+BUILD_DIRECTORY=`cat .build_dir`
+ROOT_DIRECTORY="$BUILD_DIRECTORY/../.."
+BIN_DIRECTORY="$ROOT_DIRECTORY/SourcePackages/artifacts/Sparkle/bin"
+DOWNLOAD_URL_PREFIX="https://github.com/zenangst/KeyboardCowboy/releases/download/$MARKETING_VERSION/"
+APPLICATION_NAME="Keyboard Cowboy.app"
+ARCHIVE_FILENAME="Keyboard.Cowboy.zip"
+ZIPOUPUT=`zip -r $ARCHIVE_FILENAME "Keyboard Cowboy.app"`
+OUTPUT=`$BIN_DIRECTORY/generate_appcast -o ../appcast.xml --download-url-prefix $DOWNLOAD_URL_PREFIX .`

--- a/project.yml
+++ b/project.yml
@@ -50,6 +50,9 @@ targets:
     preBuildScripts:
       - path: XcodeGen/Scripts/swiftlint.sh
         name: SwiftLint
+    postBuildScripts:
+      - path: XcodeGen/Scripts/generate_release_env.sh
+        name: Generate release environment
     entitlements:
       path: App/Resources/com.zenangst.Keyboard-Cowboy.entitlements
       properties:
@@ -164,6 +167,7 @@ fileGroups:
   - .github
   - .gitignore
   - .swiftlint.yml
+  - create_release.sh
   - appcast.xml
   - keyboard-cowboy.json
   - README.md


### PR DESCRIPTION
Adds scripts to make it easier to update appcast.xml
appcast.xml is used by Sparke to inform the users that there is a new version available.

Reference issue: #125
