### PR TITLE
Feature window management

### DIFF
--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -34,7 +34,6 @@ struct KeyboardCowboy: App {
 #endif
   private var open: Bool = true
 
-
   @Environment(\.openWindow) private var openWindow
   @Environment(\.scenePhase) private var scenePhase
 

--- a/App/Sources/Core/Models/Command.swift
+++ b/App/Sources/Core/Models/Command.swift
@@ -95,6 +95,8 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
         return typeCommand.meta
       case .systemCommand(let systemCommand):
         return systemCommand.meta
+      case .windowManagement(let windowCommand):
+        return windowCommand.meta
       }
     }
     set {
@@ -126,6 +128,9 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
       case .systemCommand(var systemCommand):
         systemCommand.meta = newValue
         self = .systemCommand(systemCommand)
+      case .windowManagement(var windowCommand):
+        windowCommand.meta = newValue
+        self = .windowManagement(windowCommand)
       }
     }
   }
@@ -139,6 +144,7 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
   case script(ScriptCommand)
   case type(TypeCommand)
   case systemCommand(SystemCommand)
+  case windowManagement(WindowCommand)
 
   enum CodingKeys: String, CodingKey, CaseIterable {
     case application = "applicationCommand"
@@ -150,6 +156,7 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
     case script = "scriptCommand"
     case type = "typeCommand"
     case system = "systemCommand"
+    case window = "windowCommand"
   }
 
   var isKeyboardBinding: Bool {
@@ -192,6 +199,9 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
     case .system:
       let command = try container.decode(SystemCommand.self, forKey: .system)
       self = .systemCommand(command)
+    case .window:
+      let command = try container.decode(WindowCommand.self, forKey: .window)
+      self = .windowManagement(command)
     case .none:
       throw DecodingError.dataCorrupted(
         DecodingError.Context(
@@ -223,6 +233,8 @@ enum Command: MetaDataProviding, Identifiable, Equatable, Codable, Hashable, Sen
       try container.encode(command, forKey: .type)
     case .systemCommand(let command):
       try container.encode(command, forKey: .system)
+    case .windowManagement(let command):
+      try container.encode(command, forKey: .window)
     }
   }
 
@@ -258,6 +270,8 @@ extension Command {
       return Command.type(.init(name: "", mode: .instant, input: "", notification: false))
     case .system:
       return Command.systemCommand(.init(id: UUID().uuidString, name: "", kind: .missionControl, notification: false))
+    case .window:
+      return Command.windowManagement(.init(id: UUID().uuidString, name: "", kind: .center, notification: false))
     }
   }
 

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -2,36 +2,36 @@ import Foundation
 import SwiftUI
 
 struct WindowCommand: MetaDataProviding {
-  enum Direction: String, Identifiable, Codable {
+  enum Direction: String, Identifiable, Codable, CaseIterable {
     var id: String { rawValue }
 
-    case leading
     case topLeading
     case top
     case topTrailing
+    case leading
     case trailing
-    case bottomTrailing
-    case bottom
     case bottomLeading
+    case bottom
+    case bottomTrailing
 
-    var displayValue: String {
+    func displayValue(increment: Bool) -> String {
       switch self {
       case .leading:
-        return "←"
+        return increment ? "←" : "→"
       case .topLeading:
-        return "↖"
+        return increment ? "↖" : "↘"
       case .top:
-        return "↑"
+        return increment ? "↑" : "↓"
       case .topTrailing:
-        return "↗"
+        return increment ? "↗" : "↙"
       case .trailing:
-        return "→"
+        return increment ? "→" : "←"
       case .bottomTrailing:
-        return "↘"
+        return increment ? "↘" : "↖"
       case .bottom:
-        return "↓"
+        return increment ? "↓" : "↑"
       case .bottomLeading:
-        return "↙"
+        return increment ? "↙" : "↗"
       }
     }
   }
@@ -82,10 +82,19 @@ struct WindowCommand: MetaDataProviding {
       [.center,
        .fullscreen(padding: 0),
        .move(by: 0, direction: .trailing, constrainedToScreen: false),
-       .decreaseSize(by: 0, direction: .trailing, constrainedToScreen: false),
-       .increaseSize(by: 0, direction: .trailing, constrainedToScreen: false),
+       .decreaseSize(by: 0, direction: .bottomTrailing, constrainedToScreen: false),
+       .increaseSize(by: 0, direction: .bottomTrailing, constrainedToScreen: false),
        .moveToNextDisplay(mode: .center),
        .moveToNextDisplay(mode: .relative)]
+    }
+
+    var isIncremental: Bool {
+      switch self {
+      case .decreaseSize:
+        return false
+      default:
+        return true
+      }
     }
   }
 

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -1,20 +1,109 @@
 import Foundation
+import SwiftUI
 
 struct WindowCommand: MetaDataProviding {
-  enum Kind: String, Identifiable, Codable, CaseIterable {
+  enum Direction: String, Identifiable, Codable {
     var id: String { rawValue }
+
+    case leading
+    case topLeading
+    case top
+    case topTrailing
+    case trailing
+    case bottomTrailing
+    case bottom
+    case bottomLeading
+
+    var displayValue: String {
+      switch self {
+      case .leading:
+        return "←"
+      case .topLeading:
+        return "↖"
+      case .top:
+        return "↑"
+      case .topTrailing:
+        return "↗"
+      case .trailing:
+        return "→"
+      case .bottomTrailing:
+        return "↘"
+      case .bottom:
+        return "↓"
+      case .bottomLeading:
+        return "↙"
+      }
+    }
+  }
+
+  enum Kind: Identifiable, Hashable, Codable {
+    var id: String {
+      switch self {
+      case .fullscreen:
+        return "fullscreen"
+      case .center:
+        return "center"
+      case .decreaseSize(let byValue, let direction, _):
+        return "decreaseSize:\(byValue)\(direction.rawValue)"
+      case .increaseSize(let byValue, let direction, _):
+        return "increaseSize:\(byValue)\(direction.rawValue)"
+      case .move(let toValue, let direction, _):
+        return "move:\(toValue)\(direction.rawValue)"
+      case .moveToNextDisplay(let mode):
+        return "moveToNextDisplay.\(mode.rawValue)"
+      }
+    }
+
+    case increaseSize(by: Int, direction: Direction, constrainedToScreen: Bool)
+    case decreaseSize(by: Int, direction: Direction, constrainedToScreen: Bool)
+    case move(by: Int, direction: Direction, constrainedToScreen: Bool)
+    case fullscreen(padding: Int)
     case center
-    case moveToNextDisplay
+    case moveToNextDisplay(mode: Mode)
 
     var displayValue: String {
       switch self {
       case .center:
         return "Center Window"
-      case .moveToNextDisplay:
-        return "Move to Next Display"
+      case .fullscreen:
+        return "Fullscreen"
+      case .move:
+        return "Move window"
+      case .decreaseSize:
+        return "Shrink window"
+      case .increaseSize:
+        return "Grow window"
+      case .moveToNextDisplay(let mode):
+        return "Move to Next Display - \(mode.displayValue)"
+      }
+    }
+
+    static var allCases: [Kind] {
+      [.center,
+       .fullscreen(padding: 0),
+       .move(by: 0, direction: .trailing, constrainedToScreen: false),
+       .decreaseSize(by: 0, direction: .trailing, constrainedToScreen: false),
+       .increaseSize(by: 0, direction: .trailing, constrainedToScreen: false),
+       .moveToNextDisplay(mode: .center),
+       .moveToNextDisplay(mode: .relative)]
+    }
+  }
+
+  enum Mode: String, Identifiable, Codable, Hashable, CaseIterable {
+    var id: String { rawValue }
+    case center
+    case relative
+
+    var displayValue: String {
+      switch self {
+      case .center:
+        return "Center"
+      case .relative:
+        return "Relative"
       }
     }
   }
+
   var kind: Kind
   var meta: Command.MetaData
 

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -14,6 +14,27 @@ struct WindowCommand: MetaDataProviding {
     case bottom
     case bottomTrailing
 
+    func imageSystemName(increment: Bool) -> String {
+      switch self {
+      case .leading:
+        return increment ? "arrow.left" : "arrow.right"
+      case .topLeading:
+        return increment ? "arrow.up.left" : "arrow.down.right"
+      case .top:
+        return increment ? "arrow.up" : "arrow.down"
+      case .topTrailing:
+        return increment ? "arrow.up.right" : "arrow.down.left"
+      case .trailing:
+        return increment ? "arrow.right" : "arrow.left"
+      case .bottomTrailing:
+        return increment ? "arrow.down.right" : "arrow.up.left"
+      case .bottom:
+        return increment ? "arrow.down" : "arrow.up"
+      case .bottomLeading:
+        return increment ? "arrow.down.left" : "arrow.up.right"
+      }
+    }
+
     func displayValue(increment: Bool) -> String {
       switch self {
       case .leading:

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct WindowCommand: MetaDataProviding {
+  enum Kind: String, Identifiable, Codable, CaseIterable {
+    var id: String { rawValue }
+    case center
+
+    var displayValue: String {
+      switch self {
+      case .center:
+        return "Center window"
+      }
+    }
+  }
+  var kind: Kind
+  var meta: Command.MetaData
+
+  init(id: String = UUID().uuidString, name: String, kind: Kind, notification: Bool) {
+    self.kind = kind
+    self.meta = Command.MetaData(id: id, name: name, isEnabled: true, notification: notification)
+  }
+}

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -4,11 +4,14 @@ struct WindowCommand: MetaDataProviding {
   enum Kind: String, Identifiable, Codable, CaseIterable {
     var id: String { rawValue }
     case center
+    case moveToNextDisplay
 
     var displayValue: String {
       switch self {
       case .center:
-        return "Center window"
+        return "Center Window"
+      case .moveToNextDisplay:
+        return "Move to Next Display"
       }
     }
   }

--- a/App/Sources/Core/Models/Extensions/Command+Name.swift
+++ b/App/Sources/Core/Models/Extensions/Command+Name.swift
@@ -33,6 +33,8 @@ extension Command {
         return command.name
       case .menuBar(let command):
         return command.name
+      case .windowManagement(let command):
+        return command.name
       }
     }
     set {
@@ -63,6 +65,9 @@ extension Command {
       case .menuBar(var command):
         command.name = newValue
         self = .menuBar(command)
+      case .windowManagement(var command):
+        command.name = newValue
+        self = .windowManagement(command)
       }
     }
   }

--- a/App/Sources/Core/Runners/CommandRunner.swift
+++ b/App/Sources/Core/Runners/CommandRunner.swift
@@ -17,6 +17,7 @@ final class CommandRunner: CommandRunning {
     let shortcut: ShortcutsCommandRunner
     let system: SystemCommandRunner
     let type: TypeCommandRunner
+    let window: WindowCommandRunner
   }
 
   var machPort: MachPortEventController? {
@@ -58,7 +59,8 @@ final class CommandRunner: CommandRunning {
       script: scriptCommandRunner,
       shortcut: ShortcutsCommandRunner(scriptCommandRunner),
       system: systemCommandRunner,
-      type: TypeCommandRunner(keyboardCommandRunner)
+      type: TypeCommandRunner(keyboardCommandRunner),
+      window: WindowCommandRunner()
     )
     self.workspace = workspace
   }
@@ -86,7 +88,7 @@ final class CommandRunner: CommandRunning {
           _ = try await runners.script.run(shellScript)
         }
       case .builtIn, .keyboard, .type,
-           .systemCommand, .menuBar:
+          .systemCommand, .menuBar, .windowManagement:
         break
       }
     }
@@ -181,6 +183,9 @@ final class CommandRunner: CommandRunning {
       case .systemCommand(let systemCommand):
         try await runners.system.run(systemCommand)
         output = command.name
+      case .windowManagement(let windowCommand):
+        try await runners.window.run(windowCommand)
+        output = "foo bar baz"
       }
 
       if command.notification {

--- a/App/Sources/Core/Runners/CommandRunner.swift
+++ b/App/Sources/Core/Runners/CommandRunner.swift
@@ -185,10 +185,10 @@ final class CommandRunner: CommandRunning {
         output = command.name
       case .windowManagement(let windowCommand):
         try await runners.window.run(windowCommand)
-        output = "foo bar baz"
+        output = ""
       }
 
-      if command.notification {
+      if command.notification, !output.isEmpty {
         await MainActor.run {
           lastExecutedCommand = command
           BezelNotificationController.shared.post(.init(text: output))

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -160,6 +160,12 @@ final class MachPortCoordinator {
                                        originalEvent: machPortEvent.event,
                                        with: machPortEvent.eventSource)
       } else if workflow.commands.allSatisfy({
+        if case .windowManagement = $0 { return true } else { return false }
+      }) {
+        guard machPortEvent.type == .keyDown else { return }
+        run(workflow)
+        previousPartialMatch = Self.defaultPartialMatch
+      } else if workflow.commands.allSatisfy({
         if case .systemCommand = $0 { return true } else { return false }
       }) {
         if machPortEvent.type == .keyDown && isRepeatingEvent {

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -34,7 +34,7 @@ final class WindowCommandRunner {
     guard let screen = screen else { return }
 
     let (window, windowFrame) = try getFocusedWindow()
-    let screenFrame = screen.visibleFrame
+    let screenFrame = screen.frame
     let x: Double = screenFrame.midX - (windowFrame.width / 2)
     let y: Double = (screenFrame.height / 2) - (windowFrame.height / 2)
     let origin: CGPoint = .init(x: x, y: y)

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -2,31 +2,61 @@ import AXEssibility
 import Cocoa
 import Foundation
 
+enum WindowCommandRunnerError: Error {
+  case unableToResolveFrontmostApplication
+  case unabelToResolveWindowFrame
+}
+
 final class WindowCommandRunner {
   @MainActor
   func run(_ command: WindowCommand) async throws {
     switch command.kind {
     case .center:
       try center()
+    case .moveToNextDisplay:
+      try moveToNextDisplay()
     }
   }
 
-  private func center() throws {
-    guard let screen = NSScreen.main else { return }
+  private func center(_ screen: NSScreen? = NSScreen.main) throws {
+    guard let screen = screen else { return }
 
-    guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else {
+    let (window, windowFrame) = try getFocusedWindow()
+    let screenFrame = screen.visibleFrame
+    let x: Double = screenFrame.midX - (windowFrame.width / 2)
+    let y: Double = (screenFrame.height / 2) - (windowFrame.height / 2)
+    let origin: CGPoint = .init(x: x, y: y)
+
+    print("screen.frame: \(screenFrame)")
+    print("window.frame: \(windowFrame)")
+    print("origin: \(origin)")
+
+    window.frame?.origin = origin
+  }
+
+  private func moveToNextDisplay() throws {
+    guard let mainScreen = NSScreen.main, 
+          let nextScreen = NSScreen.screens.first(where: { $0.frame.origin.x > mainScreen.frame.origin.x }) else {
       return
     }
+    let (window, frame) = try getFocusedWindow()
 
-    let app = AppAccessibilityElement(frontmostApplication.processIdentifier)
-    let window = try app.focusedWindow()
+    window.frame?.origin.x = nextScreen.frame.origin.x
+    try self.center(nextScreen)
+  }
 
-    guard let windowFrame = window.frame else { return }
+  private func getFocusedWindow() throws -> (WindowAccessibilityElement, CGRect) {
+    guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else {
+      throw WindowCommandRunnerError.unableToResolveFrontmostApplication
+    }
 
-    let screenFrame = screen.frame
-    let x = screenFrame.midX - (windowFrame.width / 2)
-    let y = screenFrame.midY - (windowFrame.height / 2)
+    let window = try AppAccessibilityElement(frontmostApplication.processIdentifier)
+      .focusedWindow()
 
-    window.frame?.origin = .init(x: x, y: y)
+    guard let windowFrame = window.frame else {
+      throw WindowCommandRunnerError.unabelToResolveWindowFrame
+    }
+
+    return (window, windowFrame)
   }
 }

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -142,6 +142,10 @@ final class WindowCommandRunner {
       windowFrame.size.height += newValue
     }
 
+    if constrainedToScreen {
+      windowFrame.origin.x = max(0, windowFrame.origin.x)
+    }
+
     window.frame = windowFrame
   }
 

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -1,0 +1,32 @@
+import AXEssibility
+import Cocoa
+import Foundation
+
+final class WindowCommandRunner {
+  @MainActor
+  func run(_ command: WindowCommand) async throws {
+    switch command.kind {
+    case .center:
+      try center()
+    }
+  }
+
+  private func center() throws {
+    guard let screen = NSScreen.main else { return }
+
+    guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else {
+      return
+    }
+
+    let app = AppAccessibilityElement(frontmostApplication.processIdentifier)
+    let window = try app.focusedWindow()
+
+    guard let windowFrame = window.frame else { return }
+
+    let screenFrame = screen.frame
+    let x = screenFrame.midX - (windowFrame.width / 2)
+    let y = screenFrame.midY - (windowFrame.height / 2)
+
+    window.frame?.origin = .init(x: x, y: y)
+  }
+}

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -151,8 +151,6 @@ final class WindowCommandRunner {
     var (window, windowFrame) = try getFocusedWindow()
     let oldValue = windowFrame
 
-    print(direction)
-
     switch direction {
     case .leading:
       windowFrame.origin.x += newValue

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -11,12 +11,22 @@ final class WindowCommandRunner {
   @MainActor
   func run(_ command: WindowCommand) async throws {
     switch command.kind {
+    case .decreaseSize(let byValue, let direction, let value):
+      try decreaseSize(byValue, in: direction, constrainedToScreen: value)
+    case .increaseSize(let byValue, let direction, let value):
+      try increaseSize(byValue, in: direction, constrainedToScreen: value)
+    case .move(let toValue, let direction, let value):
+      try move(toValue, in: direction, constrainedToScreen: value)
+    case .fullscreen(let padding):
+      try fullscreen(with: padding)
     case .center:
       try center()
-    case .moveToNextDisplay:
-      try moveToNextDisplay()
+    case .moveToNextDisplay(let mode):
+      try moveToNextDisplay(mode)
     }
   }
+
+  // MARK: Private methods
 
   private func center(_ screen: NSScreen? = NSScreen.main) throws {
     guard let screen = screen else { return }
@@ -27,22 +37,195 @@ final class WindowCommandRunner {
     let y: Double = (screenFrame.height / 2) - (windowFrame.height / 2)
     let origin: CGPoint = .init(x: x, y: y)
 
-    print("screen.frame: \(screenFrame)")
-    print("window.frame: \(windowFrame)")
-    print("origin: \(origin)")
-
     window.frame?.origin = origin
   }
 
-  private func moveToNextDisplay() throws {
-    guard let mainScreen = NSScreen.main, 
-          let nextScreen = NSScreen.screens.first(where: { $0.frame.origin.x > mainScreen.frame.origin.x }) else {
-      return
-    }
-    let (window, frame) = try getFocusedWindow()
+  private func fullscreen(with padding: Int) throws {
+    guard let screen = NSScreen.main else { return }
+    let (window, _) = try getFocusedWindow()
 
-    window.frame?.origin.x = nextScreen.frame.origin.x
-    try self.center(nextScreen)
+    let value: CGFloat
+    if padding > 1 {
+      value = CGFloat(padding / 2)
+    } else {
+      value = 0
+    }
+
+    window.frame = screen.visibleFrame.insetBy(dx: value, dy: value)
+  }
+
+  private func move(_ byValue: Int, in direction: WindowCommand.Direction, 
+                    constrainedToScreen: Bool) throws {
+    let newValue = CGFloat(byValue)
+    var (window, windowFrame) = try getFocusedWindow()
+
+    switch direction {
+    case .leading:
+      windowFrame.origin.x -= newValue
+    case .topLeading:
+      windowFrame.origin.x -= newValue
+      windowFrame.origin.y -= newValue
+    case .top:
+      windowFrame.origin.y -= newValue
+    case .topTrailing:
+      windowFrame.origin.x += newValue
+      windowFrame.origin.y -= newValue
+    case .trailing:
+      windowFrame.origin.x += newValue
+    case .bottomTrailing:
+      windowFrame.origin.x += newValue
+      windowFrame.origin.y += newValue
+    case .bottom:
+      windowFrame.origin.y += newValue
+    case .bottomLeading:
+      windowFrame.origin.y += newValue
+      windowFrame.origin.x -= newValue
+    }
+
+    if let screen = NSScreen.main, constrainedToScreen {
+      if windowFrame.maxX >= screen.frame.maxX {
+        windowFrame.origin.x = screen.frame.width - windowFrame.size.width
+      } else if windowFrame.origin.x <= 0 {
+        windowFrame.origin.x = screen.frame.origin.x
+      }
+
+      if windowFrame.maxY >= screen.visibleFrame.maxY {
+        windowFrame.origin.y = screen.visibleFrame.maxY - windowFrame.size.height
+      } else if windowFrame.origin.y >= screen.visibleFrame.maxY {
+        windowFrame.origin.y = screen.visibleFrame.maxY
+      }
+    }
+    window.frame?.origin = windowFrame.origin
+  }
+
+  private func increaseSize(_ byValue: Int, in direction: WindowCommand.Direction,
+                            constrainedToScreen: Bool) throws {
+    let newValue = CGFloat(byValue)
+    var (window, windowFrame) = try getFocusedWindow()
+
+    switch direction {
+    case .leading:
+      windowFrame.origin.x -= newValue
+      windowFrame.size.width += newValue
+    case .topLeading:
+      windowFrame.origin.x -= newValue
+      windowFrame.size.width += newValue
+      windowFrame.origin.y -= newValue
+      windowFrame.size.height += newValue
+    case .top:
+      windowFrame.origin.y -= newValue
+      windowFrame.size.height += newValue
+    case .topTrailing:
+      windowFrame.origin.y -= newValue
+      windowFrame.size.height += newValue
+      windowFrame.size.width += newValue
+    case .trailing:
+      windowFrame.size.width += newValue
+    case .bottomTrailing:
+      windowFrame.size.width += newValue
+      windowFrame.size.height += newValue
+    case .bottom:
+      windowFrame.size.height += newValue
+    case .bottomLeading:
+      windowFrame.origin.x -= newValue
+      windowFrame.size.width += newValue
+      windowFrame.size.height += newValue
+    }
+
+    window.frame = windowFrame
+  }
+
+  private func decreaseSize(_ byValue: Int, in direction: WindowCommand.Direction,
+                            constrainedToScreen: Bool) throws {
+    let newValue = CGFloat(byValue)
+    var (window, windowFrame) = try getFocusedWindow()
+    let oldValue = windowFrame
+
+    print(direction)
+
+    switch direction {
+    case .leading:
+      windowFrame.origin.x += newValue
+      windowFrame.size.width -= newValue
+      window.frame = windowFrame
+
+      if window.frame?.width != windowFrame.width {
+        window.frame?.origin.x = oldValue.origin.x
+      }
+    case .topLeading:
+      windowFrame.size.width -= newValue
+      windowFrame.size.height -= newValue
+      window.frame = windowFrame
+    case .top:
+      windowFrame.size.height -= newValue
+      window.frame = windowFrame
+    case .topTrailing:
+      windowFrame.origin.y += newValue
+      windowFrame.size.height -= newValue
+      windowFrame.size.width -= newValue
+      window.frame = windowFrame
+
+      if window.frame?.width != windowFrame.width {
+        window.frame?.origin = oldValue.origin
+      }
+    case .trailing:
+      windowFrame.size.width -= newValue
+      window.frame = windowFrame
+    case .bottomTrailing:
+      windowFrame.size.width -= newValue
+      windowFrame.size.height -= newValue
+      window.frame = windowFrame
+    case .bottom:
+      windowFrame.size.height -= newValue
+      window.frame = windowFrame
+    case .bottomLeading:
+      windowFrame.origin.x += newValue
+      windowFrame.size.width -= newValue
+      windowFrame.size.height -= newValue
+      window.frame = windowFrame
+
+      if window.frame?.width != windowFrame.width {
+        window.frame?.origin = oldValue.origin
+      }
+    }
+  }
+
+  private func moveToNextDisplay(_ mode: WindowCommand.Mode) throws {
+    guard let mainScreen = NSScreen.main else { return }
+
+    var nextScreen: NSScreen? = NSScreen.screens.first
+    var foundMain: Bool = false
+    for screen in NSScreen.screens {
+      if foundMain {
+        nextScreen = screen
+        break
+      } else if mainScreen == nextScreen {
+        foundMain = true
+      }
+    }
+
+    guard let nextScreen else { return }
+    let (window, windowFrame) = try getFocusedWindow()
+
+
+    switch mode {
+    case .center:
+      window.frame?.origin.x = nextScreen.frame.origin.x
+      try self.center(nextScreen)
+    case .relative:
+      // MARK: ⚠️ This needs fixing
+
+      let currentFrame = mainScreen.frame
+      let nextFrame = nextScreen.frame
+
+      let widthMultiplier = currentFrame.width / nextFrame.width
+      let heightMultiplier = currentFrame.height / nextFrame.height
+
+      let newX = (windowFrame.origin.x * widthMultiplier) + nextFrame.origin.x
+      let newY = (windowFrame.origin.y * heightMultiplier) + nextFrame.origin.y
+
+      window.frame?.origin = .init(x: newX, y: newY)
+    }
   }
 
   private func getFocusedWindow() throws -> (WindowAccessibilityElement, CGRect) {

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -180,13 +180,16 @@ final class WindowCommandRunner {
       windowFrame.size.width -= newValue
       window.frame = windowFrame
     case .bottomTrailing:
+      windowFrame.origin.y += newValue
       windowFrame.size.width -= newValue
       windowFrame.size.height -= newValue
       window.frame = windowFrame
     case .bottom:
+      windowFrame.origin.y += newValue
       windowFrame.size.height -= newValue
       window.frame = windowFrame
     case .bottomLeading:
+      windowFrame.origin.y += newValue
       windowFrame.origin.x += newValue
       windowFrame.size.width -= newValue
       windowFrame.size.height -= newValue

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -179,6 +179,11 @@ final class DetailCoordinator {
                                             name: "System command",
                                             kind: kind,
                                             notification: false))
+    case .windowManagement(let kind):
+      command = Command.windowManagement(.init(id: UUID().uuidString,
+                                               name: "Window management command",
+                                               kind: kind,
+                                               notification: false))
     }
 
     workflow.updateOrAddCommand(command)

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -181,7 +181,7 @@ final class DetailCoordinator {
                                             notification: false))
     case .windowManagement(let kind):
       command = Command.windowManagement(.init(id: UUID().uuidString,
-                                               name: "Window management command",
+                                               name: "Window Management Command",
                                                kind: kind,
                                                notification: false))
     }

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -278,7 +278,8 @@ extension CommandView.Kind {
         .script(_, let workflowId, _),
         .shortcut(_, let workflowId, _),
         .type(_, let workflowId, _),
-        .system(_, let workflowId, _):
+        .system(_, let workflowId, _),
+        .window(_, let workflowId, _):
       return workflowId
     }
   }
@@ -291,7 +292,8 @@ extension CommandView.Kind {
         .script(_, _, let commandId),
         .shortcut(_, _, let commandId),
         .type(_, _, let commandId),
-        .system(_, _, let commandId):
+        .system(_, _, let commandId),
+        .window(_, _, let commandId):
       return commandId
     }
   }

--- a/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
@@ -214,6 +214,19 @@ final class DetailCommandActionReducer {
             workflow.updateOrAddCommand(command)
           }
         }
+      case .window(let action, _, _):
+        switch action {
+        case .commandAction(let action):
+          DetailCommandContainerActionReducer.reduce(action, command: &command, workflow: &workflow)
+          workflow.updateOrAddCommand(command)
+        case .onUpdate(let newModel):
+          if case .windowManagement(let oldCommand) = command {
+            command = .windowManagement(.init(id: oldCommand.id,
+                                              name: oldCommand.name, kind: newModel.kind,
+                                              notification: oldCommand.notification))
+            workflow.updateOrAddCommand(command)
+          }
+        }
       }
     }
   }

--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -18,6 +18,7 @@ struct CommandView: View {
     case shortcut(action: ShortcutCommandView.Action, workflowId: DetailViewModel.ID, commandId: CommandViewModel.ID)
     case type(action: TypeCommandView.Action, workflowId: DetailViewModel.ID, commandId: CommandViewModel.ID)
     case system(action: SystemCommandView.Action, workflowId: DetailViewModel.ID, commandId: CommandViewModel.ID)
+    case window(action: WindowManagementCommandView.Action, workflowId: DetailViewModel.ID, commandId: CommandViewModel.ID)
   }
 
   @Environment(\.openWindow) var openWindow
@@ -202,7 +203,7 @@ struct CommandResolverView: View {
       WindowManagementCommandView($command.meta, model: model) { action in
         switch action {
         case .onUpdate:
-          print("⚠️ implement this")
+          onAction(.modify(.window(action: action, workflowId: workflowId, commandId: command.id)))
         case .commandAction(let commandContainerAction):
           handleCommandContainerAction(commandContainerAction)
         }

--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -198,6 +198,15 @@ struct CommandResolverView: View {
           onAction(.modify(.system(action: action, workflowId: workflowId, commandId: command.id)))
         }
       }
+    case .windowManagement(let model):
+      WindowManagementCommandView($command.meta, model: model) { action in
+        switch action {
+        case .onUpdate:
+          print("⚠️ implement this")
+        case .commandAction(let commandContainerAction):
+          handleCommandContainerAction(commandContainerAction)
+        }
+      }
     }
   }
 

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -20,46 +20,214 @@ struct WindowManagementCommandView: View {
   }
 
   var body: some View {
-    CommandContainerView($metaData, icon: { command in
+    CommandContainerView($metaData,
+                         icon: {
+      command in
       ZStack {
-        RoundedRectangle(cornerSize: .init(width: 8, height: 8))
-          .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
-          .frame(width: 32, height: 32, alignment: .center)
-          .background {
+        switch model.kind {
+        case  .increaseSize(_, let direction, _),
+            .decreaseSize(_, let direction, _),
+            .move(_, let direction, _):
+          RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+            .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
+            .frame(width: 32, height: 32, alignment: .center)
+            .background {
+              RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+                .fill(Color(.controlAccentColor).opacity(0.375))
+                .cornerRadius(8, antialiased: false)
+            }
+            .overlay(alignment: resolveAlignment(model.kind)) {
+              RoundedRectangle(cornerSize: .init(width: 4, height: 4))
+                .fill(Color.white)
+                .frame(width: 10, height: 10)
+                .overlay {
+                  Text(direction.displayValue(increment: true))
+                    .foregroundStyle(Color.black)
+                    .font(Font.system(size: 12, weight: .bold, design: .monospaced))
+                    .allowsTightening(true)
+                    .minimumScaleFactor(0.5)
+                }
+                .padding(4)
+            }
+        case .fullscreen:
+          ZStack {
             RoundedRectangle(cornerSize: .init(width: 8, height: 8))
               .fill(Color(.controlAccentColor).opacity(0.375))
               .cornerRadius(8, antialiased: false)
+              .frame(width: 32, height: 32, alignment: .center)
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
+              .frame(width: 32, height: 32, alignment: .center)
+            Image(systemName: "arrow.up.backward.and.arrow.down.forward")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 16, height: 16)
           }
-          .overlay(alignment: .center) {
-            RoundedRectangle(cornerSize: .init(width: 4, height: 4))
-              .frame(width: 10, height: 10)
+        case .center:
+          ZStack {
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .fill(Color(.controlAccentColor).opacity(0.375))
+              .cornerRadius(8, antialiased: false)
+              .frame(width: 32, height: 32, alignment: .center)
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
+              .frame(width: 32, height: 32, alignment: .center)
+            Image(systemName: "camera.metering.center.weighted")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 16, height: 16)
           }
-      }
-    }, content: { _ in
-      Menu(content: {
-        ForEach(WindowCommand.Kind.allCases) { kind in
-          Button(kind.displayValue) {
-            model.kind = kind
-            onAction(.onUpdate(model))
+        case .moveToNextDisplay:
+          ZStack {
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .fill(Color(.controlAccentColor).opacity(0.375))
+              .cornerRadius(8, antialiased: false)
+              .frame(width: 32, height: 32, alignment: .center)
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
+              .frame(width: 32, height: 32, alignment: .center)
+            Image(systemName: "display")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 16, height: 16)
+              .overlay {
+                Image(systemName: "arrow.right.circle.fill")
+                  .resizable()
+                  .aspectRatio(contentMode: .fit)
+                  .frame(width: 10, height: 10)
+                  .offset(x: 10, y: 10)
+              }
           }
         }
-      }, label: {
-        Text(model.kind.displayValue)
-      })
-      .menuStyle(GradientMenuStyle(.init(nsColor: .gray), fixedSize: false))
-    }, subContent: { _ in }) {
+      }
+    },
+                         content: { _ in
+      VStack(alignment: .leading) {
+        Menu(content: {
+          ForEach(WindowCommand.Kind.allCases) { kind in
+            Button(kind.displayValue) {
+              model.kind = kind
+              onAction(.onUpdate(model))
+            }
+          }
+        }, label: {
+          Text(model.kind.displayValue)
+        })
+        .menuStyle(GradientMenuStyle(.init(nsColor: .gray), fixedSize: false))
+        
+        switch model.kind {
+        case  .increaseSize(let value, let direction, _),
+            .decreaseSize(let value, let direction, _),
+            .move(let value, let direction, _):
+
+          HStack {
+            let models = WindowCommand.Direction.allCases
+            LazyVGrid(columns: (0..<3).map {
+              _ in GridItem(.fixed(24), spacing: 1)
+            },
+                      alignment: .center,
+                      spacing: 1,
+                      content: {
+              ForEach(Array(zip(models.indices, models)), id: \.1.id) {
+                offset,
+                element in
+                if offset == 4 {
+                  Spacer()
+                }
+                Button { } label: {
+                  Text(element.displayValue(increment: model.kind.isIncremental))
+                }
+                .buttonStyle(
+                  .gradientStyle(
+                    config: .init(nsColor: element == direction ? .systemGreen : .systemGray)
+                  )
+                )
+              }
+            })
+            .fixedSize()
+            HStack {
+              TextField("", text: .constant(String(value)))
+                .textFieldStyle(AppTextFieldStyle())
+                .frame(width: 32)
+                .fixedSize()
+              Text("pixels")
+                .font(.caption)
+            }
+            .padding(.leading, 8)
+
+          }
+        case .fullscreen(let padding):
+          HStack {
+            Text("Padding:")
+              .font(.caption)
+            TextField("", text: .constant(String(padding)))
+              .textFieldStyle(AppTextFieldStyle())
+              .frame(width: 32)
+              .fixedSize()
+          }
+          .padding(.leading, 8)
+        default:
+          EmptyView()
+        }
+        
+      }
+    },
+                         subContent: { _ in }) {
       onAction(.commandAction($0))
+    }
+  }
+
+  private func resolveAlignment(_ kind: WindowCommand.Kind) -> Alignment {
+    switch kind {
+    case .increaseSize(_, let direction, _),
+        .decreaseSize(_, let direction, _),
+        .move(_, let direction, _):
+      switch direction {
+      case .leading:
+        return .leading
+      case .topLeading:
+        return .topLeading
+      case .top:
+        return .top
+      case .topTrailing:
+        return .topTrailing
+      case .trailing:
+        return .trailing
+      case .bottomTrailing:
+        return .bottomTrailing
+      case .bottom:
+        return .bottom
+      case .bottomLeading:
+        return .bottomLeading
+      }
+    case .fullscreen:
+      return .center
+    case .center:
+      return .center
+    case .moveToNextDisplay:
+      return .center
     }
   }
 }
 
 struct WindowManagementCommandView_Previews: PreviewProvider {
-  static let command = DesignTime.windowCommand
+
+  static var models: [(model: CommandViewModel, kind: WindowCommand.Kind)] = WindowCommand.Kind.allCases
+    .map(DesignTime.windowCommand)
+
   static var previews: some View {
-    WindowManagementCommandView(
-      .constant(command.model.meta),
-      model: command.kind
-    ) { _ in }
-      .designTime()
+    VStack {
+      ForEach(models, id: \.model) { container in
+        WindowManagementCommandView(
+          .constant(container.model.meta),
+          model: .init(id: container.model.id, kind: container.kind)
+        ) { _ in }
+          .frame(maxHeight: 180)
+        Divider()
+      }
+    }
+    .padding()
+    .designTime()
+    .previewLayout(.sizeThatFits)
   }
 }

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct WindowManagementCommandView: View {
+  enum Action {
+    case onUpdate(CommandViewModel.Kind.WindowManagementModel)
+    case commandAction(CommandContainerAction)
+  }
+
+  @Binding var metaData: CommandViewModel.MetaData
+  @State var model: CommandViewModel.Kind.WindowManagementModel
+
+  private let onAction: (Action) -> Void
+
+  init(_ metaData: Binding<CommandViewModel.MetaData>,
+       model: CommandViewModel.Kind.WindowManagementModel,
+       onAction: @escaping (Action) -> Void) {
+    _metaData = metaData
+    _model = .init(initialValue: model)
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    CommandContainerView($metaData, icon: { command in
+      ZStack {
+        RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+          .stroke(Color.white.opacity(0.4), lineWidth: 2.0)
+          .frame(width: 32, height: 32, alignment: .center)
+          .background {
+            RoundedRectangle(cornerSize: .init(width: 8, height: 8))
+              .fill(Color(.controlAccentColor).opacity(0.375))
+              .cornerRadius(8, antialiased: false)
+          }
+          .overlay(alignment: .center) {
+            RoundedRectangle(cornerSize: .init(width: 4, height: 4))
+              .frame(width: 10, height: 10)
+          }
+      }
+    }, content: { _ in
+      Menu(content: {
+        ForEach(WindowCommand.Kind.allCases) { kind in
+          Button(kind.displayValue) {
+            model.kind = kind
+            onAction(.onUpdate(model))
+          }
+        }
+      }, label: {
+        Text(model.kind.displayValue)
+      })
+      .menuStyle(GradientMenuStyle(.init(nsColor: .gray), fixedSize: false))
+    }, subContent: { _ in }) {
+      onAction(.commandAction($0))
+    }
+  }
+}
+
+struct WindowManagementCommandView_Previews: PreviewProvider {
+  static let command = DesignTime.windowCommand
+  static var previews: some View {
+    WindowManagementCommandView(
+      .constant(command.model.meta),
+      model: command.kind
+    ) { _ in }
+      .designTime()
+  }
+}

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -72,7 +72,7 @@ struct WindowManagementCommandView: View {
             }
             .matchedGeometryEffect(id: "geometry-container-id", in: namespace)
             .compositingGroup()
-            .animation(.smooth, value: model.kind)
+            .animation(.easeInOut, value: model.kind)
         case .fullscreen:
           ZStack {
             RoundedRectangle(cornerSize: .init(width: 8, height: 8))

--- a/App/Sources/UI/Views/ContentImageView.swift
+++ b/App/Sources/UI/Views/ContentImageView.swift
@@ -75,7 +75,7 @@ struct ContentImageView: View {
         RegularKeyIcon(letter: "(...)", width: 25, height: 25)
           .fixedSize()
           .frame(width: 24, height: 24)
-      case .plain, .systemCommand:
+      case .plain, .systemCommand, .windowManagement:
         EmptyView()
       }
     }

--- a/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
+++ b/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
@@ -195,6 +195,11 @@ enum DesignTime {
     return (.init(meta: metadata(name: "Typing...", icon: nil), kind: .type(kind)), kind)
   }
 
+  static var windowCommand: (model: CommandViewModel, kind: CommandViewModel.Kind.WindowManagementModel) {
+    let kind = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: .center)
+    return (.init(meta: metadata(name: "Window Management", icon: nil), kind: .windowManagement(kind)), kind)
+  }
+
   static var emptyDetail: DetailViewModel {
     DetailViewModel(id: UUID().uuidString, name: "", isEnabled: false, commands: [], execution: .concurrent)
   }

--- a/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
+++ b/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
@@ -195,9 +195,9 @@ enum DesignTime {
     return (.init(meta: metadata(name: "Typing...", icon: nil), kind: .type(kind)), kind)
   }
 
-  static var windowCommand: (model: CommandViewModel, kind: CommandViewModel.Kind.WindowManagementModel) {
-    let kind = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: .center)
-    return (.init(meta: metadata(name: "Window Management", icon: nil), kind: .windowManagement(kind)), kind)
+  static func windowCommand(_ kind: WindowCommand.Kind) -> (model: CommandViewModel, kind: WindowCommand.Kind) {
+    let model = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: kind)
+    return (.init(meta: metadata(name: "Window Management", icon: nil), kind: .windowManagement(model)), kind)
   }
 
   static var emptyDetail: DetailViewModel {

--- a/App/Sources/UI/Views/GroupItemView.swift
+++ b/App/Sources/UI/Views/GroupItemView.swift
@@ -27,6 +27,7 @@ struct GroupItemView: View {
         .frame(width: 24)
       Text(group.wrappedValue.name)
         .font(.body)
+        .lineLimit(1)
       Spacer()
       Menu(content: { contextualMenu(for: group.wrappedValue, onAction: onAction) }) {
         Image(systemName: "ellipsis.circle")

--- a/App/Sources/UI/Views/Groups/RuleListView.swift
+++ b/App/Sources/UI/Views/Groups/RuleListView.swift
@@ -28,7 +28,7 @@ struct RuleListView: View {
             }
           }
         }
-        .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: false)))
+        .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: false), fixedSize: false))
       }
       if let rule = group.rule {
         ForEach(rule.bundleIdentifiers, id: \.self) { bundleIdentifier in

--- a/App/Sources/UI/Views/Groups/SymbolPalette.swift
+++ b/App/Sources/UI/Views/Groups/SymbolPalette.swift
@@ -25,6 +25,7 @@ struct SymbolPalette: View {
     "star",
     "tag",
     "bolt",
+    "macwindow"
   ]
 
   var items: [GridItem] {

--- a/App/Sources/UI/Views/IconView.swift
+++ b/App/Sources/UI/Views/IconView.swift
@@ -13,9 +13,7 @@ final class IconPublisher: ObservableObject {
         let image = try await IconCache.shared.icon(at: path, bundleIdentifier: bundleIdentifier, size: size)
         try Task.checkCancellation()
         cgImage = image
-      } catch {
-        Swift.print(error)
-      }
+      } catch { }
     }
   }
 

