### PR TITLE
Various performance optimizations

### DIFF
--- a/App/Sources/Core/Stores/ContentStore.swift
+++ b/App/Sources/Core/Stores/ContentStore.swift
@@ -131,18 +131,26 @@ final class ContentStore: ObservableObject {
   }
 
   private func generatePerformanceData() {
-    for kind in Command.CodingKeys.allCases {
-      var group = WorkflowGroup(name: "Group:\(kind.rawValue)")
-      for x in 0..<100 {
-        var workflow = Workflow(name: "Workflow:\(kind.rawValue):\(x + 1)")
-        for y in 0..<100 {
-          var command = Command.empty(kind)
-          command.name = "Command:\(kind.rawValue):\(y+1)"
+    var updatedGroups = Set<WorkflowGroup>()
+    updatedGroups.reserveCapacity(groupStore.groups.count)
+
+    for group in groupStore.groups {
+      var copy = group
+      let appsCount = applicationStore.applications.count
+      (0..<5).forEach { x in
+        var workflow = Workflow(name: "Performance workflow \(x)")
+        (0..<50).forEach { y in
+          let randomApp = applicationStore.applications[Int.random(in: 0..<appsCount)]
+          let command: Command = .application(
+            ApplicationCommand(name: "Application command: \(y)", application: randomApp)
+          )
           workflow.commands.append(command)
         }
-        group.workflows.append(workflow)
+        copy.workflows.append(workflow)
       }
-      groupStore.add(group)
+      updatedGroups.insert(copy)
     }
+
+    groupStore.updateGroups(updatedGroups)
   }
 }

--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -60,13 +60,7 @@ struct CommandView: View {
                   style: .focusRing)
       )
       .background(
-        LinearGradient(stops: [
-          .init(color: Color(nsColor: .windowBackgroundColor.blended(withFraction: 0.1, of: .white.withAlphaComponent(0.1))!), location: 0.0),
-          .init(color: Color(.windowBackgroundColor), location: 0.01),
-          .init(color: Color(.windowBackgroundColor), location: 0.99),
-          .init(color: Color(nsColor: .windowBackgroundColor.blended(withFraction: 0.2, of: .black.withAlphaComponent(0.1))!), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-        .cornerRadius(8)
+        Color(.windowBackgroundColor).cornerRadius(8)
       )
       .compositingGroup()
       .draggable($command.wrappedValue.draggablePayload(prefix: "WC|", selections: selectionManager.selections))
@@ -107,9 +101,6 @@ struct CommandView: View {
       .animation(.none, value: command.meta.isEnabled)
       .grayscale(command.meta.isEnabled ? controlActiveState == .key ? 0 : 0.25 : 0.5)
       .opacity(command.meta.isEnabled ? 1 : 0.5)
-      .shadow(color: Color(.sRGBLinear, white: 0, opacity: 0.1),
-              radius: command.meta.isEnabled ? 4 : 2,
-              y: command.meta.isEnabled ? 2 : 0)
       .animation(.easeIn(duration: 0.2), value: command.meta.isEnabled)
   }
 }
@@ -128,7 +119,6 @@ struct CommandResolverView: View {
     self.onAction = onAction
   }
 
-  @ViewBuilder
   var body: some View {
     switch command.kind {
     case .plain:

--- a/App/Sources/UI/Views/Commands/CommandContainerView.swift
+++ b/App/Sources/UI/Views/Commands/CommandContainerView.swift
@@ -46,22 +46,19 @@ struct CommandContainerView<IconContent, Content, SubContent>: View where IconCo
             .frame(minHeight: 30)
         }
         .padding([.top, .leading], 8)
+        .padding(.bottom, 4)
 
         HStack(spacing: 0) {
-          Toggle(isOn: $metaData.isEnabled) { }
-            .onChange(of: metaData.isEnabled, perform: {
-              onAction(.toggleIsEnabled($0))
-            })
-            .toggleStyle(.switch)
-            .tint(.green)
-            .compositingGroup()
-            .scaleEffect(0.65)
+          AppToggle("", onColor: Color(.systemGreen), style: .small, isOn: $metaData.isEnabled) {
+            onAction(.toggleIsEnabled($0))
+          }
+          .padding(.leading, 5)
+          .padding(.trailing, 5)
 
           HStack {
-            Toggle("Notify", isOn: $metaData.notification)
-              .onChange(of: metaData.notification) { newValue in
-                onAction(.toggleNotify(newValue))
-              }
+            AppCheckbox("Notify", style: .small, isOn: $metaData.notification) {
+              onAction(.toggleNotify($0))
+            }
 
             if detailPublisher.data.execution == .serial {
               Button {

--- a/App/Sources/UI/Views/Components/AppCheckbox.swift
+++ b/App/Sources/UI/Views/Components/AppCheckbox.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct AppCheckbox: View {
+  enum Style {
+    case regular
+    case small
+
+    var size: CGSize {
+      switch self {
+      case .regular:
+        CGSize(width: 16, height: 16)
+      case .small:
+        CGSize(width: 12, height: 12)
+      }
+    }
+
+    var fontSize: CGFloat {
+      switch self {
+      case .regular:
+        return 10
+      case .small:
+        return 8
+      }
+    }
+  }
+
+  @Binding private var isOn: Bool
+  private let style: Style
+  private let titleKey: String
+  private let onChange: (Bool) -> Void
+
+  init(_ titleKey: String,
+       style: Style = .regular,
+       isOn: Binding<Bool>,
+       onChange: @escaping (Bool) -> Void = { _ in }) {
+    _isOn = isOn
+    self.style = style
+    self.titleKey = titleKey
+    self.onChange = onChange
+  }
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Button(action: {
+        isOn.toggle()
+        onChange(isOn)
+      }, label: {
+        RoundedRectangle(cornerRadius: 4, style: .continuous)
+          .fill(Color(nsColor: .controlColor))
+          .overlay(content: {
+            Image(systemName: "checkmark")
+              .font(Font.system(size: style.fontSize, weight: .heavy))
+              .opacity(isOn ? 1 : 0)
+          })
+          .frame(width: style.size.width, height: style.size.height)
+
+      })
+      .buttonStyle(.plain)
+      Text(titleKey)
+    }
+  }
+}
+
+struct AppCheckbox_Previews: PreviewProvider {
+  static var systemToggles: some View {
+    VStack {
+      Toggle(isOn: .constant(true), label: {
+        Text("Default on")
+      })
+      Toggle(isOn: .constant(false), label: {
+        Text("Default off")
+      })
+    }
+  }
+
+  static var previews: some View {
+    VStack(alignment: .leading) {
+      HStack(alignment: .top, spacing: 32) {
+        VStack(alignment: .leading) {
+          Text("System")
+            .font(.headline)
+          systemToggles
+            .toggleStyle(.switch)
+        }
+
+        VStack(alignment: .leading) {
+          Text("Regular")
+            .font(.headline)
+          AppToggle("Default on", isOn: .constant(true)) { _ in }
+          AppToggle("Default off", isOn: .constant(false)) { _ in }
+        }
+
+        VStack(alignment: .leading) {
+          Text("Small")
+            .font(.headline)
+          AppToggle("Default on", style: .small, isOn: .constant(true)) { _ in }
+            .font(.caption)
+          AppToggle("Default off", style: .small, isOn: .constant(false)) { _ in }
+            .font(.caption)
+        }
+      }
+    }
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/Components/AppCheckbox.swift
+++ b/App/Sources/UI/Views/Components/AppCheckbox.swift
@@ -80,22 +80,21 @@ struct AppCheckbox_Previews: PreviewProvider {
           Text("System")
             .font(.headline)
           systemToggles
-            .toggleStyle(.switch)
         }
 
         VStack(alignment: .leading) {
           Text("Regular")
             .font(.headline)
-          AppToggle("Default on", isOn: .constant(true)) { _ in }
-          AppToggle("Default off", isOn: .constant(false)) { _ in }
+          AppCheckbox("Default on", isOn: .constant(true)) { _ in }
+          AppCheckbox("Default off", isOn: .constant(false)) { _ in }
         }
 
         VStack(alignment: .leading) {
           Text("Small")
             .font(.headline)
-          AppToggle("Default on", style: .small, isOn: .constant(true)) { _ in }
+          AppCheckbox("Default on", style: .small, isOn: .constant(true)) { _ in }
             .font(.caption)
-          AppToggle("Default off", style: .small, isOn: .constant(false)) { _ in }
+          AppCheckbox("Default off", style: .small, isOn: .constant(false)) { _ in }
             .font(.caption)
         }
       }

--- a/App/Sources/UI/Views/Components/AppCheckbox.swift
+++ b/App/Sources/UI/Views/Components/AppCheckbox.swift
@@ -8,9 +8,9 @@ struct AppCheckbox: View {
     var size: CGSize {
       switch self {
       case .regular:
-        CGSize(width: 16, height: 16)
+        return CGSize(width: 16, height: 16)
       case .small:
-        CGSize(width: 12, height: 12)
+        return CGSize(width: 12, height: 12)
       }
     }
 
@@ -85,16 +85,16 @@ struct AppCheckbox_Previews: PreviewProvider {
         VStack(alignment: .leading) {
           Text("Regular")
             .font(.headline)
-          AppCheckbox("Default on", isOn: .constant(true)) { _ in }
-          AppCheckbox("Default off", isOn: .constant(false)) { _ in }
+          AppCheckbox("Default on", isOn: .constant(true))
+          AppCheckbox("Default off", isOn: .constant(false))
         }
 
         VStack(alignment: .leading) {
           Text("Small")
             .font(.headline)
-          AppCheckbox("Default on", style: .small, isOn: .constant(true)) { _ in }
+          AppCheckbox("Default on", style: .small, isOn: .constant(true))
             .font(.caption)
-          AppCheckbox("Default off", style: .small, isOn: .constant(false)) { _ in }
+          AppCheckbox("Default off", style: .small, isOn: .constant(false))
             .font(.caption)
         }
       }

--- a/App/Sources/UI/Views/Components/AppToggle.swift
+++ b/App/Sources/UI/Views/Components/AppToggle.swift
@@ -8,18 +8,18 @@ struct AppToggle: View {
     var size: CGSize {
       switch self {
       case .regular:
-        CGSize(width: 38, height: 20)
+        return CGSize(width: 38, height: 20)
       case .small:
-        CGSize(width: 22, height: 12)
+        return CGSize(width: 22, height: 12)
       }
     }
 
     var circle: CGSize {
       switch self {
       case .regular:
-        CGSize(width: 19, height: 19)
+        return CGSize(width: 19, height: 19)
       case .small:
-        CGSize(width: 11, height: 11)
+        return CGSize(width: 11, height: 11)
       }
     }
   }

--- a/App/Sources/UI/Views/Components/AppToggle.swift
+++ b/App/Sources/UI/Views/Components/AppToggle.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct AppToggle: View {
+  enum Style {
+    case regular
+    case small
+
+    var size: CGSize {
+      switch self {
+      case .regular:
+        CGSize(width: 38, height: 20)
+      case .small:
+        CGSize(width: 22, height: 12)
+      }
+    }
+
+    var circle: CGSize {
+      switch self {
+      case .regular:
+        CGSize(width: 19, height: 19)
+      case .small:
+        CGSize(width: 11, height: 11)
+      }
+    }
+  }
+
+  @Environment(\.controlActiveState) var controlActiveState
+  @Binding private var isOn: Bool
+  private let onColor: Color
+  private let style: Style
+  private let titleKey: String
+  private let onChange: (Bool) -> Void
+
+  init(_ titleKey: String,
+       onColor: Color = Color(nsColor: .controlColor),
+       style: Style = .regular,
+       isOn: Binding<Bool>,
+       onChange: @escaping (Bool) -> Void = { _ in }) {
+    _isOn = isOn
+    self.onColor = onColor
+    self.style = style
+    self.titleKey = titleKey
+    self.onChange = onChange
+  }
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Text(titleKey)
+      Button(action: {
+        isOn.toggle()
+        onChange(isOn)
+      }, label: {
+        Capsule()
+          .fill(
+            controlActiveState == .key
+            ? isOn ? onColor : Color(nsColor: .controlColor)
+            : Color(nsColor: .controlColor)
+          )
+          .overlay(alignment: isOn ? .trailing : .leading, content: {
+            Circle()
+              .frame(width: style.circle.width, height: style.circle.height)
+              .overlay(
+                Circle()
+                  .stroke(Color(nsColor: .gray), lineWidth: 0.5)
+              )
+          })
+          .animation(.default, value: isOn)
+          .background(
+            Capsule()
+              .strokeBorder(Color(nsColor: .windowBackgroundColor), lineWidth: 1)
+          )
+          .frame(width: style.size.width, height: style.size.height)
+      })
+      .buttonStyle(.plain)
+    }
+  }
+}
+
+
+
+struct AppToggle_Previews: PreviewProvider {
+  static var systemToggles: some View {
+    VStack {
+      Toggle(isOn: .constant(true), label: {
+        Text("Default on")
+      })
+      .tint(Color(.systemGreen))
+      Toggle(isOn: .constant(false), label: {
+        Text("Default off")
+      })
+    }
+  }
+
+  static var previews: some View {
+    VStack(alignment: .leading) {
+      HStack(alignment: .top, spacing: 32) {
+        VStack(alignment: .leading) {
+          Text("System")
+            .font(.headline)
+          systemToggles
+            .toggleStyle(.switch)
+        }
+
+        VStack(alignment: .leading) {
+          Text("Regular")
+            .font(.headline)
+          AppToggle("Default on",
+                    onColor: Color(.systemGreen),
+                    style: .small,
+                    isOn: .constant(true)) { _ in }
+          AppToggle("Default off",
+                    style: .small,
+                    isOn: .constant(false)) { _ in }
+        }
+
+        VStack(alignment: .leading) {
+          Text("Small")
+            .font(.headline)
+          AppToggle("Default on", style: .small, isOn: .constant(true)) { _ in }
+          AppToggle("Default off", style: .small, isOn: .constant(false)) { _ in }
+        }
+      }
+    }
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/KeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/KeyboardTriggerView.swift
@@ -35,11 +35,10 @@ struct KeyboardTriggerView: View {
       Label("Keyboard Shortcuts sequence:", image: "")
         .padding(.trailing, 12)
       Spacer()
-      Toggle("Passthrough", isOn: $passthrough)
-        .font(.caption)
-        .onChange(of: passthrough) { newValue in
-          onAction(.togglePassthrough(workflowId: data.id, newValue: newValue))
-        }
+      AppToggle("Passthrough", isOn: $passthrough) { newValue in
+        onAction(.togglePassthrough(workflowId: data.id, newValue: newValue))
+      }
+      .font(.caption)
     }
     .padding([.leading, .trailing], 8)
 

--- a/App/Sources/UI/Views/KeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/KeyboardTriggerView.swift
@@ -35,7 +35,7 @@ struct KeyboardTriggerView: View {
       Label("Keyboard Shortcuts sequence:", image: "")
         .padding(.trailing, 12)
       Spacer()
-      AppToggle("Passthrough", isOn: $passthrough) { newValue in
+      AppCheckbox("Passthrough", isOn: $passthrough) { newValue in
         onAction(.togglePassthrough(workflowId: data.id, newValue: newValue))
       }
       .font(.caption)

--- a/App/Sources/UI/Views/NewCommand/NewCommandApplicationView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandApplicationView.swift
@@ -90,13 +90,16 @@ struct NewCommandApplicationView: View {
       Divider()
 
       HStack {
-        Toggle("In background", isOn: $inBackground)
-        Toggle("Hide when opening", isOn: $hideWhenRunning)
-        Toggle("If not running", isOn: $ifNotRunning)
+        AppCheckbox("In background", isOn: $inBackground) { _ in
+         updateAndValidatePayload()
+        }
+        AppCheckbox("Hide when opening", isOn: $hideWhenRunning) { _ in
+          updateAndValidatePayload()
+         }
+        AppCheckbox("If not running", isOn: $ifNotRunning) { _ in
+          updateAndValidatePayload()
+         }
       }
-      .onChange(of: inBackground, perform: { _ in updateAndValidatePayload() })
-      .onChange(of: hideWhenRunning, perform: { _ in updateAndValidatePayload() })
-      .onChange(of: ifNotRunning, perform: { _ in updateAndValidatePayload() })
       .onChange(of: validation) { newValue in
         guard newValue == .needsValidation else { return }
         validation = updateAndValidatePayload()

--- a/App/Sources/UI/Views/WorkflowApplicationTriggerItemView.swift
+++ b/App/Sources/UI/Views/WorkflowApplicationTriggerItemView.swift
@@ -27,7 +27,7 @@ struct WorkflowApplicationTriggerItemView: View {
         Text(element.name)
         HStack {
           ForEach(DetailViewModel.ApplicationTrigger.Context.allCases) { context in
-            Toggle(context.displayValue, isOn: Binding<Bool>(get: {
+            AppCheckbox(context.displayValue, style: .small, isOn: Binding<Bool>(get: {
               element.contexts.contains(context)
             }, set: { newValue in
               if newValue {
@@ -37,8 +37,12 @@ struct WorkflowApplicationTriggerItemView: View {
               }
 
               onAction(.updateApplicationTriggerContext(element))
-            }))
-            .font(.caption)
+            })) { _ in }
+              .lineLimit(1)
+              .allowsTightening(true)
+              .truncationMode(.tail)
+              .font(.caption)
+
           }
         }
       }

--- a/App/Sources/UI/Views/WorkflowInfoView.swift
+++ b/App/Sources/UI/Views/WorkflowInfoView.swift
@@ -45,13 +45,7 @@ struct WorkflowInfoView: View {
         .onChange(of: workflowName) { debounce.send($0) }
 
       Spacer()
-      Toggle("", isOn: $isEnabled)
-        .toggleStyle(SwitchToggleStyle())
-        .tint(Color.green)
-        .font(.callout)
-        .onChange(of: isEnabled) { newValue in
-          onAction(.setIsEnabled(isEnabled: newValue))
-        }
+      AppToggle("", onColor: Color(.systemGreen), isOn: $isEnabled) { onAction(.setIsEnabled(isEnabled: $0)) }
     }
     .debugEdit()
   }

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -27,7 +27,7 @@ struct WorkflowTriggerListView: View {
   var body: some View {
     Group {
       switch data.trigger {
-      case .keyboardShortcuts(var trigger):
+      case .keyboardShortcuts(let trigger):
        KeyboardTriggerView(namespace: namespace, focus: focus, data: data, trigger: trigger,
                            keyboardShortcutSelectionManager: keyboardShortcutSelectionManager, onAction: onAction)
 

--- a/Project.swift
+++ b/Project.swift
@@ -53,7 +53,7 @@ let project = Project(
                         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                         "CODE_SIGN_IDENTITY": "Apple Development",
                         "CODE_SIGN_STYLE": "Automatic",
-                        "CURRENT_PROJECT_VERSION": "170",
+                        "CURRENT_PROJECT_VERSION": "175",
                         "DEVELOPMENT_TEAM": env["TEAM_ID"],
                         "ENABLE_HARDENED_RUNTIME": true,
                         "MARKETING_VERSION": "3.7.0",


### PR DESCRIPTION
Seems odd, but having the built-in toggles in reusable views seems
like a bit of a performance hit in SwiftUI.

So, I ended up recreating the system controls.
Introducing `AppCheckbox` and `AppToggle`.

They look like this (the system one is also there for reference):

<img width="1322" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/e0f4bf6f-b3d3-422e-a91e-186fc7f0f7d9">

<img width="1322" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/8b5ac9f5-84dd-4ec8-ada3-6f1d4d0f78cb">



- Remove linear gradient commands, it comes with a hefty performance penalty
  to render a gradient layer with blended colors
- Remove the shadow from the command views
- Add debouncing when editing application names
- Add new `AppCheckbox` & `AppToggle`
- Replace all use of `Toggle` with wither `AppCheckbox` or `AppToggle`
- Fix warnings about using `var` instead of `let`
- Refactor performance data generator in `ContentStore`
