### PR TITLE
Fix bug where binding numbers didn't work

### DIFF
--- a/Shared/Keymapping/KeyCodeMapper.swift
+++ b/Shared/Keymapping/KeyCodeMapper.swift
@@ -41,15 +41,16 @@ final class KeyCodeMapper: KeyCodeMapping {
 
     let modifiersCombinations: [UInt32] = [
       0,
-      UInt32(optionKey >> 8) & 0xFF,
       UInt32(shiftKey >> 8) & 0xFF,
     ]
 
     for integer in 0..<128 {
       for modifiers in modifiersCombinations {
         if let container = try? map(integer, modifiers: modifiers) {
-          table[container.displayValue] = integer
-          table[container.rawValue] = integer
+          if table[container.displayValue] == nil {
+            table[container.displayValue] = integer
+            table[container.rawValue] = integer
+          }
         }
       }
     }

--- a/project.yml
+++ b/project.yml
@@ -44,9 +44,9 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
         CODE_SIGN_IDENTITY: "-"
-        CURRENT_PROJECT_VERSION: 35
+        CURRENT_PROJECT_VERSION: 37
         INFOPLIST_FILE: "App/Resources/Info.plist"
-        MARKETING_VERSION: 0.9.0
+        MARKETING_VERSION: 0.9.1
         PRODUCT_BUNDLE_IDENTIFIER: "com.zenangst.Keyboard-Cowboy"
         PRODUCT_NAME: "Keyboard Cowboy"
         ENABLE_HARDENED_RUNTIME: true


### PR DESCRIPTION
Binding numbers [0-9] didn't work properly because they got overridden by other values.