--- a/App/Sources/UI/Views/IntegerTextField.swift
+++ b/App/Sources/UI/Views/IntegerTextField.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct IntegerTextField: View {
+  @Binding var text: String
+
+  private let onValidChange: (String) -> Void
+
+  init(text: Binding<String>, onValidChange: @escaping (String) -> Void) {
+    _text = text
+    self.onValidChange = onValidChange
+  }
+
+  var body: some View {
+    TextField("", text: Binding<String>(get: {
+      text
+    }, set: { newValue in
+      if newValue.contains(where: { !$0.isNumber }) {
+        return
+      }
+      text = newValue
+      onValidChange(newValue)
+    }))
+  }
+}
+

--- a/App/Sources/UI/Views/KeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/KeyboardTriggerView.swift
@@ -71,26 +71,3 @@ struct KeyboardTriggerView: View {
   }
 }
 
-fileprivate struct IntegerTextField: View {
-  @Binding var text: String
-
-  private let onValidChange: (String) -> Void
-
-  init(text: Binding<String>, onValidChange: @escaping (String) -> Void) {
-    _text = text
-    self.onValidChange = onValidChange
-  }
-
-  var body: some View {
-    TextField("", text: Binding<String>(get: {
-      text
-    }, set: { newValue in
-      if newValue.contains(where: { !$0.isNumber }) {
-        return
-      }
-      text = newValue
-      onValidChange(newValue)
-    }))
-  }
-}
-

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -198,6 +198,14 @@ private extension Array where Element == Command {
             offset: convertedOffset,
             kind: .icon(.init(bundleIdentifier: path, path: path)))
         )
