### PR TITLE
Refactor the sidebar configuration components

### DIFF
--- a/App/Sources/UI/Views/SidebarConfigurationView.swift
+++ b/App/Sources/UI/Views/SidebarConfigurationView.swift
@@ -39,14 +39,9 @@ struct SidebarConfigurationView: View {
             .allowsTightening(true)
             .contentShape(Rectangle())
         }
-        .menuStyle(IconMenuStyle())
+        .menuStyle(GradientMenuStyle(.init(nsColor: .systemGray, grayscaleEffect: true),
+                                     fixedSize: false))
       }
-      .padding(.vertical, 4)
-      .padding(.horizontal, 6)
-      .background(
-        RoundedRectangle(cornerRadius: 4)
-          .stroke(Color(.disabledControlTextColor))
-      )
 
       Menu(content: {
         Button("New Configuration", action: {
@@ -67,63 +62,26 @@ struct SidebarConfigurationView: View {
           .resizable()
       })
       .menuStyle(GradientMenuStyle(.init(nsColor: .systemGreen, grayscaleEffect: true)))
-      .popover(isPresented: $deleteConfigurationPopover, arrowEdge: .bottom, content: {
-        VStack {
-          Text("Are you sure you want to delete '\(configurationName)'")
-          HStack {
-            Button("Abort", action: {
-              deleteConfigurationPopover = false
-            })
-            .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGray, hoverEffect: false)))
-            .keyboardShortcut(.cancelAction)
-            Button("Confirm", action: {
-              onAction(.deleteConfiguration(id: selectionManager.selections.first ?? ""))
-              deleteConfigurationPopover = false
-            })
-            .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
-          }
-        }
-        .padding()
+      .popover(isPresented: $deleteConfigurationPopover,
+               arrowEdge: .bottom,
+               content: {
+        SidebarDeleteConfigurationPopoverView($deleteConfigurationPopover,
+                                              id: selectionManager.selections.first ?? "",
+                                              configurationName: publisher.data.first(where: { $0.selected })?.name ?? "",
+                                              selectionManager: selectionManager,
+                                              onAction: { onAction(.deleteConfiguration(id: $0)) })
       })
-      .popover(isPresented: $updateConfigurationNamePopover, arrowEdge: .bottom, content: {
-        HStack {
-          Text("Configuration name:")
-          TextField("", text: $configurationName)
-            .frame(width: 170)
-            .onSubmit {
-              onAction(.updateName(name: configurationName))
-              updateConfigurationNamePopover = false
-              configurationName = ""
-            }
-          Button("Save", action: {
-            onAction(.updateName(name: configurationName))
-            updateConfigurationNamePopover = false
-            configurationName = ""
-          })
-          .keyboardShortcut(.defaultAction)
-          .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
-        }
-        .padding()
+      .popover(isPresented: $updateConfigurationNamePopover,
+               arrowEdge: .bottom,
+               content: {
+        SidebarUpdateConfigurationNamePopoverView($updateConfigurationNamePopover, configurationName: $configurationName, onAction: {
+          onAction(.updateName(name: $0))
+        })
       })
       .popover(isPresented: $newConfigurationPopover, arrowEdge: .bottom) {
-        HStack {
-          Text("Configuration name:")
-          TextField("", text: $configurationName)
-            .frame(width: 170)
-            .onSubmit {
-              onAction(.addConfiguration(name: configurationName))
-              newConfigurationPopover = false
-              configurationName = ""
-            }
-          Button("Save", action: {
-            onAction(.addConfiguration(name: configurationName))
-            newConfigurationPopover = false
-            configurationName = ""
-          })
-          .keyboardShortcut(.defaultAction)
-          .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
-        }
-        .padding()
+        SidebarNewConfigurationPopoverView($newConfigurationPopover, configurationName: "", onAction: {
+          onAction(.addConfiguration(name: $0))
+        })
       }
     }
     .debugEdit()

--- a/App/Sources/UI/Views/SidebarDeleteConfigurationPopoverView.swift
+++ b/App/Sources/UI/Views/SidebarDeleteConfigurationPopoverView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct SidebarDeleteConfigurationPopoverView: View {
+  @Binding private var deleteConfigurationPopover: Bool
+  private let id: ConfigurationViewModel.ID
+  private let configurationName: String
+  private let selectionManager: SelectionManager<ConfigurationViewModel>
+  private let onAction: (ConfigurationViewModel.ID) -> Void
+
+  init(_ deleteConfigurationPopover: Binding<Bool>,
+       id: ConfigurationViewModel.ID,
+       configurationName: String,
+       selectionManager: SelectionManager<ConfigurationViewModel>,
+       onAction: @escaping (ConfigurationViewModel.ID) -> Void) {
+    _deleteConfigurationPopover = deleteConfigurationPopover
+    self.id = id
+    self.configurationName = configurationName
+    self.selectionManager = selectionManager
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    VStack {
+      Text("Are you sure you want to delete '") +
+      Text(configurationName).bold() +
+      Text("'?")
+      HStack {
+        Spacer()
+        Button("Abort", action: {
+          deleteConfigurationPopover = false
+        })
+        .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGray, hoverEffect: false)))
+        .keyboardShortcut(.cancelAction)
+        Button("Confirm", action: {
+          onAction(id)
+          deleteConfigurationPopover = false
+        })
+        .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
+      }
+    }
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/SidebarNewConfigurationPopoverView.swift
+++ b/App/Sources/UI/Views/SidebarNewConfigurationPopoverView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct SidebarNewConfigurationPopoverView: View {
+  @Binding private var newConfigurationPopover: Bool
+  @State private var configurationName: String
+  private let onAction: (String) -> Void
+
+  init(_ newConfigurationPopover: Binding<Bool>,
+       configurationName: String,
+       onAction: @escaping (String) -> Void) {
+    _configurationName = .init(initialValue: configurationName)
+    _newConfigurationPopover = newConfigurationPopover
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    HStack {
+      Text("Configuration name:")
+      TextField("", text: $configurationName)
+        .frame(width: 170)
+        .onSubmit {
+          onAction(configurationName)
+          newConfigurationPopover = false
+          configurationName = ""
+        }
+      Button("Save", action: {
+        onAction(configurationName)
+        newConfigurationPopover = false
+        configurationName = ""
+      })
+      .keyboardShortcut(.defaultAction)
+      .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
+    }
+    .padding()
+  }
+}

--- a/App/Sources/UI/Views/SidebarUpdateConfigurationNamePopoverView.swift
+++ b/App/Sources/UI/Views/SidebarUpdateConfigurationNamePopoverView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct SidebarUpdateConfigurationNamePopoverView: View {
+  @Binding private var updateConfigurationNamePopover: Bool
+  @Binding private var configurationName: String
+  private let onAction: (String) -> Void
+
+  init(_ updateConfigurationNamePopover: Binding<Bool>,
+       configurationName: Binding<String>,
+       onAction: @escaping (String) -> Void) {
+    _configurationName = configurationName
+    _updateConfigurationNamePopover = updateConfigurationNamePopover
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    HStack {
+      Text("Configuration name:")
+      TextField("", text: $configurationName)
+        .frame(width: 170)
+        .onSubmit {
+          onAction(configurationName)
+          updateConfigurationNamePopover = false
+          configurationName = ""
+        }
+      Button("Save", action: {
+        onAction(configurationName)
+        updateConfigurationNamePopover = false
+        configurationName = ""
+      })
+      .keyboardShortcut(.defaultAction)
+      .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, hoverEffect: false)))
+    }
+    .padding()
+
+  }
+}
+


### PR DESCRIPTION
- Split all sidebar configuration components into separate files.
- Use application menu style for the configuration menu in the sidebar

 #Lines starting
