### PR TITLE
Fix table view row height issue in the workflow list

### DIFF
--- a/ViewKit/Sources/Views/MainView/MainView.swift
+++ b/ViewKit/Sources/Views/MainView/MainView.swift
@@ -40,12 +40,12 @@ public struct MainView: View {
             workflowSelection = newValue.first
           })
       )
-        .frame(minWidth: 250, idealWidth: 250)
-        .navigationTitle("\(store.selectedGroup?.name ?? "")")
-        .navigationSubtitle("Workflows")
-        .toolbar(content: {
-          WorkflowListToolbar(groupId: groupSelection, workflowsController: store.context.workflows)
-        })
+      .frame(minWidth: 250, idealWidth: 250)
+      .navigationTitle("\(store.selectedGroup?.name ?? "")")
+      .navigationSubtitle("Workflows")
+      .toolbar(content: {
+        WorkflowListToolbar(groupId: groupSelection, workflowsController: store.context.workflows)
+      })
 
       DetailView(context: store.context, workflowController: store.context.workflow)
     }

--- a/ViewKit/Sources/Views/Shared/IconView.swift
+++ b/ViewKit/Sources/Views/Shared/IconView.swift
@@ -7,7 +7,9 @@ struct IconView: View {
   var body: some View {
     ZStack {
       iconLoader.image
-    }.onAppear { iconLoader.load(path) }
+    }
+    .onAppear { iconLoader.load(path) }
+    .onDisappear { iconLoader.cancel() }
   }
 }
 

--- a/ViewKit/Sources/Views/WorkflowList/WorkflowList.swift
+++ b/ViewKit/Sources/Views/WorkflowList/WorkflowList.swift
@@ -1,4 +1,5 @@
 import BridgeKit
+import Introspect
 import ModelKit
 import SwiftUI
 
@@ -23,14 +24,10 @@ public struct WorkflowList: View {
   public var body: some View {
     List(selection: $workflowSelections) {
       ForEach(workflowsController.state, id: \.id) { workflow in
-        DeferView({
-          WorkflowListView(workflow: workflow)
-            .frame(minHeight: 48)
-            .contextMenu {
-              WorkflowListContextMenu(workflowsController: workflowsController, workflow: workflow)
-            }
-        })
-        .frame(minHeight: 48)
+        WorkflowListView(workflow: workflow)
+          .contextMenu {
+            WorkflowListContextMenu(workflowsController: workflowsController, workflow: workflow)
+          }
         .tag(workflow.id)
       }
       .onMove(perform: { indices, newOffset in
@@ -38,6 +35,9 @@ public struct WorkflowList: View {
           workflowsController.perform(.move(workflowsController.state[i], to: newOffset))
         }
       })
+    }
+    .introspectTableView { tableView in
+      tableView.rowHeight = 56
     }
     .onDrop($isDropping) { urls in
       workflowsController.perform(.drop(urls, groupSelection, nil))

--- a/ViewKit/Sources/Views/WorkflowList/WorkflowListView.swift
+++ b/ViewKit/Sources/Views/WorkflowList/WorkflowListView.swift
@@ -4,7 +4,6 @@ import ModelKit
 struct WorkflowListView: View {
   let workflow: Workflow
   @State private var isHovering: Bool = false
-  @State private var selected: Bool = false
 
   var body: some View {
     VStack(alignment: .center, spacing: 0) {
@@ -19,7 +18,7 @@ struct WorkflowListView: View {
         Spacer()
         icon
       }.padding(.leading, 10)
-      Divider().opacity(selected ? 0 : 0.33)
+      Divider().opacity(0.33)
     }
   }
 }

--- a/project.yml
+++ b/project.yml
@@ -23,6 +23,9 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     revision: "891afd44c7075e699924ed9b81d8dc94a5111dfd"
+  Introspect:
+    url: https://github.com/siteline/SwiftUI-Introspect
+    from: 0.1.2
 targets:
   Keyboard-Cowboy:
     type: application
@@ -120,6 +123,7 @@ targets:
     dependencies:
       - target: BridgeKit
       - target: ModelKit
+      - package: Introspect
     sources:
       - ViewKit
       - Shared


### PR DESCRIPTION
Fixes the table row height issue that occurs if you scroll down in the list of workflows
and then switch group. This causes the table view to use the default value for the row height which is 24.

Setting this using `Introspect` fixes the issue.

### Screenshots

![image (5) 4](https://user-images.githubusercontent.com/57446/103003256-be657900-4530-11eb-9cd1-c0c3835a6e7f.png)

![image (7)](https://user-images.githubusercontent.com/57446/103003264-c0c7d300-4530-11eb-8569-aba4e26acfb6.png)
