### PR TITLE
Fix colors when running macOS in light mode

### DIFF
--- a/App/Sources/Core/AppDelegate.swift
+++ b/App/Sources/Core/AppDelegate.swift
@@ -5,6 +5,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   lazy var coordinator = NotificationCoordinator(.init())
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
+    NSApp.appearance = NSAppearance(named: .darkAqua)
     switch KeyboardCowboy.env {
     case .designTime:
       break

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -194,8 +194,6 @@ struct KeyboardCowboy: App {
             })
           }
           .focusScope(namespace)
-          // MARK: Note - Force dark mode until the light theme is up-to-date
-          .environment(\.colorScheme, .dark)
           .environmentObject(contentStore.configurationStore)
           .environmentObject(contentStore.applicationStore)
           .environmentObject(contentStore.groupStore)

--- a/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
+++ b/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
@@ -43,7 +43,7 @@ struct EditWorfklowGroupView: View {
         RuleListView(applicationStore: applicationStore,
                      group: $group)
         .padding()
-        .background(Color(.windowBackgroundColor.withAlphaComponent(0.5)))
+        .background(Color(.windowBackgroundColor))
         .focusSection()
         
         VStack(alignment: .leading, spacing: 16) {

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -74,8 +74,7 @@ struct SingleDetailView: View {
               LinearGradient(stops: [
                 .init(color: Color(nsColor: .windowBackgroundColor.blended(withFraction: 0.3, of: .white)!), location: 0.0),
                 .init(color: Color(nsColor: .windowBackgroundColor), location: 0.01),
-                .init(color: Color(nsColor: .windowBackgroundColor), location: 0.8),
-                .init(color: Color(nsColor: .windowBackgroundColor.blended(withFraction: 0.3, of: .black)!), location: 1.0),
+                .init(color: Color(nsColor: .windowBackgroundColor), location: 1.0),
               ], startPoint: .top, endPoint: .bottom)
             )
             .mask(

--- a/App/Sources/UI/Views/Windows/EditWorfklowGroupWindow.swift
+++ b/App/Sources/UI/Views/Windows/EditWorfklowGroupWindow.swift
@@ -42,8 +42,6 @@ struct EditWorkflowGroupWindow: Scene {
         KeyboardCowboy.keyWindow?.close()
         KeyboardCowboy.mainWindow?.makeKey()
       }
-      // MARK: Note - Force dark mode until the light theme is up-to-date
-      .environment(\.colorScheme, .dark)
     }
     .windowResizability(.contentMinSize)
   }

--- a/App/Sources/UI/Views/Windows/NewCommandWindow.swift
+++ b/App/Sources/UI/Views/Windows/NewCommandWindow.swift
@@ -58,8 +58,6 @@ struct NewCommandWindow: Scene {
           EmptyView()
         }
       }
-      // MARK: Note - Force dark mode until the light theme is up-to-date
-      .environment(\.colorScheme, .dark)
     }
     .windowResizability(.contentSize)
     .windowStyle(.hiddenTitleBar)


### PR DESCRIPTION
Now the app should look like this when running macOS in light mode.

<img width="962" alt="Screenshot 2023-06-27 at 19 30 37" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/ac0e4ce3-55a1-40a8-af78-3f40a63a3630">
<img width="822" alt="Screenshot 2023-06-27 at 19 30 44" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/8fe0bdc6-137d-4e4f-82b7-629797da37fc">
<img width="632" alt="Screenshot 2023-06-27 at 19 30 40" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/59766913-231b-48b4-9e19-58be0b77fe17">

