### PR TITLE
Add support for delaying commands when execution is serial

### DIFF
--- a/App/Sources/Core/Engines/CommandEngine.swift
+++ b/App/Sources/Core/Engines/CommandEngine.swift
@@ -102,7 +102,9 @@ final class CommandEngine: CommandRunning {
           do {
             try await self.run(command)
           } catch { }
-          try await Task.sleep(for: .milliseconds(50))
+          if let delay = command.delay {
+            try await Task.sleep(for: .milliseconds(delay))
+          }
         }
       }
     }

--- a/App/Sources/Core/Engines/MachPortEngine.swift
+++ b/App/Sources/Core/Engines/MachPortEngine.swift
@@ -156,7 +156,7 @@ final class MachPortEngine {
         }
       } else if workflow.commands.allSatisfy({
         if case .keyboard = $0 { return true } else { return false }
-      }) {
+      }) && workflow.commands.count == 1 {
         let keyboardCommands = workflow.commands
           .filter(\.isEnabled)
           .compactMap {

--- a/App/Sources/Core/Engines/MachPortEngine.swift
+++ b/App/Sources/Core/Engines/MachPortEngine.swift
@@ -154,31 +154,6 @@ final class MachPortEngine {
         case .serial:
           commandEngine.serialRun(workflow.commands)
         }
-      } else if workflow.commands.allSatisfy({
-        if case .keyboard = $0 { return true } else { return false }
-      }) && workflow.commands.count == 1 {
-        let keyboardCommands = workflow.commands
-          .filter(\.isEnabled)
-          .compactMap {
-            if case .keyboard(let command) = $0 {
-              return command
-            } else {
-              return nil
-            }
-          }
-        Task {
-          for command in keyboardCommands {
-            try? keyboardEngine.run(command,
-                                    type: .keyDown,
-                                    originalEvent: machPortEvent.event,
-                                    with: machPortEvent.eventSource)
-            try await Task.sleep(for: .milliseconds(75))
-            try? keyboardEngine.run(command,
-                                    type: .keyUp,
-                                    originalEvent: machPortEvent.event,
-                                    with: machPortEvent.eventSource)
-          }
-        }
       } else if kind == .keyDown, !isRepeatingEvent {
         let commands = workflow.commands.filter(\.isEnabled)
 

--- a/App/Sources/Core/Models/Command.swift
+++ b/App/Sources/Core/Models/Command.swift
@@ -25,6 +25,12 @@ extension MetaDataProviding {
     get { meta.isEnabled }
     set { meta.isEnabled = newValue }
   }
+
+  var delay: Double? {
+    get { meta.delay }
+    set { meta.delay = newValue }
+  }
+
 }
 
 enum MetaDataMigrator: String, CodingKey {

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -287,7 +287,9 @@ extension CommandView.Kind {
 extension CommandView.Action {
   var commandId: DetailViewModel.CommandViewModel.ID {
     switch self {
-    case .toggleEnabled(_, let commandId, _), .toggleNotify(_, let commandId, _):
+    case .toggleEnabled(_, let commandId, _),
+         .toggleNotify(_, let commandId, _),
+         .changeDelay(_, let commandId, _):
       return commandId
     case .modify(let kind):
       return kind.commandId

--- a/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
@@ -10,6 +10,9 @@ final class DetailCommandActionReducer {
     }
 
     switch action {
+    case .changeDelay(_, _, let newValue):
+      command.delay = newValue
+      workflow.updateOrAddCommand(command)
     case .toggleEnabled(_, _, let newValue):
       command.isEnabled = newValue
       workflow.updateOrAddCommand(command)

--- a/App/Sources/UI/Reducers/DetailCommandContainerActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandContainerActionReducer.swift
@@ -11,6 +11,8 @@ final class DetailCommandContainerActionReducer {
       command.isEnabled = isEnabled
     case .toggleNotify(let newValue):
       command.notification = newValue
+    case .changeDelay(let delay):
+      command.meta.delay = delay
     }
   }
 }

--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CommandView: View {
   enum Action {
+    case changeDelay(workflowId: DetailViewModel.ID, commandId: DetailViewModel.CommandViewModel.ID, newValue: Double?)
     case toggleNotify(workflowId: DetailViewModel.ID, commandId: DetailViewModel.CommandViewModel.ID, newValue: Bool)
     case toggleEnabled(workflowId: DetailViewModel.ID, commandId: DetailViewModel.CommandViewModel.ID, newValue: Bool)
     case modify(Kind)
@@ -238,6 +239,8 @@ struct CommandResolverView: View {
       onAction(.toggleEnabled(workflowId: workflowId, commandId: command.id, newValue: isEnabled))
     case .toggleNotify(let newValue):
       onAction(.toggleNotify(workflowId: workflowId, commandId: command.id, newValue: newValue))
+    case .changeDelay(let newValue):
+      onAction(.changeDelay(workflowId: workflowId, commandId: command.id, newValue: newValue))
     }
   }
 }


### PR DESCRIPTION
Adds support for configuring commands to add a small delay after they have been run.
This gives fine-grain control when you have a lot of commands running in a serial queue.