### PR TITLE
Fix fullscreen window management

### DIFF
--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -185,7 +185,7 @@ final class WindowCommandRunner {
       windowFrame.size.height -= newValue
       window.frame = windowFrame
     case .topTrailing:
-      windowFrame.origin.y += newValue
+      windowFrame.origin.x += newValue
       windowFrame.size.height -= newValue
       windowFrame.size.width -= newValue
       window.frame = windowFrame
@@ -197,6 +197,7 @@ final class WindowCommandRunner {
       windowFrame.size.width -= newValue
       window.frame = windowFrame
     case .bottomTrailing:
+      windowFrame.origin.x += newValue
       windowFrame.origin.y += newValue
       windowFrame.size.width -= newValue
       windowFrame.size.height -= newValue
@@ -207,7 +208,6 @@ final class WindowCommandRunner {
       window.frame = windowFrame
     case .bottomLeading:
       windowFrame.origin.y += newValue
-      windowFrame.origin.x += newValue
       windowFrame.size.width -= newValue
       windowFrame.size.height -= newValue
       window.frame = windowFrame

--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -53,12 +53,18 @@ final class WindowCommandRunner {
       value = 0
     }
 
-    let newValue = screen.visibleFrame.insetBy(dx: value, dy: value)
+    var newValue = screen.visibleFrame.insetBy(dx: value, dy: value)
 
     if window.frame?.size.width == newValue.size.width,
        let cachedFrame = fullscreenCache[window.id] {
       window.frame = cachedFrame
     } else {
+      let statusBarHeight = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        .button?
+        .window?
+        .frame
+        .height ?? 0
+      newValue.origin.y -= statusBarHeight
       window.frame = newValue
       fullscreenCache[window.id] = windowFrame
     }


### PR DESCRIPTION
Check the size of the status bar and take that into account when making windows fullscreen. This removes the potential gap that can occur when making windows fullscreen on external displays.

Fixes #342
