### PR TITLE
Various UI improvements

### DIFF
--- a/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
@@ -74,8 +74,6 @@ struct ApplicationCommandView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .truncationMode(.middle)
                 .allowsTightening(true)
-              Image(systemName: "chevron.down")
-                .opacity(0.5)
             }
             .padding(4)
           })

--- a/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
@@ -79,12 +79,7 @@ struct ApplicationCommandView: View {
             }
             .padding(4)
           })
-          .buttonStyle(.plain)
-          .background(
-            RoundedRectangle(cornerRadius: 4)
-              .stroke(Color(.disabledControlTextColor))
-              .opacity(0.5)
-          )
+          .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: false)))
           .compositingGroup()
 
           TextField("", text: $name)

--- a/App/Sources/UI/Views/Commands/CommandContainerView.swift
+++ b/App/Sources/UI/Views/Commands/CommandContainerView.swift
@@ -38,7 +38,7 @@ struct CommandContainerView<IconContent, Content, SubContent>: View where IconCo
             .frame(maxWidth: 32, maxHeight: 32)
 
           content($command)
-            .frame(minHeight: 30)
+            .frame(minHeight: 30, maxHeight: .infinity)
         }
         .padding([.top, .leading], 8)
 
@@ -54,7 +54,7 @@ struct CommandContainerView<IconContent, Content, SubContent>: View where IconCo
 
           subContent($command)
             .buttonStyle(.appStyle)
-            .padding(.leading, 2)
+            .padding(.leading, 8)
         }
         .padding(.bottom, 8)
         .padding(.leading, 4)

--- a/App/Sources/UI/Views/Commands/KeyboardCommandView.swift
+++ b/App/Sources/UI/Views/Commands/KeyboardCommandView.swift
@@ -55,12 +55,13 @@ struct KeyboardCommandView: View {
           EditableKeyboardShortcutsView($keyboardShortcuts,
                                         selectionManager: .init(),
                                         onTab: { _ in })
-            .onChange(of: keyboardShortcuts) { newValue in
-              onAction(.updateKeyboardShortcuts(newValue))
-            }
-            .padding(.horizontal, 2)
-            .background(Color(.textBackgroundColor).opacity(0.65))
-            .cornerRadius(4)
+          .font(.caption)
+          .frame(height: 40)
+          .onChange(of: keyboardShortcuts) { newValue in
+            onAction(.updateKeyboardShortcuts(newValue))
+          }
+          .padding(.vertical, 4)
+          .background(Color(.textBackgroundColor).opacity(0.65).cornerRadius(4))
         }
       },
       subContent: { command in

--- a/App/Sources/UI/Views/Commands/OpenCommandView.swift
+++ b/App/Sources/UI/Views/Commands/OpenCommandView.swift
@@ -44,7 +44,7 @@ struct OpenCommandView: View {
           .onChange(of: name, perform: {
             onAction(.updateName(newName: $0))
           })
-        Spacer()
+          .frame(maxWidth: .infinity)
 
         if case .open(_, _, let appName) = command.wrappedValue.kind {
           Menu(content: {
@@ -55,14 +55,15 @@ struct OpenCommandView: View {
             }
           }, label: {
               Text(appName ?? "Default")
-                .fixedSize(horizontal: false, vertical: true)
+                .font(.caption)
                 .truncationMode(.middle)
                 .lineLimit(1)
                 .allowsTightening(true)
                 .padding(4)
           })
-          .menuStyle(.appStyle(padding: 4))
-          .frame(maxWidth: 120)
+          .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: false),
+                                       menuIndicator: applicationStore.applicationsToOpen(command.wrappedValue.name).isEmpty ? .hidden : .visible))
+//          .frame(maxWidth: 120, alignment: .trailing)
         }
       }
     }, subContent: { command in

--- a/App/Sources/UI/Views/Commands/OpenCommandView.swift
+++ b/App/Sources/UI/Views/Commands/OpenCommandView.swift
@@ -80,7 +80,7 @@ struct OpenCommandView: View {
         case .open(let path, _, _):
           if !path.hasPrefix("http") {
             Button("Reveal", action: { onAction(.reveal(path: path)) })
-              .buttonStyle(GradientButtonStyle(.init(nsColor: .systemBlue)))
+              .buttonStyle(GradientButtonStyle(.init(nsColor: .systemBlue, grayscaleEffect: true)))
           }
         default:
           EmptyView()

--- a/App/Sources/UI/Views/Commands/ScriptCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ScriptCommandView.swift
@@ -71,6 +71,7 @@ struct ScriptCommandView: View {
                 }))
               })
               .buttonStyle(.gradientStyle(config: .init(nsColor: .systemBlue, grayscaleEffect: true)))
