### PR TITLE
Refactor the key codes store so that it is easier to work with and test

### DIFF
--- a/App/Sources/App/KeyboardCowboy.swift
+++ b/App/Sources/App/KeyboardCowboy.swift
@@ -3,6 +3,7 @@ import Combine
 import Cocoa
 import SwiftUI
 import LaunchArguments
+import InputSources
 @_exported import Inject
 
 private let isRunningPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
@@ -50,7 +51,7 @@ struct KeyboardCowboy: App {
                                     keyboardShortcutsController: keyboardShortcutsController,
                                     shortcutStore: shortcutStore,
                                     scriptEngine: scriptEngine, workspace: .shared)
-    let keyCodeStore = KeyCodesStore()
+    let keyCodeStore = KeyCodesStore(InputSourceController())
     let keyboardEngine = KeyboardEngine(store: keyCodeStore)
     let engine = KeyboardCowboyEngine(contentStore,
                                       keyboardEngine: keyboardEngine,

--- a/App/Sources/Engines/KeyboardCowboyEngine.swift
+++ b/App/Sources/Engines/KeyboardCowboyEngine.swift
@@ -13,6 +13,7 @@ final class KeyboardCowboyEngine {
   private let contentStore: ContentStore
   private let keyCodeStore: KeyCodesStore
   private let machPortEngine: MachPortEngine
+  private let notificationCenterPublisher: NotificationCenterPublisher
   private let shortcutStore: ShortcutStore
   private let workspace: NSWorkspace
   private let workspacePublisher: WorkspacePublisher
@@ -25,6 +26,7 @@ final class KeyboardCowboyEngine {
        keyboardEngine: KeyboardEngine,
        keyboardShortcutsController: KeyboardShortcutsController,
        keyCodeStore: KeyCodesStore,
+       notificationCenter: NotificationCenter = .default,
        scriptEngine: ScriptEngine,
        shortcutStore: ShortcutStore,
        workspace: NSWorkspace = .shared) {
@@ -42,6 +44,7 @@ final class KeyboardCowboyEngine {
     self.applicationTriggerController = ApplicationTriggerController(commandEngine)
     self.workspace = workspace
     self.workspacePublisher = WorkspacePublisher(workspace)
+    self.notificationCenterPublisher = NotificationCenterPublisher(notificationCenter)
 
     guard KeyboardCowboy.env != .designTime else { return }
 
@@ -74,7 +77,7 @@ final class KeyboardCowboyEngine {
     machPortEngine.machPort = newMachPortController
     commandEngine.machPort = newMachPortController
     machPortController = newMachPortController
-    keyCodeStore.subscribe()
+    keyCodeStore.subscribe(to: notificationCenterPublisher.$keyboardSelectionDidChange)
   }
 
   func run(_ commands: [Command], execution: Workflow.Execution) {

--- a/App/Sources/Engines/MachPortEngine.swift
+++ b/App/Sources/Engines/MachPortEngine.swift
@@ -207,11 +207,7 @@ final class MachPortEngine {
     switch recording {
     case .valid:
       mode = .intercept
-    case .systemShortcut:
-      break
-    case .delete:
-      break
-    case .cancel:
+    case .delete, .cancel:
       break
     }
 
@@ -233,12 +229,6 @@ final class MachPortEngine {
     let modifiers = virtualModifiers
       .compactMap({ ModifierKey(rawValue: $0.rawValue) })
     let keyboardShortcut = KeyShortcut(key: displayValue, lhs: machPortEvent.lhs, modifiers: modifiers)
-//    let systemShortcuts = store.systemKeys()
-//      .first(where: { $0.keyCode == keyCode && $0.modifiers ==  virtualModifiers })
-
-    //    if systemShortcuts != nil {
-    //      validationContext = .systemShortcut(keyboardShortcut)
-    //    } else
     if let restrictedKeyCode = RestrictedKeyCode(rawValue: Int(machPortEvent.keyCode)) {
       switch restrictedKeyCode {
       case .backspace, .delete:
@@ -258,14 +248,6 @@ final class MachPortEngine {
 
 public enum KeyShortcutRecording: Hashable {
   case valid(KeyShortcut)
-  case systemShortcut(KeyShortcut)
   case delete(KeyShortcut)
   case cancel(KeyShortcut)
-}
-
-private extension MachPortEvent {
-  func isSame(as otherEvent: MachPortEvent) -> Bool {
-    keyCode == otherEvent.keyCode &&
-    type == otherEvent.type
-  }
 }

--- a/App/Sources/Publishers/NotificationCenterPublisher.swift
+++ b/App/Sources/Publishers/NotificationCenterPublisher.swift
@@ -1,0 +1,16 @@
+import Cocoa
+import Combine
+
+final class NotificationCenterPublisher {
+  @Published private(set) var keyboardSelectionDidChange: UUID?
+
+  private var keyboardSelectionDidChangeSubscription: AnyCancellable?
+
+  init(_ notificationCenter: NotificationCenter = .default) {
+    keyboardSelectionDidChangeSubscription = notificationCenter
+      .publisher(for: NSTextInputContext.keyboardSelectionDidChangeNotification)
+      .sink { [weak self] _ in
+        self?.keyboardSelectionDidChange = UUID()
+      }
+  }
+}

--- a/App/Sources/Publishers/WorkspacePublisher.swift
+++ b/App/Sources/Publishers/WorkspacePublisher.swift
@@ -1,5 +1,5 @@
-import Combine
 import Cocoa
+import Combine
 
 final class WorkspacePublisher {
   @Published private(set) var frontmostApplication: RunningApplication?

--- a/App/Sources/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/Reducers/DetailCommandActionReducer.swift
@@ -145,7 +145,6 @@ final class DetailCommandActionReducer {
           command.name = newName
           workflow.updateOrAddCommand(command)
         case .open(let source):
-          let execution = workflow.execution
           Task {
             let path = (source as NSString).expandingTildeInPath
             try await commandEngine.run(.open(.init(path: path)))


### PR DESCRIPTION
This pull request includes several changes to the codebase:
- A new NotificationCenterPublisher has been added to wrap NSTextInputContext.keyboardSelectionDidChangeNotification.
- Unused code inside KeyCodeStore has been cleaned up.
- The new CurrentInputSourceProviding is now used as a dependency and is contained within the constraint management for use in KeyCodeStore.
- Mapping the current input source has been removed until the application is setup and ready.
- The systemShortcuts constraint and disabled code inside MachPortEngine have been removed.