### PR TITLE
Improve the process of giving the application permissions

### DIFF
--- a/App/Sources/Core/Controllers/AppPermissions.swift
+++ b/App/Sources/Core/Controllers/AppPermissions.swift
@@ -1,0 +1,26 @@
+import Cocoa
+import Combine
+import Foundation
+
+final class AppPermissions {
+  var runningApplicationSubscription: AnyCancellable?
+  @Published var hasPermissions: Bool = false
+
+  func subscribe(to publisher: Published<RunningApplication?>.Publisher) {
+    runningApplicationSubscription = publisher.sink { [weak self] _ in
+      guard let self else { return }
+      let value = hasPrivileges(shouldPrompt: false)
+      if value {
+        runningApplicationSubscription = nil
+        hasPermissions = true
+      }
+    }
+  }
+
+  func hasPrivileges(shouldPrompt: Bool) -> Bool {
+    let trusted = kAXTrustedCheckOptionPrompt.takeUnretainedValue()
+    let privOptions = [trusted: shouldPrompt] as CFDictionary
+    let accessEnabled = AXIsProcessTrustedWithOptions(privOptions)
+    return accessEnabled
+  }
+}


### PR DESCRIPTION
On the first launch of Keyboard Cowboy, it will enter a mode that checks for permissions every time the frontmost application changes.
This process will continue until the app has obtained the necessary permissions to function correctly.
Once this occurs, the subscription will be invalidated, and a working mach port will be set up.
This eliminates the need to restart the application after obtaining permissions, resulting in a significant improvement to the user experience.