+              .font(.caption)
             }
           }
         }
@@ -83,7 +84,9 @@ struct ScriptCommandView: View {
             EmptyView()
           case .path(_, let source, _):
             Button("Open", action: { onAction(.open(path: source)) })
+              .buttonStyle(.gradientStyle(config: .init(nsColor: .systemCyan, grayscaleEffect: true)))
             Button("Reveal", action: { onAction(.reveal(path: source)) })
+              .buttonStyle(.gradientStyle(config: .init(nsColor: .systemBlue, grayscaleEffect: true)))
           }
         }
       }

--- a/App/Sources/UI/Views/Commands/ShortcutCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ShortcutCommandView.swift
@@ -49,7 +49,8 @@ struct ShortcutCommandView: View {
         Text("|")
 
         Button("Open Shortcuts", action: { onAction(.openShortcuts) })
-          .buttonStyle(GradientButtonStyle(.init(nsColor: .systemPurple)))
+          .buttonStyle(GradientButtonStyle(.init(nsColor: .systemPurple, grayscaleEffect: true)))
+          .font(.caption)
       }
     }, onAction: { onAction(.commandAction($0)) })
     .debugEdit()

--- a/App/Sources/UI/Views/Commands/SystemCommandView.swift
+++ b/App/Sources/UI/Views/Commands/SystemCommandView.swift
@@ -42,20 +42,12 @@ struct SystemCommandView: View {
           HStack(spacing: 4) {
             Text(kind.displayValue)
               .font(.caption)
-              .fixedSize(horizontal: false, vertical: true)
               .truncationMode(.middle)
               .allowsTightening(true)
-            Image(systemName: "chevron.down")
-              .opacity(0.5)
           }
           .padding(4)
         })
