### PR TITLE
Fixed bug causing disabled system commands to execute

### DIFF
--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -146,7 +146,7 @@ final class MachPortCoordinator {
                                        originalEvent: machPortEvent.event,
                                        with: machPortEvent.eventSource)
       } else if workflow.commands.allSatisfy({
-        if case .systemCommand = $0 { return true } else { return false }
+        if case .systemCommand = $0 { true } else { false }
       }) {
         if machPortEvent.type == .keyDown && isRepeatingEvent {
           shouldHandleKeyUp = true
@@ -161,11 +161,12 @@ final class MachPortCoordinator {
           }
         }
 
+        let commands = workflow.commands.filter(\.isEnabled)
         switch workflow.execution {
         case .concurrent:
-          commandRunner.concurrentRun(workflow.commands)
+          commandRunner.concurrentRun(commands)
         case .serial:
-          commandRunner.serialRun(workflow.commands)
+          commandRunner.serialRun(commands)
         }
       } else if kind == .keyDown, !isRepeatingEvent {
         let commands = workflow.commands.filter(\.isEnabled)

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -146,7 +146,7 @@ final class MachPortCoordinator {
                                        originalEvent: machPortEvent.event,
                                        with: machPortEvent.eventSource)
       } else if workflow.commands.allSatisfy({
-        if case .systemCommand = $0 { true } else { false }
+        if case .systemCommand = $0 { return true } else { return false }
       }) {
         if machPortEvent.type == .keyDown && isRepeatingEvent {
           shouldHandleKeyUp = true


### PR DESCRIPTION
Fixed a critical bug that was causing disabled system commands to execute unintentionally. The fix involved modifying the command execution logic to properly check the command status before execution.
