### PR TITLE
Fix typo command not working properly

### DIFF
--- a/App/Sources/Core/Engines/KeyboardEngine.swift
+++ b/App/Sources/Core/Engines/KeyboardEngine.swift
@@ -18,8 +18,8 @@ final class KeyboardEngine {
     self.store = store
   }
 
-  func virtualKey(for string: String) -> VirtualKey? {
-    store.virtualKey(for: string)
+  func virtualKey(for string: String, modifiers: [VirtualModifierKey] = [], matchDisplayValue: Bool = true) -> VirtualKey? {
+    store.virtualKey(for: string, modifiers: modifiers, matchDisplayValue: matchDisplayValue)
   }
 
   func run(_ command: KeyboardCommand,

--- a/App/Sources/Core/Engines/MachPortEngine.swift
+++ b/App/Sources/Core/Engines/MachPortEngine.swift
@@ -115,7 +115,11 @@ final class MachPortEngine {
     let keyboardShortcut = KeyShortcut(key: displayValue, lhs: machPortEvent.lhs, modifiers: modifiers)
 
     // Found a match
-    let result = keyboardShortcutsController.lookup(keyboardShortcut, partialMatch: previousPartialMatch)
+    var result = keyboardShortcutsController.lookup(keyboardShortcut, partialMatch: previousPartialMatch)
+    if result == nil {
+      let keyboardShortcut = KeyShortcut(key: displayValue.uppercased(), lhs: machPortEvent.lhs, modifiers: modifiers)
+      result = keyboardShortcutsController.lookup(keyboardShortcut, partialMatch: previousPartialMatch)
+    }
 
     switch result {
     case .partialMatch(let key):

--- a/App/Sources/Core/Stores/KeyCodesStore.swift
+++ b/App/Sources/Core/Stores/KeyCodesStore.swift
@@ -39,8 +39,10 @@ final class KeyCodesStore {
     VirtualSpecialKey.keys
   }
 
-  func virtualKey(for string: String) -> VirtualKey? {
-    virtualKeyContainer?.valueForString(string, matchDisplayValue: false)
+  func virtualKey(for string: String, modifiers: [VirtualModifierKey] = [], matchDisplayValue: Bool = true) -> VirtualKey? {
+    virtualKeyContainer?.valueForString(string,
+                                        modifiers: modifiers,
+                                        matchDisplayValue: matchDisplayValue)
   }
 
   func keyCode(for string: String, matchDisplayValue: Bool) -> Int? {

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -7,7 +7,7 @@ let dependencies = Dependencies(
       .remote(url: "https://github.com/zenangst/AXEssibility.git", requirement: .exact("0.0.5")),
       .remote(url: "https://github.com/zenangst/Dock.git", requirement: .exact("1.0.1")),
       .remote(url: "https://github.com/zenangst/InputSources.git", requirement: .exact("1.0.1")),
-      .remote(url: "https://github.com/zenangst/KeyCodes.git", requirement: .exact("4.0.3")),
+      .remote(url: "https://github.com/zenangst/KeyCodes.git", requirement: .exact("4.0.4")),
       .remote(url: "https://github.com/zenangst/LaunchArguments.git", requirement: .exact("1.0.1")),
       .remote(url: "https://github.com/zenangst/MachPort.git", requirement: .exact("3.0.1")),
       .remote(url: "https://github.com/zenangst/Windows.git", requirement: .exact("1.0.0")),


### PR DESCRIPTION
- Refactor type command to rely directly on the mach port
- Update to the latest and greatest version of KeyCodes (4.0.4)
- Minor refactoring on resolving keys based on the changes coming from KeyCodes