-        .buttonStyle(.plain)
-        .background(
-          RoundedRectangle(cornerRadius: 4)
-            .stroke(Color(.disabledControlTextColor))
-            .opacity(0.5)
-        )
+        .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: false), fixedSize: false))
       }
     }, subContent: { command in
       Toggle("Notify", isOn: $notify)

--- a/App/Sources/UI/Views/Commands/SystemCommandView.swift
+++ b/App/Sources/UI/Views/Commands/SystemCommandView.swift
@@ -59,6 +59,10 @@ struct SystemCommandView: View {
       }
     }, subContent: { command in
       Toggle("Notify", isOn: $notify)
+        .lineLimit(1)
+        .allowsTightening(true)
+        .truncationMode(.tail)
+        .font(.caption)
         .onChange(of: notify) { newValue in
           onAction(.toggleNotify(newValue: newValue))
         }

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -89,11 +89,12 @@ private extension Array where Element == Command {
 
   func images(limit: Int) -> [ContentViewModel.ImageModel] {
     var images = [ContentViewModel.ImageModel]()
-    for (offset, element) in self.enumerated() where element.isEnabled {
+    for (offset, element) in self.reversed().enumerated() where element.isEnabled {
       // Don't render icons for commands that are not enabled.
       if !element.isEnabled { continue }
 
       if offset == limit { break }
+
       let convertedOffset = Double(offset)
       switch element {
       case .application(let command):
@@ -179,6 +180,6 @@ private extension Array where Element == Command {
       }
     }
 
-    return images
+    return images.reversed()
   }
 }

--- a/App/Sources/UI/Views/NewCommand/NewCommandView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandView.swift
@@ -80,7 +80,7 @@ struct NewCommandView: View {
                   .fill(Color.white.opacity(0.2))
                   .frame(width: 1)
               })
-            .frame(maxWidth: 200)
+            .frame(maxWidth: 225)
           detail(title: $title)
         }
       } else {
@@ -109,17 +109,9 @@ struct NewCommandView: View {
                 .layoutPriority(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
               Spacer()
-              Text("\(ModifierKey.command.keyValue)\(kind.rawKey)")
-                .font(.system(.caption, design: .monospaced))
-                .multilineTextAlignment(.center)
-                .tracking(2)
-                .layoutPriority(1)
-                .padding(2)
-                .background(
-                  RoundedRectangle(cornerRadius: 4)
-                    .fill(Color(.textBackgroundColor))
-                    .shadow(radius: 4)
-                )
+
+              RegularKeyIcon(letter: "\(ModifierKey.command.keyValue)\(kind.rawKey)", width: 24, height: 24)
+                .fixedSize()
             }
             .padding(.leading, 4)
             .padding(.trailing, 18)

--- a/App/Sources/UI/Views/SidebarConfigurationView.swift
+++ b/App/Sources/UI/Views/SidebarConfigurationView.swift
@@ -67,7 +67,6 @@ struct SidebarConfigurationView: View {
           .resizable()
       })
       .menuStyle(GradientMenuStyle(.init(nsColor: .systemGreen, grayscaleEffect: true)))
-      .menuIndicator(.hidden)
       .popover(isPresented: $deleteConfigurationPopover, arrowEdge: .bottom, content: {
         VStack {
           Text("Are you sure you want to delete '\(configurationName)'")

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -133,7 +133,7 @@ struct SingleDetailView: View {
                 .padding(.vertical, 4)
                 .offset(x: -4, y: 1)
             })
-            .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray)))
+            .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray), menuIndicator: .visible))
             .frame(maxWidth: detailPublisher.data.execution == .concurrent ? 144 : 110,
                    alignment: .leading)
           }

--- a/App/Sources/UI/Views/Styles/GradientButtonStyle.swift
+++ b/App/Sources/UI/Views/Styles/GradientButtonStyle.swift
@@ -85,16 +85,26 @@ struct GradientButtonStyle_Previews: PreviewProvider {
 
 struct GradientMenuStyle: MenuStyle {
   private let config: GradientConfiguration
+  private let fixedSize: Bool
+  private let menuIndicator: Visibility
   @State private var isHovered: Bool
 
-  init(_ config: GradientConfiguration) {
+  init(_ config: GradientConfiguration,
+       fixedSize: Bool = true,
+       menuIndicator: Visibility = .visible) {
     self.config = config
+    self.fixedSize = fixedSize
+    self.menuIndicator = menuIndicator
     _isHovered = .init(initialValue: config.hoverEffect ? false : true)
   }
 
   func makeBody(configuration: Configuration) -> some View {
     Menu(configuration)
+      .font(.caption)
+      .truncationMode(.middle)
+      .allowsTightening(true)
       .menuStyle(.borderlessButton)
+      .menuIndicator(menuIndicator)
       .foregroundColor(Color(.textColor))
       .padding(.horizontal, 4)
       .frame(minHeight: 24)
@@ -125,7 +135,7 @@ struct GradientMenuStyle: MenuStyle {
         guard config.hoverEffect else { return }
         self.isHovered = value
       })
-      .fixedSize()
+      .fixedSize(horizontal: fixedSize, vertical: true)
       .contentShape(Rectangle())
   }
 }


### PR DESCRIPTION
- Add `grayScaleEffect` on the Reveal, Open Shortcuts button
- Add truncation to notification toggle
- Fix sizing issue of the `KeyCommandView`
- Fix truncation issues in the new command window and use a regular key
  instead of customized text to show the keyboard shortcuts for navigating
  between panes
- Use caption fonts in command views
- Improve order of images used in the content list view items

<img width="1003" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/10869bd9-cff8-4509-9bee-03bf58a6e1fc">
<img width="1003" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/3b4a9e9f-a116-4f0d-80d1-32c638acd704">
<img width="822" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/f8e10656-9e15-40d4-b8d3-3628f8965df4">

