### PR TITLE
Bump KeyCodes to version 4.0.3 to fix key code mapping bug

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -7,7 +7,7 @@ let dependencies = Dependencies(
       .remote(url: "https://github.com/zenangst/AXEssibility.git", requirement: .exact("0.0.4")),
       .remote(url: "https://github.com/zenangst/Dock.git", requirement: .exact("1.0.1")),
       .remote(url: "https://github.com/zenangst/InputSources.git", requirement: .exact("1.0.1")),
-      .remote(url: "https://github.com/zenangst/KeyCodes.git", requirement: .exact("4.0.2")),
+      .remote(url: "https://github.com/zenangst/KeyCodes.git", requirement: .exact("4.0.3")),
       .remote(url: "https://github.com/zenangst/LaunchArguments.git", requirement: .exact("1.0.1")),
       .remote(url: "https://github.com/zenangst/MachPort.git", requirement: .exact("3.0.1")),
       .remote(url: "https://github.com/zenangst/Windows.git", requirement: .exact("1.0.0")),


### PR DESCRIPTION
After some optimization work in the KeyCodes framework, not all mapping resolved properly.
This should be fixed in the latest version of the framework (4.0.3)