+      case .windowManagement(let command):
+        let path: String = "/System/Applications/Mission Control.app/Contents/Resources/AppIcon.icns"
+        images.append(
+          ContentViewModel.ImageModel(
+            id: command.id,
+            offset: convertedOffset,
+            kind: .icon(.init(bundleIdentifier: path, path: path)))
+        )
       }
     }
 

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -99,6 +99,8 @@ private extension Command {
       kind = .type(.init(id: type.id, mode: type.mode, input: type.input))
     case .systemCommand(let systemCommand):
       kind = .systemCommand(.init(id: systemCommand.id, kind: systemCommand.kind))
+    case .windowManagement(let windowCommand):
+      kind = .windowManagement(.init(id: windowCommand.id, kind: windowCommand.kind))
     }
 
     return kind
@@ -157,6 +159,9 @@ private extension Command {
         path = "/System/Library/CoreServices/Dock.app/Contents/Resources/Dock.icns"
       }
 
+      return .init(bundleIdentifier: path, path: path)
+    case .windowManagement:
+      let path = "/System/Applications/Mission Control.app/Contents/Resources/AppIcon.icns"
       return .init(bundleIdentifier: path, path: path)
     }
   }

--- a/App/Sources/UI/Views/Models/CommandViewModel.swift
+++ b/App/Sources/UI/Views/Models/CommandViewModel.swift
@@ -17,28 +17,7 @@ struct CommandViewModel: Codable, Hashable, Identifiable {
   var kind: Kind
 
   enum Kind: Codable, Hashable, Identifiable, Sendable {
-    var id: String {
-      switch self {
-      case .application(let applicationModel):
-        return applicationModel.id
-      case .open(let openModel):
-        return openModel.id
-      case .keyboard(let keyboardModel):
-        return keyboardModel.id
-      case .script(let scriptModel):
-        return scriptModel.id
-      case .plain:
-        return UUID().uuidString
-      case .shortcut(let shortcutModel):
-        return shortcutModel.id
-      case .type(let typeModel):
-        return typeModel.id
-      case .systemCommand(let systemModel):
-        return systemModel.id
-      case .menuBar(let menuBarModel):
-        return menuBarModel.id
-      }
-    }
+    var id: String { (self as (any Identifiable<String>)).id }
 
     case application(ApplicationModel)
     case open(OpenModel)
@@ -49,6 +28,7 @@ struct CommandViewModel: Codable, Hashable, Identifiable {
     case type(TypeModel)
     case systemCommand(SystemModel)
     case menuBar(MenuBarModel)
+    case windowManagement(WindowManagementModel)
 
     struct ApplicationModel: Codable, Hashable, Identifiable, Sendable {
       let id: String
@@ -96,6 +76,11 @@ struct CommandViewModel: Codable, Hashable, Identifiable {
       let id: String
       var mode: TypeCommand.Mode
       var input: String
+    }
+
+    struct WindowManagementModel: Codable, Hashable, Identifiable, Sendable {
+      let id: String
+      var kind: WindowCommand.Kind
     }
   }
 }

--- a/App/Sources/UI/Views/Models/NewCommandPayload.swift
+++ b/App/Sources/UI/Views/Models/NewCommandPayload.swift
@@ -13,6 +13,7 @@ enum NewCommandPayload: Equatable {
   case type(text: String, mode: TypeCommand.Mode)
   case systemCommand(kind: SystemCommand.Kind)
   case menuBar(tokens: [MenuBarCommand.Token])
+  case windowManagement(kind: WindowCommand.Kind)
 
   var title: String {
     switch self {
@@ -75,6 +76,8 @@ enum NewCommandPayload: Equatable {
       return "System command"
     case .menuBar:
       return "MenuBar command"
+    case .windowManagement:
+      return "Window management command"
     }
   }
 }

--- a/App/Sources/UI/Views/Models/NewCommandPayload.swift
+++ b/App/Sources/UI/Views/Models/NewCommandPayload.swift
@@ -73,11 +73,11 @@ enum NewCommandPayload: Equatable {
     case .type:
       return "Input text"
     case .systemCommand:
-      return "System command"
+      return "System Command"
     case .menuBar:
-      return "MenuBar command"
+      return "MenuBar Command"
     case .windowManagement:
-      return "Window management command"
+      return "Window Management Command"
     }
   }
 }

--- a/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
@@ -34,6 +34,9 @@ struct NewCommandImageView: View {
         image(for: "/System")
       case .menuBar:
         image(for: "/System/Library/PreferencePanes/Appearance.prefPane")
+      case .windowManagement:
+        Rectangle()
+          .fill(Color.red)
       }
     }
     .frame(width: 24, height: 24)

