### PR TITLE
Add tests for the application trigger logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,14 +51,11 @@ jobs:
           name: Test results
           path: ResultBundle.xcresult
       - name: "Run Danger"
-        steps:
-          - uses: actions/checkout@v1
-          - name: Danger
-            uses: danger/swift@3.15.0
-            with:
-                args: --failOnErrors --no-publish-check
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: danger/swift@3.15.0
+        with:
+          args: --failOnErrors --no-publish-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add comment to PR
         uses: actions/github-script@v6
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,12 @@ jobs:
               repo: context.repo.repo,
               body: body
             })
+      - name: "Run Danger"
+        steps:
+          - uses: actions/checkout@v1
+          - name: Danger
+            uses: danger/swift@3.15.0
+            with:
+                args: --failOnErrors --no-publish-check
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,15 @@ jobs:
         with:
           name: Test results
           path: ResultBundle.xcresult
+      - name: "Run Danger"
+        steps:
+          - uses: actions/checkout@v1
+          - name: Danger
+            uses: danger/swift@3.15.0
+            with:
+                args: --failOnErrors --no-publish-check
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add comment to PR
         uses: actions/github-script@v6
         if: always()
@@ -66,12 +75,3 @@ jobs:
               repo: context.repo.repo,
               body: body
             })
-      - name: "Run Danger"
-        steps:
-          - uses: actions/checkout@v1
-          - name: Danger
-            uses: danger/swift@3.15.0
-            with:
-                args: --failOnErrors --no-publish-check
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,6 @@ jobs:
         with:
           name: Test results
           path: ResultBundle.xcresult
-      - name: "Run Danger"
-        uses: danger/swift@3.15.0
-        with:
-          args: --failOnErrors --no-publish-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add comment to PR
         uses: actions/github-script@v6
         if: always()

--- a/App/Resources/com.zenangst.Keyboard-Cowboy.entitlements
+++ b/App/Resources/com.zenangst.Keyboard-Cowboy.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>com.apple.security.automation.apple-events</key>
-	<true/>
-</dict>
-</plist>

--- a/App/Sources/Engines/CommandEngine.swift
+++ b/App/Sources/Engines/CommandEngine.swift
@@ -2,7 +2,12 @@ import Foundation
 import AppKit
 import MachPort
 
-final class CommandEngine {
+protocol CommandRunning {
+  func serialRun(_ commands: [Command])
+  func concurrentRun(_ commands: [Command])
+}
+
+final class CommandEngine: CommandRunning {
   struct Engines {
     let application: ApplicationEngine
     let keyboard: KeyboardEngine

--- a/App/Sources/Engines/CommandEngine.swift
+++ b/App/Sources/Engines/CommandEngine.swift
@@ -49,8 +49,8 @@ final class CommandEngine: CommandRunning {
       open: OpenEngine(scriptEngine, workspace: workspace),
       script: scriptEngine,
       shortcut: ShortcutsEngine(engine: scriptEngine),
-      type: TypeEngine(keyboardEngine: keyboardEngine),
-      system: systemCommandEngine
+      system: systemCommandEngine,
+      type: TypeEngine(keyboardEngine: keyboardEngine)
     )
     self.workspace = workspace
   }

--- a/App/Sources/Engines/CommandEngine.swift
+++ b/App/Sources/Engines/CommandEngine.swift
@@ -14,8 +14,8 @@ final class CommandEngine: CommandRunning {
     let open: OpenEngine
     let script: ScriptEngine
     let shortcut: ShortcutsEngine
-    let type: TypeEngine
     let system: SystemCommandEngine
+    let type: TypeEngine
   }
 
   var machPort: MachPortEventController? {

--- a/App/Sources/Engines/KeyboardCowboyEngine.swift
+++ b/App/Sources/Engines/KeyboardCowboyEngine.swift
@@ -15,6 +15,7 @@ final class KeyboardCowboyEngine {
   private let machPortEngine: MachPortEngine
   private let shortcutStore: ShortcutStore
   private let workspace: NSWorkspace
+  private let workspacePublisher: WorkspacePublisher
 
   private var frontmostApplicationSubscription: AnyCancellable?
   private var machPortController: MachPortEventController?
@@ -40,6 +41,7 @@ final class KeyboardCowboyEngine {
     self.shortcutStore = shortcutStore
     self.applicationTriggerController = ApplicationTriggerController(commandEngine)
     self.workspace = workspace
+    self.workspacePublisher = WorkspacePublisher(workspace)
 
     guard KeyboardCowboy.env != .designTime else { return }
 
@@ -108,7 +110,8 @@ final class KeyboardCowboyEngine {
 
     guard KeyboardCowboy.env == .production else { return }
 
-    applicationTriggerController.subscribe(to: workspace)
+    applicationTriggerController.subscribe(to: workspacePublisher.$frontmostApplication)
+    applicationTriggerController.subscribe(to: workspacePublisher.$runningApplications)
     applicationTriggerController.subscribe(to: contentStore.groupStore.$groups)
   }
 

--- a/App/Sources/Models/KeyboardCowboyConfiguration.swift
+++ b/App/Sources/Models/KeyboardCowboyConfiguration.swift
@@ -125,24 +125,24 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
                       workflows: [
                         Workflow(name: "Vim bindings H to ←",
                                  trigger: .keyboardShortcuts([.init(key: "H", modifiers: [.option])]),
-                                 commands: [
+                                 isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "←")))
-                                 ], isEnabled: false),
+                                 ]),
                         Workflow(name: "Vim bindings J to ↓",
                                  trigger: .keyboardShortcuts([.init(key: "J", modifiers: [.option])]),
-                                 commands: [
+                                 isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "↓")))
-                                 ], isEnabled: false),
+                                 ]),
                         Workflow(name: "Vim bindings K to ↑",
                                  trigger: .keyboardShortcuts([.init(key: "K", modifiers: [.option])]),
-                                 commands: [
+                                 isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "↑")))
-                                 ], isEnabled: false),
+                                 ]),
                         Workflow(name: "Vim bindings L to →",
                                  trigger: .keyboardShortcuts([.init(key: "L", modifiers: [.option])]),
-                                 commands: [
+                                 isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "→")))
-                                 ], isEnabled: false)
+                                 ])
                       ]),
         WorkflowGroup(symbol: "flowchart", name: "Shortcuts", color: "#B263EA"),
         WorkflowGroup(symbol: "terminal", name: "ShellScripts", color: "#5D5FDE"),

