### PR TITLE
Fix bug with script commands not being mapped correctly

### DIFF
--- a/App/Sources/Core/Engines/Scripting/ScriptEngine.swift
+++ b/App/Sources/Core/Engines/Scripting/ScriptEngine.swift
@@ -21,8 +21,8 @@ final class ScriptEngine {
     var result: String?
 
     switch (command.kind, command.source) {
-    case (.appleScript, .path(let source)):
-      result = try await plugins.appleScript.execute(source, withId: command.id)
+    case (.appleScript, .path(let path)):
+      result = try await plugins.appleScript.executeScript(at: path, withId: command.id)
     case (.appleScript, .inline(let script)):
       result = try await plugins.appleScript.execute(script, withId: command.id)
     case (.shellScript, .path(let source)):

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -95,15 +95,13 @@ final class DetailModelMapper {
       kind = .shortcut
       name = command.name
     case .script(let script):
-      let source: String
       switch script.source {
-      case .path(let string):
-        source = string
-      case .inline(let string):
-        source = string
+      case .path(let source):
+        kind = .script(.path(id: script.id, source: source, scriptExtension: script.kind))
+      case .inline(let source):
+        kind = .script(.inline(id: script.id, source: source, scriptExtension: script.kind))
       }
 
-      kind = .script(.inline(id: script.id, source: source, scriptExtension: script.kind))
       name = command.name
     case .type(let type):
       kind = .type(input: type.input)


### PR DESCRIPTION
Fixes a regression that appeared when the meta data rewrite happened.
Script commands should now be mapped and resolved correctly.
