### PR TITLE
Improve Window Management

### DIFF
--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -64,7 +64,7 @@ final class WindowCommandRunner {
     }
   }
 
-  private func move(_ byValue: Int, in direction: WindowCommand.Direction, 
+  private func move(_ byValue: Int, in direction: WindowCommand.Direction,
                     constrainedToScreen: Bool) throws {
     let newValue = CGFloat(byValue)
     var (window, windowFrame) = try getFocusedWindow()
@@ -230,18 +230,26 @@ final class WindowCommandRunner {
       window.frame?.origin.x = nextScreen.frame.origin.x
       try self.center(nextScreen)
     case .relative:
-      // MARK: ⚠️ This needs fixing
-
       let currentFrame = mainScreen.frame
       let nextFrame = nextScreen.frame
+      var windowFrame = windowFrame
 
-      let widthMultiplier = currentFrame.width / nextFrame.width
-      let heightMultiplier = currentFrame.height / nextFrame.height
+      // Make window frame relative to the next frame
+      windowFrame.origin.x -= currentFrame.origin.x
+      windowFrame.origin.y -= currentFrame.origin.y
 
-      let newX = (windowFrame.origin.x * widthMultiplier) + nextFrame.origin.x
-      let newY = (windowFrame.origin.y * heightMultiplier) + nextFrame.origin.y
+      let screenMultiplier = CGSize(
+        width: nextFrame.width / currentFrame.width,
+        height: nextFrame.height / currentFrame.height
+      )
 
-      window.frame?.origin = .init(x: newX, y: newY)
+      let width = windowFrame.size.width * screenMultiplier.width
+      let height = windowFrame.size.height * screenMultiplier.height
+      let x = nextFrame.origin.x + (windowFrame.origin.x * screenMultiplier.width)
+      let y = nextFrame.origin.y  + (windowFrame.origin.y * screenMultiplier.height)
+      let newFrame: CGRect = .init(x: x, y: y, width: width, height: height)
+
+      window.frame = newFrame
     }
   }
 

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -98,6 +98,8 @@ final class WindowCommandRunner {
         windowFrame.origin.x = screen.frame.maxX - windowFrame.size.width
       } else if windowFrame.origin.x <= 0 {
         windowFrame.origin.x = screen.frame.origin.x
+      } else if windowFrame.origin.x < screen.frame.origin.x {
+        windowFrame.origin.x = screen.frame.origin.x
       }
 
       if windowFrame.maxY >= screen.visibleFrame.maxY {

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -68,6 +68,7 @@ final class WindowCommandRunner {
                     constrainedToScreen: Bool) throws {
     let newValue = CGFloat(byValue)
     var (window, windowFrame) = try getFocusedWindow()
+    let oldWindowFrame = windowFrame
 
     switch direction {
     case .leading:
@@ -92,9 +93,9 @@ final class WindowCommandRunner {
       windowFrame.origin.x -= newValue
     }
 
-    if let screen = NSScreen.main, constrainedToScreen {
+    if let screen = NSScreen.screens.first(where: { $0.frame.contains(oldWindowFrame) }), constrainedToScreen {
       if windowFrame.maxX >= screen.frame.maxX {
-        windowFrame.origin.x = screen.frame.width - windowFrame.size.width
+        windowFrame.origin.x = screen.frame.maxX - windowFrame.size.width
       } else if windowFrame.origin.x <= 0 {
         windowFrame.origin.x = screen.frame.origin.x
       }
@@ -105,6 +106,7 @@ final class WindowCommandRunner {
         windowFrame.origin.y = screen.visibleFrame.maxY
       }
     }
+
     window.frame?.origin = windowFrame.origin
   }
 


### PR DESCRIPTION
This pull request improves the newly introduced window management commands. It fixes the issue with moving windows between displays using the relative setting, ensuring that the origin and size of the window are kept intact.

Moving windows with the constraint to screen setting on now works more reliably. It will be constrained to the current screen that the window belongs to. Second screens were not handled properly before, but that should be a thing of the past.

### Commits

- Fix constrainedToScreen not working on second screen
- Refactor moving windows to next screen with relative configuration
- Properly constrain the move command to the current screen
