### PR TITLE
Improve filtering workflows

### DIFF
--- a/App/Sources/UI/Views/ContentListView.swift
+++ b/App/Sources/UI/Views/ContentListView.swift
@@ -62,6 +62,18 @@ struct ContentListView: View {
                                             unfocusedOpacity: 0,
                                             color: contentSelectionManager.selectedColor))
           .focused(focus, equals: .search)
+          .onExitCommand(perform: {
+            searchTerm = ""
+          })
+          .onSubmit {
+            focus.wrappedValue = .workflows
+          }
+        if !searchTerm.isEmpty {
+          Button(action: { searchTerm = "" },
+                 label: { Text("Clear") })
+          .buttonStyle(GradientButtonStyle(.init(nsColor: .systemGray)))
+          .font(.caption2)
+        }
       }
       .padding(8)
     }
@@ -107,7 +119,7 @@ struct ContentListView: View {
             .onMoveCommand(perform: { direction in
               if let elementID = contentSelectionManager.handle(
                 direction,
-                publisher.data,
+                $publisher.data.filter(search).map(\.wrappedValue),
                 proxy: proxy,
                 vertical: true) {
                 focusPublisher.publish(elementID)


### PR DESCRIPTION
- Add clear button when the filter textfield as input
- Add .onSubmit to move the focus to the workflow list when the user
   hits enter
- Hitting escape will clear the input when the filter textfield is focused
- Fix bug with the `onMoveCommand` not using filtered results
