### PR TITLE
Feature data structure and UI changes related to passthrough settings on workflows

### DIFF
--- a/App/Sources/Core/Controllers/KeyboardShortcutsController.swift
+++ b/App/Sources/Core/Controllers/KeyboardShortcutsController.swift
@@ -35,12 +35,12 @@ final class KeyboardShortcutsController {
       bundleIdentifiers.forEach { bundleIdentifier in
         group.workflows.forEach { workflow in
           guard workflow.isEnabled else { return }
-          guard case .keyboardShortcuts(let keyboardShortcuts) = workflow.trigger else { return }
+          guard case .keyboardShortcuts(let trigger) = workflow.trigger else { return }
 
-          let count = keyboardShortcuts.count - 1
+          let count = trigger.shortcuts.count - 1
           var previousKey: String = "."
           var offset = 0
-          keyboardShortcuts.forEach { keyboardShortcut in
+          trigger.shortcuts.forEach { keyboardShortcut in
             let key = createKey(keyboardShortcut, bundleIdentifier: bundleIdentifier, previousKey: previousKey)
             previousKey += "\(keyboardShortcut.dictionaryKey)+"
 

--- a/App/Sources/Core/Controllers/Storage.swift
+++ b/App/Sources/Core/Controllers/Storage.swift
@@ -64,7 +64,7 @@ final class Storage {
     do {
       let result = try decoder.decode([KeyboardCowboyConfiguration].self, from: data)
 
-      if MetaDataMigrator.didMigrate {
+      if Migration.shouldSave {
          try save(result)
       }
 

--- a/App/Sources/Core/Models/Command.swift
+++ b/App/Sources/Core/Models/Command.swift
@@ -34,15 +34,13 @@ extension MetaDataProviding {
 }
 
 enum MetaDataMigrator: String, CodingKey {
-  static var didMigrate: Bool = false
-
   case id
   case name
   case isEnabled = "enabled"
   case notification
 
   static func migrate(_ decoder: Decoder) throws -> Command.MetaData {
-    Self.didMigrate = true
+    Migration.shouldSave = true
     // Try and migrate from the previous data structure.
     let container = try decoder.container(keyedBy: Command.MetaData.CodingKeys.self)
     let id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString

--- a/App/Sources/Core/Models/KeyboardCowboyConfiguration.swift
+++ b/App/Sources/Core/Models/KeyboardCowboyConfiguration.swift
@@ -22,7 +22,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
     if !NSWorkspace.shared.urlsForApplications(withBundleIdentifier: "com.apple.dt.Xcode").isEmpty {
       editorWorkflow = Workflow(
         name: "Switch to Xcode",
-        trigger: .keyboardShortcuts([.init(key: "E", modifiers: [.function])]),
+        trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "E", modifiers: [.function])])),
         commands: [
           .application(
             .init(application: .xcode())
@@ -32,7 +32,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
     } else {
       editorWorkflow = Workflow(
         name: "Switch to TextEdit",
-        trigger: .keyboardShortcuts([.init(key: "E", modifiers: [.function])]),
+        trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "E", modifiers: [.function])])),
         commands: [
           .application(
             .init(application: .init(bundleIdentifier: "com.apple.TextEdit",
@@ -50,7 +50,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
         WorkflowGroup(symbol: "app.dashed", name: "Applications", color: "#F2A23C", workflows: [
           Workflow(
             name: "Switch to Finder",
-            trigger: .keyboardShortcuts([.init(key: "F", modifiers: [.function])]),
+            trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "F", modifiers: [.function])])),
             commands: [
               .application(
                 .init(application: .finder())
@@ -60,7 +60,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
           editorWorkflow,
           Workflow(
             name: "Switch to Terminal",
-            trigger: .keyboardShortcuts([.init(key: "T", modifiers: [.function])]),
+            trigger: .keyboardShortcuts(.init(shortcuts:[.init(key: "T", modifiers: [.function])])),
             commands: [
               .application(
                 .init(application: .init(
@@ -73,7 +73,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
 
           Workflow(
             name: "Switch to Safari",
-            trigger: .keyboardShortcuts([.init(key: "S", modifiers: [.function])]),
+            trigger: .keyboardShortcuts(.init(shortcuts:[.init(key: "S", modifiers: [.function])])),
             commands: [
               .application(
                 .init(application: .safari())
@@ -82,7 +82,7 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
           ),
           Workflow(
             name: "Open System Settings",
-            trigger: .keyboardShortcuts([.init(key: ",", modifiers: [.function])]),
+            trigger: .keyboardShortcuts(.init(shortcuts:[.init(key: ",", modifiers: [.function])])),
             commands: [
               .application(
                 .init(application: .systemSettings())
@@ -104,17 +104,17 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
         WorkflowGroup(symbol: "folder", name: "Files & Folders", color: "#6BD35F",
                       workflows: [
                         Workflow(name: "Open Home folder",
-                                 trigger: .keyboardShortcuts([.init(key: "H", modifiers: [.function])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "H", modifiers: [.function])])),
                                  commands: [
                                   .open(.init(path: ("~/" as NSString).expandingTildeInPath))
                                  ]),
                         Workflow(name: "Open Documents folder",
-                                 trigger: .keyboardShortcuts([]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [])),
                                  commands: [
                                   .open(.init(path: ("~/Documents" as NSString).expandingTildeInPath))
                                  ]),
                         Workflow(name: "Open Downloads folder",
-                                 trigger: .keyboardShortcuts([]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [])),
                                  commands: [
                                   .open(.init(path: ("~/Downloads" as NSString).expandingTildeInPath))
                                  ]),
@@ -124,22 +124,22 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
                       color: "#3984F7",
                       workflows: [
                         Workflow(name: "Vim bindings H to ←",
-                                 trigger: .keyboardShortcuts([.init(key: "H", modifiers: [.option])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "H", modifiers: [.option])])),
                                  isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "←")))
                                  ]),
                         Workflow(name: "Vim bindings J to ↓",
-                                 trigger: .keyboardShortcuts([.init(key: "J", modifiers: [.option])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "J", modifiers: [.option])])),
                                  isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "↓")))
                                  ]),
                         Workflow(name: "Vim bindings K to ↑",
-                                 trigger: .keyboardShortcuts([.init(key: "K", modifiers: [.option])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "K", modifiers: [.option])])),
                                  isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "↑")))
                                  ]),
                         Workflow(name: "Vim bindings L to →",
-                                 trigger: .keyboardShortcuts([.init(key: "L", modifiers: [.option])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "L", modifiers: [.option])])),
                                  isEnabled: false, commands: [
                                   .keyboard(.init(keyboardShortcut: .init(key: "→")))
                                  ])
@@ -150,29 +150,29 @@ struct KeyboardCowboyConfiguration: Identifiable, Codable, Hashable, Sendable {
         WorkflowGroup(symbol: "safari", name: "Websites", color: "#98989D",
                       workflows: [
                         Workflow(name: "Open apple.com",
-                                 trigger: .keyboardShortcuts([
+                                 trigger: .keyboardShortcuts(.init(shortcuts:[
                                   .init(key: "⇥", modifiers: [.function]),
                                   .init(key: "A"),
-                                 ]),
+                                 ])),
                                  commands: [.open(.init(path: "https://www.apple.com"))]),
                         Workflow(name: "Open github.com",
-                                 trigger: .keyboardShortcuts([
+                                 trigger: .keyboardShortcuts(.init(shortcuts:[
                                   .init(key: "⇥", modifiers: [.function]),
                                   .init(key: "G"),
-                                 ]),
+                                 ])),
                                  commands: [.open(.init(path: "https://www.github.com"))]),
                         Workflow(name: "Open imdb.com",
-                                 trigger: .keyboardShortcuts([
+                                 trigger: .keyboardShortcuts(.init(shortcuts:[
                                   .init(key: "⇥", modifiers: [.function]),
                                   .init(key: "I"),
-                                 ]),
+                                 ])),
                                  commands: [.open(.init(path: "https://www.imdb.com"))]),
                       ]),
         WorkflowGroup(name: "Mail", color:"#3984F7",
                       rule: Rule.init(bundleIdentifiers: ["com.apple.mail"]),
                       workflows: [
                         Workflow(name: "Type mail signature",
-                                 trigger: .keyboardShortcuts([.init(key: "S", modifiers: [.function, .command])]),
+                                 trigger: .keyboardShortcuts(.init(shortcuts: [.init(key: "S", modifiers: [.function, .command])])),
                                  commands: [
                                   .type(.init(name: "Signature", input: """
 Stay hungry, stay awesome!

--- a/App/Sources/Core/Models/KeyboardShortcutTrigger.swift
+++ b/App/Sources/Core/Models/KeyboardShortcutTrigger.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct KeyboardShortcutTrigger: Hashable, Codable, Equatable {
+  var passthrough: Bool
+  let shortcuts: [KeyShortcut]
+
+  init(passthrough: Bool = false, shortcuts: [KeyShortcut]) {
+    self.passthrough = passthrough
+    self.shortcuts = shortcuts
+  }
+}

--- a/App/Sources/Core/Models/Migration/Migration.swift
+++ b/App/Sources/Core/Models/Migration/Migration.swift
@@ -1,0 +1,4 @@
+enum Migration {
+  static var shouldSave: Bool = false
+}
+

--- a/App/Sources/Core/Models/WorkflowGroup.swift
+++ b/App/Sources/Core/Models/WorkflowGroup.swift
@@ -89,11 +89,11 @@ extension WorkflowGroup {
                          workflows: [
                           Workflow.designTime(nil),
                           Workflow.designTime(.application([.init(application: application)])),
-                          Workflow.designTime(.keyboardShortcuts([
+                          Workflow.designTime(.keyboardShortcuts(.init(shortcuts: [
                             .init(key: "A", lhs: true),
                             .init(key: "B", lhs: false),
                             .init(key: "C", lhs: true)
-                          ]))
+                          ])))
                          ])
   }
 }

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -314,7 +314,8 @@ extension SingleDetailView.Action {
          .trigger(let workflowId, _),
          .updateName(let workflowId, _),
          .updateExecution(let workflowId, _),
-         .runWorkflow(let workflowId):
+         .runWorkflow(let workflowId),
+         .togglePassthrough(let workflowId, _):
       return workflowId
     }
   }

--- a/App/Sources/UI/Reducers/DetailViewActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailViewActionReducer.swift
@@ -17,6 +17,11 @@ final class DetailViewActionReducer {
     switch action {
     case .singleDetailView(let action):
       switch action {
+      case .togglePassthrough:
+        if case .keyboardShortcuts(var previousTrigger) = workflow.trigger {
+          previousTrigger.passthrough.toggle()
+          workflow.trigger = .keyboardShortcuts(previousTrigger)
+        }
       case .dropUrls(_, let urls):
         let commands = DropCommandsController.generateCommands(from: urls, applications: applicationStore.applications)
         workflow.commands.append(contentsOf: commands)

--- a/App/Sources/UI/Reducers/DetailViewActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailViewActionReducer.swift
@@ -22,7 +22,7 @@ final class DetailViewActionReducer {
         workflow.commands.append(contentsOf: commands)
         result = .animated
       case .updateKeyboardShortcuts(_, let keyboardShortcuts):
-        workflow.trigger = .keyboardShortcuts(keyboardShortcuts)
+        workflow.trigger = .keyboardShortcuts(.init(shortcuts: keyboardShortcuts))
       case .commandView(_, let action):
         DetailCommandActionReducer.reduce(action, commandEngine: commandEngine, workflow: &workflow)
       case .moveCommand(_, let fromOffsets, let toOffset):
@@ -40,7 +40,7 @@ final class DetailViewActionReducer {
       case .trigger(_, let action):
         switch action {
         case .addKeyboardShortcut:
-          workflow.trigger = .keyboardShortcuts([])
+          workflow.trigger = .keyboardShortcuts(.init(shortcuts: []))
         case .removeKeyboardShortcut:
           workflow.trigger = nil
         case .addApplication:

--- a/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
+++ b/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
@@ -190,7 +190,7 @@ enum DesignTime {
       id: UUID().uuidString,
       name: "Open News",
       isEnabled: true,
-      trigger: .keyboardShortcuts([.init(key: "f", lhs: true, modifiers: [.function])]),
+      trigger: .keyboardShortcuts(.init(passthrough: false, shortcuts: [.init(key: "f", lhs: true, modifiers: [.function])])),
       commands: [
         Self.menuBarCommand,
         Self.applicationCommand,

--- a/App/Sources/UI/Views/KeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/KeyboardTriggerView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct KeyboardTriggerView: View {
+  private let data: DetailViewModel
+  private let namespace: Namespace.ID
+  private let onAction: (SingleDetailView.Action) -> Void
+  private let trigger: DetailViewModel.KeyboardTrigger
+  private let focus: FocusState<AppFocus?>.Binding
+  private let keyboardShortcutSelectionManager: SelectionManager<KeyShortcut>
+
+  @State private var passthrough: Bool
+
+  init(namespace: Namespace.ID,
+       focus: FocusState<AppFocus?>.Binding,
+       data: DetailViewModel,
+       trigger: DetailViewModel.KeyboardTrigger,
+       keyboardShortcutSelectionManager: SelectionManager<KeyShortcut>,
+       onAction: @escaping (SingleDetailView.Action) -> Void) {
+    self.namespace = namespace
+    self.focus = focus
+    self.data = data
+    self.trigger = trigger
+    self.onAction = onAction
+    self.keyboardShortcutSelectionManager = keyboardShortcutSelectionManager
+    _passthrough = .init(initialValue: trigger.passthrough)
+  }
+
+  var body: some View {
+    HStack {
+      Button(action: {
+        onAction(.removeTrigger(workflowId: data.id))
+      },
+             label: { Image(systemName: "xmark") })
+      .buttonStyle(.appStyle)
+      Label("Keyboard Shortcuts sequence:", image: "")
+        .padding(.trailing, 12)
+      Spacer()
+      Toggle("Passthrough", isOn: $passthrough)
+        .font(.caption)
+        .onChange(of: passthrough) { newValue in
+          onAction(.togglePassthrough(workflowId: data.id, newValue: newValue))
+        }
+    }
+    .padding([.leading, .trailing], 8)
+
+    WorkflowShortcutsView(focus, data: trigger.shortcuts, selectionManager: keyboardShortcutSelectionManager) { keyboardShortcuts in
+      onAction(.updateKeyboardShortcuts(workflowId: data.id, keyboardShortcuts: keyboardShortcuts))
+    }
+    .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
+  }
+}

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -54,8 +54,8 @@ private extension Workflow {
 private extension Workflow.Trigger {
   var binding: String? {
     switch self {
-    case .keyboardShortcuts(let shortcuts):
-      return shortcuts.binding
+    case .keyboardShortcuts(let trigger):
+      return trigger.shortcuts.binding
     case .application:
       return nil
     }

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -202,7 +202,7 @@ extension Workflow.Trigger {
         }
       )
     case .keyboardShortcuts(let trigger):
-      return .keyboardShortcuts(trigger.shortcuts)
+      return .keyboardShortcuts(.init(passthrough: trigger.passthrough, shortcuts: trigger.shortcuts))
     }
   }
 }

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -201,8 +201,8 @@ extension Workflow.Trigger {
           })
         }
       )
-    case .keyboardShortcuts(let shortcuts):
-      return .keyboardShortcuts(shortcuts)
+    case .keyboardShortcuts(let trigger):
+      return .keyboardShortcuts(trigger.shortcuts)
     }
   }
 }

--- a/App/Sources/UI/Views/Models/DetailViewModel.swift
+++ b/App/Sources/UI/Views/Models/DetailViewModel.swift
@@ -46,20 +46,20 @@ struct DetailViewModel: Hashable, Identifiable, Equatable {
 
   enum Trigger: Hashable, Equatable {
     case applications([DetailViewModel.ApplicationTrigger])
-    case keyboardShortcuts([KeyShortcut])
+    case keyboardShortcuts(DetailViewModel.KeyboardTrigger)
   }
 
   struct ApplicationTrigger: Codable, Hashable, Identifiable, Equatable {
-    public var id: String
-    public var name: String
-    public var application: Application
-    public var contexts: [Context]
+    var id: String
+    var name: String
+    var application: Application
+    var contexts: [Context]
 
-    public var icon: IconViewModel {
+    var icon: IconViewModel {
       IconViewModel(bundleIdentifier: application.bundleIdentifier, path: application.path)
     }
 
-    public enum Context: String, Hashable, Codable, CaseIterable, Identifiable {
+    enum Context: String, Hashable, Codable, CaseIterable, Identifiable {
       public var id: String { rawValue }
 
       case closed, launched, frontMost
@@ -75,6 +75,11 @@ struct DetailViewModel: Hashable, Identifiable, Equatable {
         }
       }
     }
+  }
+
+  struct KeyboardTrigger: Codable, Hashable, Equatable {
+    var passthrough: Bool
+    var shortcuts: [KeyShortcut]
   }
 
   struct CommandViewModel: Codable, Hashable, Identifiable {

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -11,6 +11,7 @@ struct SingleDetailView: View {
     case moveCommand(workflowId: Workflow.ID, indexSet: IndexSet, toOffset: Int)
     case removeCommands(workflowId: Workflow.ID, commandIds: Set<Command.ID>)
     case removeTrigger(workflowId: Workflow.ID)
+    case togglePassthrough(workflowId: Workflow.ID, newValue: Bool)
     case runWorkflow(workflowId: Workflow.ID)
     case setIsEnabled(workflowId: Workflow.ID, isEnabled: Bool)
     case trigger(workflowId: Workflow.ID, action: WorkflowTriggerView.Action)

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -27,22 +27,9 @@ struct WorkflowTriggerListView: View {
   var body: some View {
     Group {
       switch data.trigger {
-      case .keyboardShortcuts(let shortcuts):
-        HStack {
-          Button(action: {
-            onAction(.removeTrigger(workflowId: data.id))
-          },
-                 label: { Image(systemName: "xmark") })
-          .buttonStyle(.appStyle)
-          Label("Keyboard Shortcuts sequence:", image: "")
-            .padding(.trailing, 12)
-        }
-        .padding([.leading, .trailing], 8)
-
-        WorkflowShortcutsView(focus, data: shortcuts, selectionManager: keyboardShortcutSelectionManager) { keyboardShortcuts in
-          onAction(.updateKeyboardShortcuts(workflowId: data.id, keyboardShortcuts: keyboardShortcuts))
-        }
-        .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
+      case .keyboardShortcuts(var trigger):
+       KeyboardTriggerView(namespace: namespace, focus: focus, data: data, trigger: trigger,
+                           keyboardShortcutSelectionManager: keyboardShortcutSelectionManager, onAction: onAction)
 
       case .applications(let triggers):
         HStack {
@@ -79,6 +66,7 @@ struct WorkflowTriggerListView_Previews: PreviewProvider {
     WorkflowTriggerListView($focus, data: DesignTime.detail,
                             applicationTriggerSelectionManager: .init(),
                             keyboardShortcutSelectionManager: .init()) { _ in }
+      .designTime()
       .frame(height: 900)
   }
 }

--- a/UnitTests/Sources/Controllers/KeyboardShortcutsControllerTests.swift
+++ b/UnitTests/Sources/Controllers/KeyboardShortcutsControllerTests.swift
@@ -67,7 +67,7 @@ final class KeyboardShortcutsControllerTests: XCTestCase {
       let newPrefix = "\(prefix)-workflow"
       return Workflow(id: "\(newPrefix)-id-\($0)",
                       name: "\(newPrefix)-name-\($0)",
-                      trigger: Workflow.Trigger.keyboardShortcuts(generateTriggers(keyboardShortcuts, prefix: newPrefix)))
+                      trigger: Workflow.Trigger.keyboardShortcuts(.init(shortcuts: generateTriggers(keyboardShortcuts, prefix: newPrefix))))
     }
   }
 


### PR DESCRIPTION
With this change, the user can now configure workflow keyboard shortcut triggers to be flagged as passthrough.
The idea here is that if the keyboard shortcut is marked as `passthrough`, Keyboard Cowboy won't capture the key events but instead run command alongside the existing events.

Keep in mind that passthrough is not take into account just yet because it isn't implemented in the mach port intercept code. That will happen in a follow-up PR.