### PR TITLE
Fix application trigger dropdown menu

### DIFF
--- a/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
@@ -59,7 +59,7 @@ struct WorkflowApplicationTriggerView: View {
                 vertical: 8
               ),
               grayscaleEffect: false
-            )
+            ),  fixedSize: false
           )
         )
       }


### PR DESCRIPTION
Configure the view to use a flexible size, allowing it to expand and fill the available space.
