### PR TITLE
Improve the UX when Mission Control is active

### DIFF
--- a/App/Sources/Core/Engines/Applications/ApplicationEngine.swift
+++ b/App/Sources/Core/Engines/Applications/ApplicationEngine.swift
@@ -6,7 +6,6 @@ final class ApplicationEngine {
     let bringToFront: BringToFrontApplicationPlugin
     let close: CloseApplicationPlugin
     let launch: LaunchApplicationPlugin
-    let missionControl: MissionControlPlugin
   }
 
   private let windowListStore: WindowListStoring
@@ -23,8 +22,7 @@ final class ApplicationEngine {
       activate: ActivateApplicationPlugin(workspace: workspace),
       bringToFront: BringToFrontApplicationPlugin(engine: scriptEngine),
       close: CloseApplicationPlugin(workspace: workspace),
-      launch: LaunchApplicationPlugin(workspace: workspace),
-      missionControl: MissionControlPlugin(keyboard: keyboard)
+      launch: LaunchApplicationPlugin(workspace: workspace)
     )
   }
 
@@ -80,8 +78,6 @@ final class ApplicationEngine {
       if !windowListStore.windowOwners().contains(command.application.bundleName) {
         try await plugins.activate.execute(command)
       }
-
-      plugins.missionControl.execute()
     }
   }
 }

--- a/App/Sources/Core/Engines/Applications/Plugins/MissionControlPlugin.swift
+++ b/App/Sources/Core/Engines/Applications/Plugins/MissionControlPlugin.swift
@@ -7,7 +7,7 @@ final class MissionControlPlugin {
     self.keyboard = keyboard
   }
 
-  func execute() {
+  func dismissIfActive() {
     let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as [AnyObject]? ?? []
     let missionControlIsActive = !windows.filter { entry in
       guard let appName = entry[kCGWindowOwnerName as String] as? String,

--- a/App/Sources/Core/Engines/CommandEngine.swift
+++ b/App/Sources/Core/Engines/CommandEngine.swift
@@ -28,6 +28,7 @@ final class CommandEngine: CommandRunning {
     }
   }
 
+  private let missionControl: MissionControlPlugin
   private let engines: Engines
   private let workspace: WorkspaceProviding
   private var runningTask: Task<Void, Error>?
@@ -41,6 +42,7 @@ final class CommandEngine: CommandRunning {
        scriptEngine: ScriptEngine,
        keyboardEngine: KeyboardEngine) {
     let systemCommandEngine = SystemCommandEngine(applicationStore)
+    self.missionControl = MissionControlPlugin(keyboard: keyboardEngine)
     self.engines = .init(
       application: ApplicationEngine(
         scriptEngine: scriptEngine,
@@ -59,6 +61,7 @@ final class CommandEngine: CommandRunning {
   }
 
   func reveal(_ commands: [Command]) {
+    missionControl.dismissIfActive()
     for command in commands {
       switch command {
       case .application(let applicationCommand):
@@ -99,6 +102,7 @@ final class CommandEngine: CommandRunning {
   }
 
   func serialRun(_ commands: [Command]) {
+    missionControl.dismissIfActive()
     runningTask?.cancel()
     runningTask = Task.detached(priority: .userInitiated) { [weak self] in
       guard let self else { return }
@@ -115,6 +119,7 @@ final class CommandEngine: CommandRunning {
   }
 
   func concurrentRun(_ commands: [Command]) {
+    missionControl.dismissIfActive()
     runningTask?.cancel()
     runningTask = Task.detached(priority: .userInitiated) { [weak self] in
       guard let self else { return }

--- a/Project.swift
+++ b/Project.swift
@@ -53,10 +53,10 @@ let project = Project(
                         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                         "CODE_SIGN_IDENTITY": "Apple Development",
                         "CODE_SIGN_STYLE": "Automatic",
-                        "CURRENT_PROJECT_VERSION": "160",
+                        "CURRENT_PROJECT_VERSION": "161",
                         "DEVELOPMENT_TEAM": env["TEAM_ID"],
                         "ENABLE_HARDENED_RUNTIME": true,
-                        "MARKETING_VERSION": "3.5.1",
+                        "MARKETING_VERSION": "3.5.2",
                         "PRODUCT_NAME": "Keyboard Cowboy"
                     ],
                     configurations: [


### PR DESCRIPTION
- Move `MissionControl` plugin to `CommandEngine`
- Invoke dismissing mission control when all commands are run (like opening a file or a webiste) w