--- a/App/Sources/Models/Workflow.swift
+++ b/App/Sources/Models/Workflow.swift
@@ -65,20 +65,25 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
   var trigger: Trigger?
   var isEnabled: Bool = true
   var name: String
-  var execution: Execution = .concurrent
+  var execution: Execution
 
   var isRebinding: Bool {
     if commands.count == 1, case .keyboard = commands.first { return true }
     return false
   }
 
-  init(id: String = UUID().uuidString, name: String, trigger: Trigger? = nil,
-       commands: [Command] = [], isEnabled: Bool = true) {
+  init(id: String = UUID().uuidString, name: String,
+       trigger: Trigger? = nil,
+       execution: Execution = .concurrent,
+       isEnabled: Bool = true,
+       commands: [Command] = []
+       ) {
     self.id = id
     self.commands = commands
     self.trigger = trigger
     self.name = name
     self.isEnabled = isEnabled
+    self.execution = execution
   }
 
   func copy() -> Self {

--- a/App/Sources/Publishers/WorkspacePublisher.swift
+++ b/App/Sources/Publishers/WorkspacePublisher.swift
@@ -1,0 +1,21 @@
+import Combine
+import Cocoa
+
+final class WorkspacePublisher {
+  @Published private(set) var frontmostApplication: RunningApplication?
+  @Published private(set) var runningApplications: [RunningApplication] = []
+
+  private var frontmostApplicationSubscription: AnyCancellable?
+  private var runningApplicationsSubscription: AnyCancellable?
+
+  init(_ workspace: NSWorkspace = .shared) {
+    frontmostApplicationSubscription = workspace.publisher(for: \.frontmostApplication)
+      .sink { [weak self] in
+        self?.frontmostApplication = $0
+      }
+    runningApplicationsSubscription = workspace.publisher(for: \.runningApplications)
+      .sink { [weak self] in
+        self?.runningApplications = $0
+      }
+  }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -118,6 +118,7 @@ let project = Project(
     ],
     additionalFiles: [
         FileElement(stringLiteral: ".gitignore"),
+        FileElement(stringLiteral: ".github/workflows"),
         FileElement(stringLiteral: ".env"),
         FileElement(stringLiteral: "Project.swift"),
         FileElement(stringLiteral: "Tuist/Dependencies.swift"),

--- a/UnitTests/Sources/Controllers/ApplicationTriggerControllerTests.swift
+++ b/UnitTests/Sources/Controllers/ApplicationTriggerControllerTests.swift
@@ -1,0 +1,127 @@
+@testable import Keyboard_Cowboy
+import XCTest
+import Combine
+import Cocoa
+
+final class ApplicationTriggerControllerTests: XCTestCase {
+  func testApplicationTriggerController_frontMost() {
+    let ctx = context(.frontMost)
+    let controller = ApplicationTriggerController(ctx.runner)
+    controller.subscribe(to: ctx.groupPublisher.$groups)
+    controller.subscribe(to: ctx.workspacePublisher.$frontMostApplication)
+    controller.subscribe(to: ctx.workspacePublisher.$runningApplications)
+
+    ctx.workspacePublisher.frontMostApplication = RunningApplicationMock(bundleIdentifier: "com.apple.calendar")
+
+    // Run command when Finder becomes the frontmost application
+    ctx.runner.concurrentRunHandler = { newCommand in
+      XCTAssertEqual(ctx.command, newCommand.first!)
+    }
+    ctx.workspacePublisher.frontMostApplication = RunningApplicationMock(bundleIdentifier: "com.apple.finder")
+  }
+
+  func testApplicationTriggerController_launched() {
+    let ctx = context(.launched)
+    let controller = ApplicationTriggerController(ctx.runner)
+    controller.subscribe(to: ctx.groupPublisher.$groups)
+    controller.subscribe(to: ctx.workspacePublisher.$frontMostApplication)
+    controller.subscribe(to: ctx.workspacePublisher.$runningApplications)
+
+    // Run command when Finder is launched.
+    ctx.runner.concurrentRunHandler = { newCommand in
+      XCTAssertEqual(ctx.command, newCommand.first!)
+    }
+
+    ctx.workspacePublisher.runningApplications = [RunningApplicationMock(bundleIdentifier: "com.apple.finder")]
+    ctx.workspacePublisher.frontMostApplication = RunningApplicationMock(bundleIdentifier: "com.apple.calendar")
+  }
+
+  func testApplicationTriggerController_closed() {
+    let ctx = context(.closed)
+    let controller = ApplicationTriggerController(ctx.runner)
+    controller.subscribe(to: ctx.groupPublisher.$groups)
+    controller.subscribe(to: ctx.workspacePublisher.$frontMostApplication)
+    controller.subscribe(to: ctx.workspacePublisher.$runningApplications)
+
+    // Run command when Finder is closed.
+    ctx.runner.concurrentRunHandler = { newCommand in
+      XCTAssertEqual(ctx.command, newCommand.first!)
+    }
+
+    ctx.workspacePublisher.runningApplications = [RunningApplicationMock(bundleIdentifier: "com.apple.finder")]
+    ctx.workspacePublisher.runningApplications = []
+  }
+
+  private func context(_ triggerContext: ApplicationTrigger.Context) -> (
+    command: Command,
+    groupPublisher: WorkGroupPublisher,
+    runner: CommandRunner,
+    workspacePublisher: WorkspacePublisherMock) {
+    let command = Command.type(.init(name: "Type command",
+                                     input: "Hello, Finder!"))
+    let runner = CommandRunner(
+      concurrent: { _ in fatalError("Should not be invoked yet.") },
+      serial: { _ in fatalError("Should not be invoked yet.") })
+
+    let group = WorkflowGroup(
+      name: "Test Group",
+      workflows: [
+        Workflow(name: "Finder",
+                 trigger: .application([.init(application: .finder(), contexts: [triggerContext])]),
+                 execution: .concurrent,
+                 commands: [command])
+      ])
+
+    let groupPublisher = WorkGroupPublisher(groups: [group])
+    let workspacePublisher = WorkspacePublisherMock(runningApplications: [])
+    return (command,
+            groupPublisher,
+            runner,
+            workspacePublisher)
+  }
+}
+
+private struct RunningApplicationMock: RunningApplication {
+  var bundleIdentifier: String?
+  func activate(options: NSApplication.ActivationOptions) -> Bool { false }
+  func terminate() -> Bool { false }
+}
+
+private final class WorkspacePublisherMock: ObservableObject {
+  @Published var runningApplications: [RunningApplication] = []
+  @Published var frontMostApplication: (RunningApplication)?
+
+  init(runningApplications: [RunningApplication],
+       frontMostApplication: (RunningApplication)? = nil) {
+    self.runningApplications = runningApplications
+    self.frontMostApplication = frontMostApplication
+  }
+}
+
+private final class WorkGroupPublisher {
+  @Published var groups: [WorkflowGroup]
+
+  init(groups: [WorkflowGroup]) {
+    self.groups = groups
+  }
+}
+
+private final class CommandRunner: CommandRunning {
+  var concurrentRunHandler: ([Command]) -> Void
+  var serialRunHandler: ([Command]) -> Void
+
+  init(concurrent: @escaping ([Command]) -> Void,
+       serial: @escaping ([Command]) -> Void) {
+    self.concurrentRunHandler = concurrent
+    self.serialRunHandler = serial
+  }
+
+  func concurrentRun(_ commands: [Command]) {
+    concurrentRunHandler(commands)
+  }
+
+  func serialRun(_ commands: [Command]) {
+    serialRunHandler(commands)
+  }
+}
+


### PR DESCRIPTION
Refactor ApplicationTriggerController to be more testable.
As an added bonus, the `receive` method has been highly optimized and should be a lot faster when the class receives new groups. Other changes include an added execution label to Workflow during init, it doesn't have to default to `concurrent` anymore.
To make NSWorkspace reliant components more testable, we now have a WorkspacePublisher, which will forward changes in `NSWorkspace.runningApplications` and `NSWorkspace.frontmostApplication` to the dependent component.

Fixes https://github.com/zenangst/KeyboardCowboy/issues/262