### PR TITLE
Refactor content images into seperate views

### DIFF
--- a/App/Sources/UI/Views/ContentIconImageView.swift
+++ b/App/Sources/UI/Views/ContentIconImageView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ContentIconImageView: View {
+  let icon: IconViewModel
+  let size: CGFloat
+
+  var body: some View {
+    IconView(icon: icon, size: .init(width: size, height: size))
+      .fixedSize()
+      .id(icon)
+  }
+}
+
+struct ContentIconImageView_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      ContentIconImageView(
+        icon: .init(
+          bundleIdentifier: "com.apple.finder",
+          path: "/System/Library/CoreServices/Finder.app"
+        ),
+        size: 32
+      )
+    }
+    .frame(minWidth: 200, minHeight: 120)
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/ContentImageView.swift
+++ b/App/Sources/UI/Views/ContentImageView.swift
@@ -4,77 +4,26 @@ struct ContentImageView: View {
   let image: ContentViewModel.ImageModel
   let size: CGFloat
 
+  @ViewBuilder
   var body: some View {
     switch image.kind {
     case .icon(let icon):
-      Group {
-        IconView(icon: icon, size: .init(width: size, height: size))
-          .fixedSize()
-          .id(icon)
-      }
+      ContentIconImageView(icon: icon, size: size)
     case .command(let kind):
       switch kind {
-      case .menuBar:
+      case .menuBar, .application, .open:
         EmptyView()
       case .keyboard(let model):
-        ZStack {
-          ForEach(model.keys) { key in
-            RegularKeyIcon(letter: key.key)
-              .fixedSize()
-              .scaleEffect(0.8)
-
-            ForEach(key.modifiers) { modifier in
-              HStack {
-                ModifierKeyIcon(key: modifier)
-                  .scaleEffect(0.4, anchor: .bottomLeading)
-                  .opacity(0.8)
-              }
-              .padding(4)
-            }
-          }
-        }
-        .rotationEffect(.degrees(-(3.75 * image.offset)))
-        .offset(.init(width: -(image.offset * 1.25),
-                      height: image.offset * 1.25))
-      case .application:
-       EmptyView()
-      case .open:
-        EmptyView()
+        ContentKeyboardImageView(keys: model.keys)
+          .rotationEffect(.degrees(-(3.75 * image.offset)))
+          .offset(.init(width: -(image.offset * 1.25),
+                        height: image.offset * 1.25))
       case .script(let model):
-        switch model.source {
-        case .inline:
-          ZStack {
-            Rectangle()
-              .fill(LinearGradient(stops: [
-                .init(color: Color.accentColor.opacity(0.2), location: 0.0),
-                .init(color: .black, location: 0.2),
-                .init(color: .black, location: 1.0),
-              ], startPoint: .top, endPoint: .bottom))
-              .cornerRadius(8)
-              .scaleEffect(0.9)
-            RoundedRectangle(cornerRadius: 8)
-              .stroke(.black)
-              .scaleEffect(0.9)
-
-            Text(">_")
-              .font(Font.system(.caption, design: .monospaced))
-          }
-          .frame(width: size, height: size)
-        case .path:
-          Image(nsImage: NSWorkspace.shared.icon(forFile: "/System/Applications/Utilities/Script Editor.app"))
-            .resizable()
-            .aspectRatio(1, contentMode: .fill)
-            .frame(width: 32)
-        }
+        ContentScriptImageView(source: model.source, size: size)
       case .shortcut:
-        Image(nsImage: NSWorkspace.shared.icon(forFile: "/System/Applications/Shortcuts.app"))
-          .resizable()
-          .aspectRatio(1, contentMode: .fill)
-          .frame(width: 32)
+        ContentShortcutImageView(size: size)
       case .type:
-        RegularKeyIcon(letter: "(...)", width: 25, height: 25)
-          .fixedSize()
-          .frame(width: 24, height: 24)
+        ContentTypeImageView()
       case .plain, .systemCommand, .windowManagement:
         EmptyView()
       }

--- a/App/Sources/UI/Views/ContentKeyboardImageView.swift
+++ b/App/Sources/UI/Views/ContentKeyboardImageView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ContentKeyboardImageView: View {
+  let keys: [KeyShortcut]
+  var body: some View {
+    ZStack {
+      ForEach(keys) { key in
+        RegularKeyIcon(letter: key.key)
+          .fixedSize()
+          .scaleEffect(0.8)
+
+        ForEach(key.modifiers) { modifier in
+          HStack {
+            ModifierKeyIcon(key: modifier)
+              .scaleEffect(0.4, anchor: .bottomLeading)
+              .opacity(0.8)
+              .fixedSize()
+          }
+          .padding(4)
+        }
+      }
+    }
+  }
+}
+
+struct ContentKeyboardImageView_Previews: PreviewProvider {
+  static var previews: some View {
+    ContentKeyboardImageView(keys: [
+      .init(key: "", modifiers: [.command]),
+      .init(key: "C", modifiers: []),
+    ])
+    .frame(minWidth: 200, minHeight: 120)
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/ContentScriptImageView.swift
+++ b/App/Sources/UI/Views/ContentScriptImageView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ContentScriptImageView: View {
+  let source: ScriptCommand.Source
+  let size: CGFloat
+
+  @ViewBuilder
+  var body: some View {
+    switch source {
+    case .inline:
+      ZStack {
+        Rectangle()
+          .fill(LinearGradient(stops: [
+            .init(color: Color.accentColor.opacity(0.2), location: 0.0),
+            .init(color: .black, location: 0.2),
+            .init(color: .black, location: 1.0),
+          ], startPoint: .top, endPoint: .bottom))
+          .cornerRadius(8)
+          .scaleEffect(0.9)
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(.black)
+          .scaleEffect(0.9)
+
+        Text(">_")
+          .font(Font.system(.caption, design: .monospaced))
+      }
+      .frame(width: size, height: size)
+    case .path:
+      IconView(
+        icon: .init(
+          bundleIdentifier: "/System/Applications/Utilities/Script Editor.app",
+          path: "/System/Applications/Utilities/Script Editor.app"
+        ),
+        size: .init(width: size, height: size)
+      )
+        .aspectRatio(1, contentMode: .fill)
+        .frame(width: 32)
+    }
+  }
+}
+
+struct ContentScriptImageView_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      ContentScriptImageView(source: .inline("Hello world!"), size: 32)
+      ContentScriptImageView(source: .path("~/"), size: 32)
+    }
+    .frame(minWidth: 200, minHeight: 120)
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/ContentShortcutImageView.swift
+++ b/App/Sources/UI/Views/ContentShortcutImageView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ContentShortcutImageView: View {
+  let size: CGFloat
+
+  var body: some View {
+    IconView(
+      icon: .init(bundleIdentifier: "/System/Applications/Shortcuts.app", 
+                  path: "/System/Applications/Shortcuts.app"),
+      size: CGSize(width: size, height: size)
+    )
+      .aspectRatio(1, contentMode: .fill)
+      .frame(width: size)
+  }
+}
+
+struct ContentShortcutImageView_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      ContentShortcutImageView(size: 32)
+    }
+    .frame(minWidth: 200, minHeight: 120)
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/ContentTypeImageView.swift
+++ b/App/Sources/UI/Views/ContentTypeImageView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct ContentTypeImageView: View {
+    var body: some View {
+      RegularKeyIcon(letter: "(...)", width: 25, height: 25)
+        .fixedSize()
+        .frame(width: 24, height: 24)
+    }
+}
+
+struct ContentTypeImageView_Previews: PreviewProvider {
+    static var previews: some View {
+      Group {
+        ContentTypeImageView()
+      }
+      .frame(minWidth: 200, minHeight: 120)
+      .padding()
+    }
+}


### PR DESCRIPTION
- Improve performance for shortcut & script by using `IconView` internally, which handles images loading off the main thread.
- Reduces the clutter inside `ContentImageView`
