### PR TITLE
Improve the information in the onboarding view

### DIFF
--- a/App/Sources/Views/Onboarding/PermissionsView.swift
+++ b/App/Sources/Views/Onboarding/PermissionsView.swift
@@ -40,13 +40,27 @@ struct PermissionsView: View {
           Text("Keyboard Cowboy comes with built-in security measures to protect your sensitive information. Password fields and other secure inputs cannot be monitored by our application.")
             .opacity(animated ? 1 : 0)
             .offset(y: animated ? 0 : -10)
-          Text("We value your privacy and take your security seriously.")
+          Text("Keyboard Cowboy is designed to be secure and private.")
             .font(.headline)
+            .opacity(animated ? 1 : 0)
+            .offset(y: animated ? 0 : -10)
+          Text("It does not collect any personal information or send any data to third parties. All data is stored locally on your computer and is never transmitted over the internet.")
             .opacity(animated ? 1 : 0)
             .offset(y: animated ? 0 : -10)
           Text("Additionally, Keyboard Cowboy is 100% open source, so you can review the code for yourself.")
             .opacity(animated ? 1 : 0)
             .offset(y: animated ? 0 : -10)
+
+          Text("tl;dr")
+            .bold()
+            .opacity(animated ? 1 : 0)
+            .offset(y: animated ? 0 : -10)
+
+          Text("We don't stalk you, we don't collect your data, we don't sell your data. We don't even know who you are. But we care about your privacy and security. ❤️")
+            .opacity(animated ? 1 : 0)
+            .offset(y: animated ? 0 : -10)
+
+
           Text("If you have any concerns, please contact us.")
             .opacity(animated ? 1 : 0)
             .offset(y: animated ? 0 : -10)
@@ -81,7 +95,7 @@ struct PermissionsView: View {
     }
     .compositingGroup()
     .padding()
-    .frame(maxHeight: .infinity, alignment: .top)
+    .frame(minHeight: 560, maxHeight: .infinity, alignment: .top)
     .background(SplashView(done: $done))
     .onAppear {
       animated = true
@@ -92,5 +106,6 @@ struct PermissionsView: View {
 struct PermissionsView_Previews: PreviewProvider {
     static var previews: some View {
       PermissionsView(onAction: { _ in })
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/App/Sources/Views/Windows/PermissionsScene.swift
+++ b/App/Sources/Views/Windows/PermissionsScene.swift
@@ -11,7 +11,7 @@ struct PermissionsScene: Scene {
           Text("Keyboard Cowboy: Permissions")
           Spacer()
         })
-        .frame(width: 640, height: 380)
+        .frame(width: 640, height: 560)
     }
     .windowResizability(.contentSize)
     .windowToolbarStyle(.unified(showsTitle: true))

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Once you've created your workflow, it will run automatically, without the need f
 
 By assigning frequently-used commands to the function key, you can streamline your workflow and save time. Overall, utilizing function keys can help you work more efficiently and effectively, making it a valuable tool for any programmer or power user.
 
+### Security and Privacy
+
+Keyboard Cowboy is designed to be secure and private. It does not collect any personal information or send any data to third parties. All data is stored locally on your computer and is never transmitted over the internet.
+
+In addition, macOS comes with built in security, so Keyboard Cowboy will be disabled when you are focsed on a password field or when you are in a secure input mode.
+
+**tl;dr**
+
+We don't stalk you, we don't collect your data, we don't sell your data. We don't even know who you are. But we care about your privacy and security. ❤️
+
 
 ## Development
 

--- a/gh-pages/css/main.css
+++ b/gh-pages/css/main.css
@@ -130,6 +130,13 @@ section.constrained {
     max-width: 680px;
 }
 
+div.constrained {
+    max-width: 680px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .button-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -152,6 +152,24 @@
      </section>
 
      <section class="white-container">
+         <h2><span class="highlight">Security</span> & Privacy</h2>
+
+         <p>
+         Keyboard Cowboy is designed to be secure and private. It does not collect any personal information or send any data to third parties. All data is stored locally on your computer and is never transmitted over the internet.
+         </p>
+
+         <p>
+         In addition, macOS comes with built in security, so Keyboard Cowboy will be disabled when you are focsed on a password field or when you are in a secure input mode.
+         </p>
+
+         <h4>tl;dr</h4>
+         <p>
+         We don't stalk you, we don't collect your data, we don't sell your data. We don't even know who you are. But we care about your privacy and security. ❤️
+         </p>
+     </section>
+
+     <section class="black-container">
+         <div class="constrained">
          <h2><span class="highlight">Open</span> Source</h2>
          <h4>
          At the heart of this app lies the philosophy<br/> that <span class="highlight">technology should be accessible to everyone</span>. </h4>
@@ -159,6 +177,7 @@
          <p>
          <a href="#" class="button github-button">View on GitHub</a>
          </p>
+         </div>
      </section>
 
      <section class="constrained centered">


### PR DESCRIPTION
The onboarding screen looks like this now:

<img width="752" alt="Screenshot 2023-05-25 at 08 49 12" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/e7065f24-66ba-4f89-895c-23bb3b40b7f7">

- Add additional information about security & privacy
- Updates the README.md and the web page to include this information
