### PR TITLE
Add two new system commands to switch between all apps inside the same space

### DIFF
--- a/App/Sources/Core/Engines/System/SystemCommandEngine.swift
+++ b/App/Sources/Core/Engines/System/SystemCommandEngine.swift
@@ -13,6 +13,7 @@ final class SystemCommandEngine {
   private var flagSubscription: AnyCancellable?
   private var subject = PassthroughSubject<Void, Never>()
 
+  private var allVisibleApplicationsInSpace: [WindowModel] = .init()
   private var visibleApplicationWindows: [WindowModel] = .init()
   private var visibleMostIndex: Int = 0
 
@@ -20,11 +21,8 @@ final class SystemCommandEngine {
   private var frontMostIndex: Int = 0
 
   func subscribe(to publisher: Published<CGEventFlags?>.Publisher) {
-    indexVisibleApplications()
-    indexFrontmost()
-
     subjectSubscription = publisher
-      .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+      .debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
       .sink { [weak self] flags in
         guard let self else { return }
         self.index()
@@ -40,70 +38,110 @@ final class SystemCommandEngine {
       }
   }
 
-  func index() {
-    self.indexVisibleApplications()
-    self.indexFrontmost()
-  }
-
   func run(_ command: SystemCommand) async throws {
-    switch command.kind {
-    case .moveFocusToNextWindow, .moveFocusToPreviousWindow:
-      guard visibleApplicationWindows.count > 1 else { return }
-      if case .moveFocusToNextWindow = command.kind {
-        visibleMostIndex += 1
-        if visibleMostIndex >= visibleApplicationWindows.count {
-          visibleMostIndex = 0
+    Task { @MainActor in
+      switch command.kind {
+      case .moveFocusToNextWindow, .moveFocusToPreviousWindow,
+           .moveFocusToNextWindowGlobal, .moveFocusToPreviousWindowGlobal:
+        let collection = command.kind == .moveFocusToNextWindowGlobal ||
+        command.kind == .moveFocusToPreviousWindowGlobal
+        ? allVisibleApplicationsInSpace
+        : visibleApplicationWindows
+        
+        guard collection.count > 1 else { return }
+        if case .moveFocusToNextWindow = command.kind {
+          visibleMostIndex += 1
+          if visibleMostIndex >= collection.count {
+            visibleMostIndex = 0
+          }
+        } else if case .moveFocusToNextWindowGlobal = command.kind {
+          visibleMostIndex += 1
+          if visibleMostIndex >= collection.count {
+            visibleMostIndex = 0
+          }
+        } else {
+          visibleMostIndex -= 1
+          if visibleMostIndex < 0 {
+            visibleMostIndex = collection.count - 1
+          }
         }
-      } else {
-        visibleMostIndex -= 1
-        if visibleMostIndex < 0 {
-          visibleMostIndex = visibleApplicationWindows.count - 1
-        }
-      }
-      let window = visibleApplicationWindows[visibleMostIndex]
-      let windowId = UInt32(window.id)
-      let processIdentifier = pid_t(window.ownerPid.rawValue)
-      let runningApplication = NSRunningApplication(processIdentifier: processIdentifier)
-      let app = AppAccessibilityElement(processIdentifier)
-      let axWindow = try app.windows().first(where: { $0.id == windowId })
-      runningApplication?.activate(options: .activateIgnoringOtherApps)
-      axWindow?.performAction(.raise)
-    case .moveFocusToNextWindowFront, .moveFocusToPreviousWindowFront:
-      guard frontMostApplicationWindows.count > 1 else { return }
-      if case .moveFocusToNextWindowFront = command.kind {
-        frontMostIndex += 1
-        if frontMostIndex >= frontMostApplicationWindows.count {
-          frontMostIndex = 0
-        }
-      } else {
-        frontMostIndex -= 1
-        if frontMostIndex < 0 {
-          frontMostIndex = frontMostApplicationWindows.count - 1
-        }
-      }
+        let window = collection[visibleMostIndex]
+        let windowId = UInt32(window.id)
+        let processIdentifier = pid_t(window.ownerPid.rawValue)
+        let runningApplication = NSRunningApplication(processIdentifier: processIdentifier)
+        let app = AppAccessibilityElement(processIdentifier)
+        let axWindow = try app.windows().first(where: {
+          $0.id == windowId
+        })
 
-      let window = frontMostApplicationWindows[frontMostIndex]
-      window.performAction(.raise)
-    case .showDesktop:
-      Dock.run(.showDesktop)
-    case .applicationWindows:
-      Dock.run(.applicationWindows)
-    case .missionControl:
-      Dock.run(.missionControl)
+        runningApplication?.activate(options: .activateIgnoringOtherApps)
+        axWindow?.performAction(.raise)
+      case .moveFocusToNextWindowFront, .moveFocusToPreviousWindowFront:
+        guard frontMostApplicationWindows.count > 1 else { return }
+
+        if case .moveFocusToNextWindowFront = command.kind {
+          frontMostIndex += 1
+          if frontMostIndex >= frontMostApplicationWindows.count {
+            frontMostIndex = 0
+          }
+        } else {
+          frontMostIndex -= 1
+          if frontMostIndex < 0 {
+            frontMostIndex = frontMostApplicationWindows.count - 1
+          }
+        }
+        
+        let window = frontMostApplicationWindows[frontMostIndex]
+        window.performAction(.raise)
+      case .showDesktop:
+        Dock.run(.showDesktop)
+      case .applicationWindows:
+        Dock.run(.applicationWindows)
+      case .missionControl:
+        Dock.run(.missionControl)
+      }
     }
   }
 
-  private func indexVisibleApplications() {
-    let excluded = ["WindowManager", "Window Server"]
+  // MARK: - Private methods
+
+  private func index() {
     let options: CGWindowListOption = [.optionOnScreenOnly, .optionIncludingWindow, .excludeDesktopElements]
-    let minimumSize = CGSize(width: 300, height: 300)
     let windowModels: [WindowModel] = ((try? WindowsInfo.getWindows(options)) ?? [])
-      .filter { !excluded.contains($0.ownerName) }
+
+    frontMostIndex = 0
+
+    indexAllApplicationsInSpace(windowModels)
+    indexVisibleApplications(windowModels)
+    indexFrontmost()
+  }
+
+  private func indexAllApplicationsInSpace(_ models: [WindowModel]) {
+    let excluded = ["WindowManager", "Window Server"]
+    let minimumSize = CGSize(width: 0, height: 0)
+    let windowModels: [WindowModel] = models
       .filter {
+        $0.isOnScreen &&
         $0.rect.size.width > minimumSize.width &&
-        $0.rect.size.height > minimumSize.height
+        $0.rect.size.height > minimumSize.height &&
+        !excluded.contains($0.ownerName)
       }
-      .filter(\.isOnScreen)
+      .sorted { lhs, rhs in
+        lhs.rect.origin.y < rhs.rect.origin.y
+      }
+    allVisibleApplicationsInSpace = windowModels
+  }
+
+  private func indexVisibleApplications(_ models: [WindowModel]) {
+    let excluded = ["WindowManager", "Window Server"]
+    let minimumSize = CGSize(width: 300, height: 300)
+    let windowModels: [WindowModel] = models
+      .filter {
+        $0.isOnScreen &&
+        $0.rect.size.width > minimumSize.width &&
+        $0.rect.size.height > minimumSize.height &&
+        !excluded.contains($0.ownerName)
+      }
 
     visibleApplicationWindows = windowModels
     visibleMostIndex = 0
@@ -115,7 +153,6 @@ final class SystemCommandEngine {
     let element = AppAccessibilityElement(pid)
     do {
       frontMostApplicationWindows = try element.windows()
-      frontMostIndex = 0
     } catch { }
   }
 }

--- a/App/Sources/Core/Models/Commands/SystemCommand.swift
+++ b/App/Sources/Core/Models/Commands/SystemCommand.swift
@@ -12,6 +12,10 @@ struct SystemCommand: Identifiable, Equatable, Codable, Hashable, Sendable {
         return "Mission Control"
       case .showDesktop:
         return "Show Desktop"
+      case .moveFocusToNextWindowGlobal:
+        return "Move focus to next window (all windows)"
+      case .moveFocusToPreviousWindowGlobal:
+        return "Move focus to previous window (all windows)"
       case .moveFocusToNextWindow:
         return "Move focus to next window"
       case .moveFocusToPreviousWindow:
@@ -28,6 +32,8 @@ struct SystemCommand: Identifiable, Equatable, Codable, Hashable, Sendable {
     case moveFocusToPreviousWindowFront
     case moveFocusToNextWindow
     case moveFocusToPreviousWindow
+    case moveFocusToNextWindowGlobal
+    case moveFocusToPreviousWindowGlobal
     case missionControl
     case showDesktop
   }

--- a/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
+++ b/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
@@ -18,6 +18,7 @@ final class ConfigurationCoordinator {
 
     Task {
       // TODO: Should we remove this subscription and make it more explicit when configurations change?
+      // Why do we do this inside of a Task?
       subscription = store.$selectedConfiguration.sink(receiveValue: { [weak self] selectedConfiguration in
         self?.render(selectedConfiguration: selectedConfiguration)
       })

--- a/App/Sources/UI/Views/Commands/SystemCommandView.swift
+++ b/App/Sources/UI/Views/Commands/SystemCommandView.swift
@@ -78,9 +78,9 @@ extension SystemCommand.Kind {
       path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
     case .moveFocusToPreviousWindowFront:
       path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
-    case .moveFocusToNextWindow:
+    case .moveFocusToNextWindow, .moveFocusToNextWindowGlobal:
       path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
-    case .moveFocusToPreviousWindow:
+    case .moveFocusToPreviousWindow, .moveFocusToPreviousWindowGlobal:
       path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
     case .missionControl:
       path = "/System/Applications/Mission Control.app/Contents/Resources/AppIcon.icns"

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -161,9 +161,9 @@ private extension Array where Element == Command {
           path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
         case .moveFocusToPreviousWindowFront:
           path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
-        case .moveFocusToNextWindow:
+        case .moveFocusToNextWindow, .moveFocusToNextWindowGlobal:
           path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
-        case .moveFocusToPreviousWindow:
+        case .moveFocusToPreviousWindow, .moveFocusToPreviousWindowGlobal:
           path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
         case .missionControl:
           path = "/System/Applications/Mission Control.app/Contents/Resources/AppIcon.icns"

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -153,9 +153,9 @@ private extension Command {
       switch command.kind {
       case .applicationWindows:
         path = "/System/Applications/Mission Control.app/Contents/Resources/AppIcon.icns"
-      case .moveFocusToNextWindowFront:
+      case .moveFocusToNextWindowFront, .moveFocusToNextWindowGlobal:
         path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
-      case .moveFocusToPreviousWindowFront:
+      case .moveFocusToPreviousWindowFront, .moveFocusToPreviousWindowGlobal:
         path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"
       case .moveFocusToNextWindow:
         path = "/System/Library/CoreServices/WidgetKit Simulator.app/Contents/Resources/AppIcon.icns"

--- a/Project.swift
+++ b/Project.swift
@@ -53,10 +53,10 @@ let project = Project(
                         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                         "CODE_SIGN_IDENTITY": "Apple Development",
                         "CODE_SIGN_STYLE": "Automatic",
-                        "CURRENT_PROJECT_VERSION": "150",
+                        "CURRENT_PROJECT_VERSION": "151",
                         "DEVELOPMENT_TEAM": env["TEAM_ID"],
                         "ENABLE_HARDENED_RUNTIME": true,
-                        "MARKETING_VERSION": "3.4.0",
+                        "MARKETING_VERSION": "3.5.0",
                         "PRODUCT_NAME": "Keyboard Cowboy"
                     ],
                     configurations: [


### PR DESCRIPTION
This PR adds functionality to let the user switch between all applications inside the same `Space`.
This means that using either command will either iterate forward or backwards through the stack of visible windows inside the current space.
It also fixes a pesky "not on the main thread" issue when calling `.performAction`
In addition to that, it also is smarter when it comes to indexering and iterating over windows