--- a/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
@@ -35,8 +35,7 @@ struct NewCommandImageView: View {
       case .menuBar:
         image(for: "/System/Library/PreferencePanes/Appearance.prefPane")
       case .windowManagement:
-        Rectangle()
-          .fill(Color.red)
+        image(for: "/System/Applications/Mission Control.app")
       }
     }
     .frame(width: 24, height: 24)

--- a/App/Sources/UI/Views/NewCommand/NewCommandView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandView.swift
@@ -5,7 +5,13 @@ struct NewCommandView: View {
   enum Kind: String, CaseIterable, Hashable, Identifiable {
     var id: String { self.rawValue }
     var rawKey: String {
-      String(Self.allCases.firstIndex(of: self)! + 1)
+      let value = Self.allCases.firstIndex(of: self)! + 1
+
+      if value == 10 {
+        return "0"
+      }
+
+      return String(value)
     }
     var key: KeyEquivalent {
       return KeyEquivalent(rawKey.first!)
@@ -20,6 +26,7 @@ struct NewCommandView: View {
     case script = "Script"
     case type = "Type"
     case system = "System Command"
+    case windowManagement = "Window Management"
   }
 
   private let workflowId: Workflow.ID
@@ -66,7 +73,7 @@ struct NewCommandView: View {
                   .fill(Color.white.opacity(0.2))
                   .frame(width: 1)
               })
-            .frame(maxWidth: 225)
+            .frame(maxWidth: 235)
           detail(title: $title)
         }
       } else {
@@ -78,7 +85,7 @@ struct NewCommandView: View {
           })
       }
     }
