### PR TITLE
Fix reordering commands on Sonoma

### DIFF
--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -70,7 +70,7 @@ struct CommandView: View {
         for item in items {
           switch item {
           case .text(let item):
-            if let url = URL(string: item) {
+            if !item.hasPrefix("WC|"), let url = URL(string: item) {
               urls.append(url)
               continue
             }


### PR DESCRIPTION
Add prefix check to avoid creating a URL from the item payload.
