### PR TITLE
Improve switching between windows and using Exposé

### DIFF
--- a/App/Sources/Core/Engines/Applications/ApplicationEngine.swift
+++ b/App/Sources/Core/Engines/Applications/ApplicationEngine.swift
@@ -6,6 +6,7 @@ final class ApplicationEngine {
     let bringToFront: BringToFrontApplicationPlugin
     let close: CloseApplicationPlugin
     let launch: LaunchApplicationPlugin
+    let missionControl: MissionControlPlugin
   }
 
   private let windowListStore: WindowListStoring
@@ -19,10 +20,11 @@ final class ApplicationEngine {
     self.windowListStore = windowListStore
     self.workspace = workspace
     self.plugins = Plugins(
-      activate: ActivateApplicationPlugin(keyboard: keyboard, workspace: workspace),
+      activate: ActivateApplicationPlugin(workspace: workspace),
       bringToFront: BringToFrontApplicationPlugin(engine: scriptEngine),
       close: CloseApplicationPlugin(workspace: workspace),
-      launch: LaunchApplicationPlugin(workspace: workspace)
+      launch: LaunchApplicationPlugin(workspace: workspace),
+      missionControl: MissionControlPlugin(keyboard: keyboard)
     )
   }
 
@@ -78,6 +80,8 @@ final class ApplicationEngine {
       if !windowListStore.windowOwners().contains(command.application.bundleName) {
         try await plugins.activate.execute(command)
       }
+
+      plugins.missionControl.execute()
     }
   }
 }

--- a/App/Sources/Core/Engines/Applications/Plugins/ActivateApplicationPlugin.swift
+++ b/App/Sources/Core/Engines/Applications/Plugins/ActivateApplicationPlugin.swift
@@ -9,10 +9,8 @@ final class ActivateApplicationPlugin {
   }
 
   private let workspace: WorkspaceProviding
-  private let keyboard: KeyboardEngine
 
-  init(keyboard: KeyboardEngine, workspace: WorkspaceProviding) {
-    self.keyboard = keyboard
+  init(workspace: WorkspaceProviding) {
     self.workspace = workspace
   }
 
@@ -48,22 +46,6 @@ final class ActivateApplicationPlugin {
 
     if !runningApplication.activate(options: options) {
       throw ActivateApplicationPlugin.failedToActivate
-    }
-
-    let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as [AnyObject]? ?? []
-    let missionControlIsActive = !windows.filter { entry in
-      guard let appName = entry[kCGWindowOwnerName as String] as? String,
-            let layer = entry[kCGWindowLayer as String] as? Int,
-            appName == "Dock" &&
-            layer == CGWindowLevelKey.desktopIconWindow.rawValue else {
-        return false
-      }
-
-      return true
-    }.isEmpty
-
-    if missionControlIsActive {
-      
     }
   }
 }

--- a/App/Sources/Core/Engines/Applications/Plugins/MissionControlPlugin.swift
+++ b/App/Sources/Core/Engines/Applications/Plugins/MissionControlPlugin.swift
@@ -1,0 +1,27 @@
+import Cocoa
+
+final class MissionControlPlugin {
+  private let keyboard: KeyboardEngine
+
+  init(keyboard: KeyboardEngine) {
+    self.keyboard = keyboard
+  }
+
+  func execute() {
+    let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as [AnyObject]? ?? []
+    let missionControlIsActive = !windows.filter { entry in
+      guard let appName = entry[kCGWindowOwnerName as String] as? String,
+            let layer = entry[kCGWindowLayer as String] as? Int,
+            appName == "Dock" &&
+            layer == CGWindowLevelKey.desktopIconWindow.rawValue else {
+        return false
+      }
+
+      return true
+    }.isEmpty
+
+    if missionControlIsActive {
+      try? keyboard.run(.init(keyboardShortcut: .init(key: "⎋")), type: .keyDown, originalEvent: nil, with: nil)
+    }
+  }
+}

--- a/App/Sources/Core/Engines/CommandEngine.swift
+++ b/App/Sources/Core/Engines/CommandEngine.swift
@@ -36,8 +36,11 @@ final class CommandEngine: CommandRunning {
   var lastExecutedCommand: Command?
   var eventSource: CGEventSource?
 
-  init(_ workspace: WorkspaceProviding, scriptEngine: ScriptEngine, keyboardEngine: KeyboardEngine) {
-    let systemCommandEngine = SystemCommandEngine()
+  init(_ workspace: WorkspaceProviding,
+       applicationStore: ApplicationStore,
+       scriptEngine: ScriptEngine,
+       keyboardEngine: KeyboardEngine) {
+    let systemCommandEngine = SystemCommandEngine(applicationStore)
     self.engines = .init(
       application: ApplicationEngine(
         scriptEngine: scriptEngine,

--- a/App/Sources/Core/Engines/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Engines/KeyboardCowboyEngine.swift
@@ -31,7 +31,12 @@ final class KeyboardCowboyEngine {
        shortcutStore: ShortcutStore,
        workspace: NSWorkspace = .shared) {
     
-    let commandEngine = CommandEngine(workspace, scriptEngine: scriptEngine, keyboardEngine: keyboardEngine)
+    let commandEngine = CommandEngine(
+      workspace,
+      applicationStore: contentStore.applicationStore,
+      scriptEngine: scriptEngine,
+      keyboardEngine: keyboardEngine
+    )
     self.contentStore = contentStore
     self.keyCodeStore = keyCodeStore
     self.commandEngine = commandEngine

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -98,6 +98,7 @@ struct KeyboardCowboy: App {
     let detailCoordinator = DetailCoordinator(applicationStore: applicationStore,
                                               applicationTriggerSelectionManager: applicationTriggerSelectionManager,
                                               commandEngine: CommandEngine(NSWorkspace.shared,
+                                                                           applicationStore: applicationStore,
                                                                            scriptEngine: scriptEngine,
                                                                            keyboardEngine: keyboardEngine),
                                               commandSelectionManager: commandSelectionManager,


### PR DESCRIPTION
Added `MissionControlPlugin` to detect mission control activation and dismiss Exposé automatically during application command.

The ActivateApplicationPlugin codebase has been updated to remove any mission control related code that is not directly related to the functionality of activating the application.

Improve reliability of switching between windows when Stage Manager is configured to Show windows from an application: "One at a Time"