-    .frame(minWidth: 710, minHeight: 400)
+    .frame(minWidth: 710, minHeight: 410)
   }
 
   private func sidebar() -> some View {
@@ -231,6 +238,8 @@ struct NewCommandView: View {
       NewCommandSystemCommandView($payload, validation: $validation)
     case .menuBar:
       NewCommandMenuBarView($payload, validation: $validation)
+    case .windowManagement:
+      NewCommandWindowManagementView($payload, validation: $validation)
     }
   }
 

--- a/App/Sources/UI/Views/NewCommand/NewCommandWindowManagementView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandWindowManagementView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct NewCommandWindowManagementView: View {
+  @Binding var payload: NewCommandPayload
+  @Binding var validation: NewCommandValidation
+  @State var selection: WindowCommand.Kind = .center
+
+  init(_ payload: Binding<NewCommandPayload>, validation: Binding<NewCommandValidation>) {
+    _payload = payload
+    _validation = validation
+  }
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Label(title: { Text("Window Management") }, icon: { EmptyView() })
+        .labelStyle(HeaderLabelStyle())
+
+      Menu {
+        ForEach(WindowCommand.Kind.allCases) { kind in
+          Button(action: {
+            self.selection = kind
+            validation = updateAndValidatePayload()
+          }, label: {
+            Text(kind.displayValue)
+          })
+        }
+      } label: {
+        Text(selection.displayValue)
+      }
+      .menuStyle(GradientMenuStyle(.init(nsColor: .gray), fixedSize: false))
+    }
+    .onChange(of: validation) { newValue in
+      guard newValue == .needsValidation else { return }
+      validation = updateAndValidatePayload()
+    }
+    .onAppear {
+      validation = .valid
+      payload = .windowManagement(kind: self.selection)
+    }
+  }
+
+  @discardableResult
+  private func updateAndValidatePayload() -> NewCommandValidation {
+    payload = .windowManagement(kind: self.selection)
+    return .valid
+  }
+}
+
+struct NewCommandWindowManagementView_Previews: PreviewProvider {
+  static var previews: some View {
+    NewCommandView(
+      workflowId: UUID().uuidString,
+      commandId: nil,
+      title: "New command",
+      selection: .windowManagement,
+      payload: .placeholder,
+      onDismiss: {},
+      onSave: { _, _ in })
+    .designTime()
+  }
+}

