### PR TITLE
Refactor keyboard shortcut caching and lookup

### DIFF
--- a/App/Sources/App/KeyboardCowboy.swift
+++ b/App/Sources/App/KeyboardCowboy.swift
@@ -42,19 +42,19 @@ struct KeyboardCowboy: App {
 
     // Core functionality
     let scriptEngine = ScriptEngine(workspace: .shared)
-    let keyboardShortcutsCache = KeyboardShortcutsCache()
+    let keyboardShortcutsController = KeyboardShortcutsController()
     let applicationStore = ApplicationStore()
     let shortcutStore = ShortcutStore(engine: scriptEngine)
     let contentStore = ContentStore(Self.config,
                                     applicationStore: applicationStore,
-                                    keyboardShortcutsCache: keyboardShortcutsCache,
+                                    keyboardShortcutsController: keyboardShortcutsController,
                                     shortcutStore: shortcutStore,
                                     scriptEngine: scriptEngine, workspace: .shared)
     let keyCodeStore = KeyCodesStore()
     let keyboardEngine = KeyboardEngine(store: keyCodeStore)
     let engine = KeyboardCowboyEngine(contentStore,
                                       keyboardEngine: keyboardEngine,
-                                      keyboardShortcutsCache: keyboardShortcutsCache,
+                                      keyboardShortcutsController: keyboardShortcutsController,
                                       keyCodeStore: keyCodeStore,
                                       scriptEngine: scriptEngine,
                                       shortcutStore: shortcutStore,

--- a/App/Sources/Engines/KeyboardCowboyEngine.swift
+++ b/App/Sources/Engines/KeyboardCowboyEngine.swift
@@ -23,7 +23,7 @@ final class KeyboardCowboyEngine {
 
   init(_ contentStore: ContentStore,
        keyboardEngine: KeyboardEngine,
-       keyboardShortcutsCache: KeyboardShortcutsCache,
+       keyboardShortcutsController: KeyboardShortcutsController,
        keyCodeStore: KeyCodesStore,
        scriptEngine: ScriptEngine,
        shortcutStore: ShortcutStore,
@@ -36,7 +36,7 @@ final class KeyboardCowboyEngine {
     self.machPortEngine = MachPortEngine(store: keyboardEngine.store,
                                          commandEngine: commandEngine,
                                          keyboardEngine: keyboardEngine,
-                                         keyboardShortcutsCache: keyboardShortcutsCache,
+                                         keyboardShortcutsController: keyboardShortcutsController,
                                          mode: .intercept)
     self.shortcutStore = shortcutStore
     self.applicationTriggerController = ApplicationTriggerController(commandEngine)

--- a/App/Sources/Extensions/PreviewProvider+Extentions.swift
+++ b/App/Sources/Extensions/PreviewProvider+Extentions.swift
@@ -7,7 +7,7 @@ extension PreviewProvider {
     ContentStore(
       .designTime(),
       applicationStore: applicationStore,
-      keyboardShortcutsCache: KeyboardShortcutsCache(),
+      keyboardShortcutsController: KeyboardShortcutsController(),
       shortcutStore: .init(engine: ScriptEngine(workspace: .shared)),
       scriptEngine: .init(workspace: .shared),
       workspace: .shared)

--- a/App/Sources/Stores/ContentStore.swift
+++ b/App/Sources/Stores/ContentStore.swift
@@ -17,7 +17,7 @@ final class ContentStore: ObservableObject {
   var undoManager: UndoManager?
 
   private let storage: Storage
-  private let keyboardShortcutsCache: KeyboardShortcutsCache
+  private let keyboardShortcutsController: KeyboardShortcutsController
 
   private var subscriptions = [AnyCancellable]()
 
@@ -31,7 +31,7 @@ final class ContentStore: ObservableObject {
 
   init(_ preferences: AppPreferences,
        applicationStore: ApplicationStore,
-       keyboardShortcutsCache: KeyboardShortcutsCache,
+       keyboardShortcutsController: KeyboardShortcutsController,
        shortcutStore: ShortcutStore,
        scriptEngine: ScriptEngine,
        workspace: NSWorkspace) {
@@ -42,7 +42,7 @@ final class ContentStore: ObservableObject {
     self.shortcutStore = shortcutStore
     self.groupStore = groupStore
     self.configurationStore = ConfigurationStore()
-    self.keyboardShortcutsCache = keyboardShortcutsCache
+    self.keyboardShortcutsController = keyboardShortcutsController
     self.preferences = preferences
     self.storage = Storage(preferences.storageConfiguration)
 
@@ -90,7 +90,7 @@ final class ContentStore: ObservableObject {
   }
 
   func use(_ configuration: KeyboardCowboyConfiguration) {
-    keyboardShortcutsCache.createCache(configuration.groups)
+    keyboardShortcutsController.cache(configuration.groups)
     configurationId = configuration.id
     configurationStore.select(configuration)
     groupStore.groups = configuration.groups

--- a/UnitTests/Sources/Controllers/KeyboardShortcutsControllerTests.swift
+++ b/UnitTests/Sources/Controllers/KeyboardShortcutsControllerTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Keyboard_Cowboy
+
+final class KeyboardShortcutsControllerTests: XCTestCase {
+  func testLookupInLargeCollection() {
+    let controller = KeyboardShortcutsController()
+    let groups = generateGroups(50, workflows: 50, keyboardShortcuts: 20)
+
+    controller.cache(groups)
+
+    var offset = 0
+    let initialKey = KeyShortcut(key: "group-id-9-workflow-keyboard-shortcut-key-0")
+    let result = recursiveLookup(controller, keyShortcut: initialKey, offset: &offset)
+    XCTAssertTrue(result)
+  }
+
+  // TODO: Add additional tests
+  // We should add tests that cover binding workflows
+  // that are bound to the frontmost application.
+
+
+  // MARK: - Private methods
+
+  private func recursiveLookup(_ controller: KeyboardShortcutsController,
+                               keyShortcut: KeyShortcut,
+                               offset: inout Int,
+                               partial: PartialMatch = .init(rawValue: ".")) -> Bool {
+    let result = controller.lookup(keyShortcut, partialMatch: partial)
+
+    switch result {
+    case .exact:
+      return true
+    case .partialMatch(let partial):
+      offset += 1
+      let key = removeLastEntry(from: keyShortcut.key) + "-\(offset)"
+      return recursiveLookup(controller,
+                             keyShortcut: .init(key: key),
+                             offset: &offset, partial: partial)
+    case .none:
+      return false
+    }
+  }
+
+  private func removeLastEntry(from string: String) -> String {
+    var components = string.components(separatedBy: "-")
+    components.removeLast()
+    return components.joined(separator: "-")
+  }
+
+  private func generateGroups(_ groups: Int,
+                              workflows: Int,
+                              keyboardShortcuts: Int) -> [WorkflowGroup] {
+    (0..<groups).map {
+      WorkflowGroup(id: "group-id-\($0)",
+                    name: "group-name-\($0)",
+                    workflows: generateWorkflows(
+                      workflows,
+                      keyboardShortcuts: keyboardShortcuts,
+                      prefix: "group-id-\($0)"))
+    }
+  }
+
+  private func generateWorkflows(_ number: Int,
+                                 keyboardShortcuts: Int,
+                                 prefix: String) -> [Workflow] {
+    (0..<number).map {
+      let newPrefix = "\(prefix)-workflow"
+      return Workflow(id: "\(newPrefix)-id-\($0)",
+                      name: "\(newPrefix)-name-\($0)",
+                      trigger: Workflow.Trigger.keyboardShortcuts(generateTriggers(keyboardShortcuts, prefix: newPrefix)))
+    }
+  }
+
+  private func generateTriggers(_ number: Int, prefix: String) -> [KeyShortcut] {
+    (0..<number).map {
+      let newPrefix = "\(prefix)-keyboard-shortcut"
+      return KeyShortcut(id: "\(newPrefix)-id-\($0)",
+                         key: "\(newPrefix)-key-\($0)")
+    }
+  }
+}


### PR DESCRIPTION
The goal here was firstly to add some tests to one of the most critical parts of the app.
It is also important that these methods and classes are performant as they are very often invoked.
So, the caching functionality has been improved by using `forEach` and manually doing book-keeping
of the current offset. That helped some when dealing with larger collections.

There are also some slight improvements to the lookup API, it should be safer to work with a concrete type going forward for the partial match, rather than just using a `String`.

One future improvement could be that the initializer of the `PartialResult` is `fileprivate` inside of the `KeyboardShortcutController`, which would mean that it is the only compontent that can create them.
This would mean that, at the call-site, you would have to do some book-keeping on which was the partial result and then forward that with the next lookup. It is basiacally what we did and do today, but we did it with a String, and anyone could create the `PartialMatch`.

Reference: https://github.com/zenangst/KeyboardCowboy/issues/252