### PR TITLE
Fix SwiftUI crash and add debugEdit support in content components

### DIFF
--- a/App/Sources/Views/ContentHeaderView.swift
+++ b/App/Sources/Views/ContentHeaderView.swift
@@ -71,6 +71,6 @@ struct ContentHeaderView: View {
         .padding(.bottom, 4)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
-
+    .debugEdit()
   }
 }

--- a/App/Sources/Views/ContentListView.swift
+++ b/App/Sources/Views/ContentListView.swift
@@ -111,6 +111,7 @@ struct ContentListView: View {
         }
       }
     }
+    .debugEdit()
   }
 
   private func getColor() -> NSColor {

--- a/App/Sources/Views/WorkflowCommandListView.swift
+++ b/App/Sources/Views/WorkflowCommandListView.swift
@@ -41,7 +41,7 @@ struct WorkflowCommandListView: View {
           .matchedGeometryEffect(id: "command-list", in: namespace)
       } else {
         LazyVStack(spacing: 0) {
-          ForEach($detailPublisher.data.commands, id: \.self) { element in
+          ForEach($detailPublisher.data.commands) { element in
             let command = element
             CommandView(command,
                         detailPublisher: detailPublisher,


### PR DESCRIPTION
- Adds the `.debugEdit` view modifier to some of the content related components
- Fixes a SwiftUI crash when using `id`

## Backtrace

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = Fatal error: Index out of range
    frame #0: 0x00000001a0b0b97c libswiftCore.dylib`_swift_runtime_on_report
    frame #1: 0x00000001a0bb4a08 libswiftCore.dylib`_swift_stdlib_reportFatalErrorInFile + 208
    frame #2: 0x00000001a07aa0fc libswiftCore.dylib`closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in Swift._assertionFailure(_: Swift.StaticString, _: Swift.StaticString, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 308
    frame #3: 0x00000001a07a9f80 libswiftCore.dylib`closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in Swift._assertionFailure(_: Swift.StaticString, _: Swift.StaticString, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 344
    frame #4: 0x00000001a07a98fc libswiftCore.dylib`Swift._assertionFailure(_: Swift.StaticString, _: Swift.StaticString, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 188
    frame #5: 0x00000001a0789a48 libswiftCore.dylib`Swift.Array._checkSubscript(_: Swift.Int, wasNativeTypeChecked: Swift.Bool) -> Swift._DependenceToken + 160
    frame #6: 0x00000001a078cc74 libswiftCore.dylib`Swift.Array.subscript.read : (Swift.Int) -> τ_0_0 + 180
    frame #7: 0x00000001a078cb8c libswiftCore.dylib`protocol witness for Swift.Collection.subscript.read : (τ_0_0.Index) -> τ_0_0.Element in conformance Swift.Array<τ_0_0> : Swift.Collection in Swift + 68
    frame #8: 0x00000001008be1bc Keyboard Cowboy`closure #1 in ForEach<>.init<A>(_:id:content:) at <compiler-generated>:0
    frame #9: 0x00000001008c0c8c Keyboard Cowboy`partial apply for closure #1 in ForEach<>.init<A>(_:id:content:) at <compiler-generated>:0
    frame #10: 0x00000001a08dd40c libswiftCore.dylib`Swift.LazyMapSequence< where τ_0_0: Swift.Collection>.subscript.read : (τ_0_0.Index) -> τ_0_1 + 388
    frame #11: 0x00000001a08dd0e8 libswiftCore.dylib`protocol witness for Swift.Collection.subscript.read : (τ_0_0.Index) -> τ_0_0.Element in conformance < where τ_0_0: Swift.Collection> Swift.LazyMapSequence<τ_0_0, τ_0_1> : Swift.Collection in Swift + 72
    frame #12: 0x00000001ba94471c SwiftUI`___lldb_unnamed_symbol162819 + 172
    frame #13: 0x00000001ba9472f8 SwiftUI`___lldb_unnamed_symbol162838 + 1308
    frame #14: 0x00000001ba9494ac SwiftUI`___lldb_unnamed_symbol162847 + 1780
    frame #15: 0x00000001ba94b1a8 SwiftUI`___lldb_unnamed_symbol162854 + 52
    frame #16: 0x00000001ba94fd78 SwiftUI`___lldb_unnamed_symbol162990 + 40
    frame #17: 0x00000001ba9501dc SwiftUI`___lldb_unnamed_symbol163012 + 60
    frame #18: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #19: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #20: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #21: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #22: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #23: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #24: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #25: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #26: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #27: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #28: 0x00000001b9f87b14 SwiftUI`___lldb_unnamed_symbol96252 + 280
    frame #29: 0x00000001b9f7f07c SwiftUI`___lldb_unnamed_symbol95984 + 192
    frame #30: 0x00000001bab18ccc SwiftUI`___lldb_unnamed_symbol177110 + 112
    frame #31: 0x00000001baffed14 SwiftUI`___lldb_unnamed_symbol210145 + 836
    frame #32: 0x00000001bb00295c SwiftUI`___lldb_unnamed_symbol210202 + 100
    frame #33: 0x00000001bab24ebc SwiftUI`___lldb_unnamed_symbol177253 + 392
    frame #34: 0x00000001bab24c5c SwiftUI`___lldb_unnamed_symbol177252 + 548
    frame #35: 0x00000001ba71fd4c SwiftUI`___lldb_unnamed_symbol146441 + 148
    frame #36: 0x00000001ba5d4de8 SwiftUI`___lldb_unnamed_symbol138319 + 272
    frame #37: 0x00000001ba5d530c SwiftUI`___lldb_unnamed_symbol138323 + 44
    frame #38: 0x00000001bab571d8 SwiftUI`___lldb_unnamed_symbol178189 + 100
    frame #39: 0x00000001bab570b0 SwiftUI`___lldb_unnamed_symbol178188 + 520
    frame #40: 0x00000001bab56dc8 SwiftUI`___lldb_unnamed_symbol178185 + 16
    frame #41: 0x00000001ba71fd4c SwiftUI`___lldb_unnamed_symbol146441 + 148
    frame #42: 0x00000001ba5d4de8 SwiftUI`___lldb_unnamed_symbol138319 + 272
    frame #43: 0x00000001ba5d530c SwiftUI`___lldb_unnamed_symbol138323 + 44
    frame #44: 0x00000001bab571d8 SwiftUI`___lldb_unnamed_symbol178189 + 100
    frame #45: 0x00000001bab570b0 SwiftUI`___lldb_unnamed_symbol178188 + 520
    frame #46: 0x00000001bab56dc8 SwiftUI`___lldb_unnamed_symbol178185 + 16
    frame #47: 0x00000001ba71fd4c SwiftUI`___lldb_unnamed_symbol146441 + 148
    frame #48: 0x00000001bacec580 SwiftUI`___lldb_unnamed_symbol189552 + 408
    frame #49: 0x00000001b9e8e16c SwiftUI`___lldb_unnamed_symbol86824 + 52
    frame #50: 0x00000001bb62dcec AttributeGraph`AG::Graph::UpdateStack::update() + 520
    frame #51: 0x00000001bb62e494 AttributeGraph`AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 424
    frame #52: 0x00000001bb63c5d8 AttributeGraph`AG::Subgraph::update(unsigned int) + 864
    frame #53: 0x00000001bb20c54c SwiftUI`___lldb_unnamed_symbol223376 + 528
    frame #54: 0x00000001ba90357c SwiftUI`___lldb_unnamed_symbol160983 + 28
    frame #55: 0x00000001bad335e0 SwiftUI`___lldb_unnamed_symbol191516 + 524
    frame #56: 0x00000001bad32b0c SwiftUI`___lldb_unnamed_symbol191515 + 152
    frame #57: 0x00000001bb26bcd8 SwiftUI`___lldb_unnamed_symbol225818 + 768
    frame #58: 0x00000001bafbc718 SwiftUI`___lldb_unnamed_symbol208826 + 984
    frame #59: 0x00000001bafbd0b8 SwiftUI`___lldb_unnamed_symbol208839 + 52
    frame #60: 0x0000000191b37180 CoreFoundation`__CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
    frame #61: 0x0000000191bd2eec CoreFoundation`___CFXRegistrationPost_block_invoke + 88
    frame #62: 0x0000000191bd2e34 CoreFoundation`_CFXRegistrationPost + 440
    frame #63: 0x0000000191b084cc CoreFoundation`_CFXNotificationPost + 704
    frame #64: 0x0000000194d930ac AppKit`-[NSView _postFrameChangeNotification] + 240
    frame #65: 0x0000000194d92dd0 AppKit`-[NSView setFrameOrigin:] + 648
    frame #66: 0x0000000194dc3eb0 AppKit`-[NSClipView setFrameOrigin:] + 112
    frame #67: 0x0000000194d9baa0 AppKit`-[NSView setFrame:] + 272
    frame #68: 0x0000000194ddd930 AppKit`-[NSScrollView _setContentViewFrame:] + 248
    frame #69: 0x0000000194ddd300 AppKit`-[NSScrollView _applyContentAreaLayout:] + 360
    frame #70: 0x0000000194ddb4e4 AppKit`-[NSScrollView tile] + 432
    frame #71: 0x0000000194ddb308 AppKit`-[NSScrollView _tileWithoutRecursing] + 52
    frame #72: 0x000000019552e32c AppKit`___NSViewLayout_block_invoke + 592
    frame #73: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #74: 0x0000000194daa790 AppKit`_NSViewLayout + 96
    frame #75: 0x0000000195524c14 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 364
    frame #76: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #77: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #78: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #79: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #80: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #81: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #82: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #83: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #84: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #85: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #86: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #87: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #88: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #89: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #90: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #91: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #92: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #93: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #94: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #95: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #96: 0x0000000195524d58 AppKit`__36-[NSView _layoutSubtreeWithOldSize:]_block_invoke + 688
    frame #97: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #98: 0x0000000194daa724 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 100
    frame #99: 0x0000000195525718 AppKit`__56-[NSView _layoutSubtreeIfNeededAndAllowTemporaryEngine:]_block_invoke + 800
    frame #100: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #101: 0x0000000194daa274 AppKit`-[NSView _layoutSubtreeIfNeededAndAllowTemporaryEngine:] + 100
    frame #102: 0x0000000194da55f8 AppKit`NSPerformVisuallyAtomicChange + 108
    frame #103: 0x0000000194daa204 AppKit`-[NSView layoutSubtreeIfNeeded] + 96
    frame #104: 0x00000001957763bc AppKit`-[NSWindow(NSConstraintBasedLayoutInternal) _layoutViewTree] + 104
    frame #105: 0x0000000195776544 AppKit`-[NSWindow(NSConstraintBasedLayoutInternal) layoutIfNeeded] + 240
    frame #106: 0x0000000194e09694 AppKit`__NSWindowGetDisplayCycleObserverForLayout_block_invoke + 364
    frame #107: 0x0000000194e08c30 AppKit`NSDisplayCycleObserverInvoke + 168
    frame #108: 0x0000000194e0888c AppKit`NSDisplayCycleFlush + 644
    frame #109: 0x0000000199025ce4 QuartzCore`CA::Transaction::run_commit_handlers(CATransactionPhase) + 120
    frame #110: 0x0000000199024aa0 QuartzCore`CA::Transaction::commit() + 320
    frame #111: 0x0000000194e8ac7c AppKit`__62+[CATransaction(NSCATransaction) NS_setFlushesWithDisplayLink]_block_invoke + 272
    frame #112: 0x0000000195566f7c AppKit`___NSRunLoopObserverCreateWithHandler_block_invoke + 64
    frame #113: 0x0000000191b419f0 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 36
    frame #114: 0x0000000191b418dc CoreFoundation`__CFRunLoopDoObservers + 532
    frame #115: 0x0000000191b40f14 CoreFoundation`__CFRunLoopRun + 776
    frame #116: 0x0000000191b404b8 CoreFoundation`CFRunLoopRunSpecific + 612
    frame #117: 0x000000019b38ac40 HIToolbox`RunCurrentEventLoopInMode + 292
    frame #118: 0x000000019b38aa7c HIToolbox`ReceiveNextEventCommon + 648
    frame #119: 0x000000019b38a7d4 HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 76
    frame #120: 0x0000000194d61d44 AppKit`_DPSNextEvent + 636
    frame #121: 0x0000000194d60ee0 AppKit`-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 716
    frame #122: 0x0000000194d55344 AppKit`-[NSApplication run] + 464
    frame #123: 0x0000000194d2c794 AppKit`NSApplicationMain + 880
    frame #124: 0x00000001b9e276b8 SwiftUI`___lldb_unnamed_symbol82487 + 148
    frame #125: 0x00000001baf885ac SwiftUI`___lldb_unnamed_symbol207385 + 164
    frame #126: 0x00000001ba808c48 SwiftUI`static SwiftUI.App.main() -> () + 128
  * frame #127: 0x00000001003e1fa8 Keyboard Cowboy`static KeyboardCowboy.$main(self=Keyboard_Cowboy.KeyboardCowboy) at KeyboardCowboy.swift:10:1
    frame #128: 0x00000001003e1fe8 Keyboard Cowboy`main at KeyboardCowboy.swift:0
    frame #129: 0x000000019170bf28 dyld`start + 2236
```

## Screenshot

<img width="1254" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/18f99e8c-8e8f-47f1-9932-91b130391029">