--- a/App/Sources/UI/Views/Windows/NewCommandWindow.swift
+++ b/App/Sources/UI/Views/Windows/NewCommandWindow.swift
@@ -148,6 +148,8 @@ struct NewCommandWindow: Scene {
       return .type(text: typeCommand.input, mode: typeCommand.mode)
     case .systemCommand(let systemCommand):
       return .systemCommand(kind: systemCommand.kind)
+    case .windowManagement(let windowCommand):
+      return .windowManagement(kind: windowCommand.kind)
     }
   }
 
@@ -172,6 +174,8 @@ struct NewCommandWindow: Scene {
       return .type
     case .systemCommand:
       return .system
+    case .windowManagement:
+      return .windowManagement
     }
   }
 


### PR DESCRIPTION
This PR adds support for window management commands.

<img width="1146" alt="image" src="https://github.com/zenangst/KeyboardCowboy/assets/57446/816477ff-0be9-4d06-9ef6-6e3dbfee6f92">


The kinds of operations that are supported are:
- Centering the frontmost window
- Toggling between "real" fullscreen and the windows previous frame
- Growing a window in any direction
- Shrinking a window in any direction 
- Moving a window in any direction
- Supports key repeat so that you can hold down keys to apply multiple
  transformations
- Last but not least, it supports moving the frontmost window to the next
  display, with support for cycling


### Commits
- Add foundation for window management
- Continue window management implementation
- Continue implementing window management
- Continue implement the UI for editing window management commands
- Fix visual bug in RuleListView
- Limit the line numbers in the group item view
- Add support for fullscreen rect toggling
- Various improvements to the window management
- Fix origin bug when reducing size
- Add support for key repeat when running window commands
- Add support for setting padding when using fullscreen
- Add macwindow to symbol palette
- Fix constraint to screen bug when increasing size
- Use frame rather than visibleFrame when centering
- Don't show notifications when output is empty
- Fix icon for window management commands
