### PR TITLE
SwiftUI related improvements

### DIFF
--- a/App/Sources/UI/Coordinators/SidebarCoordinator.swift
+++ b/App/Sources/UI/Coordinators/SidebarCoordinator.swift
@@ -161,7 +161,7 @@ final class SidebarCoordinator {
 
     publisher.publish(groups)
 
-    if let newSelections {
+    if let newSelections, selectionManager.selections != newSelections {
       selectionManager.selections = newSelections
     }
   }

--- a/App/Sources/UI/Stores/IconCache.swift
+++ b/App/Sources/UI/Stores/IconCache.swift
@@ -14,6 +14,17 @@ actor IconCache {
 
   private init() {}
 
+  public func iconFromCache(at path: String, bundleIdentifier: String, size: CGSize) -> Data? {
+    let identifier: String = "\(bundleIdentifier)_\(size.suffix).tiff"
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: " ", with: "-")
+
+    if let inMemoryImage = cache.object(forKey: identifier as NSString) {
+      return inMemoryImage as Data
+    }
+    return nil
+  }
+
   public func icon(at path: String, bundleIdentifier: String, size: CGSize) -> Data? {
     let identifier: String = "\(bundleIdentifier)_\(size.suffix).tiff"
       .replacingOccurrences(of: "/", with: "_")

--- a/App/Sources/UI/Styles/SidebarLabelStyle.swift
+++ b/App/Sources/UI/Styles/SidebarLabelStyle.swift
@@ -10,3 +10,15 @@ struct SidebarLabelStyle: LabelStyle {
       .frame(height: 12)
     }
 }
+
+extension Text {
+  @ViewBuilder
+  func sidebarLabel() -> some View {
+    self
+      .font(.subheadline.bold())
+      .allowsTightening(true)
+      .lineLimit(1)
+      .foregroundColor(Color.secondary)
+      .frame(height: 12)
+  }
+}

--- a/App/Sources/UI/Views/Commands/CommandContainerView.swift
+++ b/App/Sources/UI/Views/Commands/CommandContainerView.swift
@@ -99,6 +99,8 @@ struct CommandContainerActionView: View {
           .frame(width: 1)
           .opacity(0.5)
       }
+      .drawingGroup()
+
       VStack(alignment: .center, spacing: 0) {
         Button(action: { onAction(.delete) },
                label: {
@@ -118,6 +120,7 @@ struct CommandContainerActionView: View {
             .frame(height: 1)
             .opacity(0.5)
         }
+        .drawingGroup()
 
         Button(action: { onAction(.run) },
                label: {

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -228,7 +228,7 @@ struct WindowManagementCommandView: View {
             }
 
           }
-        case .fullscreen(var padding):
+        case .fullscreen:
           HStack {
             Text("Padding:")
               .font(.caption)

--- a/App/Sources/UI/Views/ContainerView.swift
+++ b/App/Sources/UI/Views/ContainerView.swift
@@ -26,7 +26,6 @@ struct ContainerView: View {
 
   @Namespace var namespace
   @Environment(\.undoManager) var undoManager
-  @Environment(\.openWindow) private var openWindow
   @ObservedObject var navigationPublisher = NavigationPublisher()
 
   private let onAction: (Action, UndoManager?) -> Void

--- a/App/Sources/UI/Views/ContentAddWorkflowHeaderView.swift
+++ b/App/Sources/UI/Views/ContentAddWorkflowHeaderView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentAddWorkflowHeaderView: View {
+  @EnvironmentObject private var contentPublisher: ContentPublisher
+
+  private let namespace: Namespace.ID
+  private let onAction: () -> Void
+
+  init(_ namespace: Namespace.ID,
+       onAction: @escaping () -> Void) {
+    self.namespace = namespace
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    if !contentPublisher.data.isEmpty {
+      Button(action: onAction) {
+        Image(systemName: "plus.square.dashed")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(height: 12)
+          .padding(2)
+      }
+      .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, grayscaleEffect: true)))
+      .padding(.trailing, 8)
+      .matchedGeometryEffect(id: "add-workflow-button", in: namespace)
+    }
+  }
+}

--- a/App/Sources/UI/Views/ContentHeaderView.swift
+++ b/App/Sources/UI/Views/ContentHeaderView.swift
@@ -17,52 +17,41 @@ struct ContentHeaderView: View {
   }
 
   var body: some View {
-      if let groupId = groupSelectionManager.selections.first,
-         let group = groupsPublisher.data.first(where: { $0.id == groupId }) {
-        Label("Group", image: "")
-          .labelStyle(SidebarLabelStyle())
-          .padding(.leading, 8)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.top, 6)
-        HStack(spacing: 8) {
-          GroupIconView(color: group.color, icon: group.icon, symbol: group.symbol)
-            .frame(width: 24, height: 24)
-            .padding(4)
-            .background(
-              RoundedRectangle(cornerRadius: 8)
-                .fill(Color(nsColor: .init(hex: group.color)).opacity(0.4))
-            )
-          VStack(alignment: .leading) {
-            Text(group.name)
-              .font(.headline)
-            Text("Workflows: \(contentPublisher.data.count)")
-              .font(.caption)
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-
-          if !contentPublisher.data.isEmpty {
-            Button(action: {
-              onAction(.addWorkflow(workflowId: UUID().uuidString))
-            }) {
-              Image(systemName: "plus.square.dashed")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 12)
-                .padding(2)
-            }
-            .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, grayscaleEffect: true)))
-            .padding(.trailing, 8)
-            .matchedGeometryEffect(id: "add-workflow-button", in: namespace)
-          }
-        }
-        .padding(.bottom, 4)
-        .padding(.leading, 14)
-        .id(group)
-      }
-
-      Label("Workflows", image: "")
-        .labelStyle(SidebarLabelStyle())
+    if let groupId = groupSelectionManager.selections.first,
+       let group = groupsPublisher.data.first(where: { $0.id == groupId }) {
+      Text("Group")
+        .sidebarLabel()
         .padding(.leading, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 6)
+      HStack(spacing: 8) {
+        GroupIconView(color: group.color, icon: group.icon, symbol: group.symbol)
+          .frame(width: 24, height: 24)
+          .padding(4)
+          .background(
+            RoundedRectangle(cornerRadius: 8)
+              .fill(Color(nsColor: .init(hex: group.color)).opacity(0.4))
+          )
+        VStack(alignment: .leading) {
+          Text(group.name)
+            .font(.headline)
+          Text("Workflows: \(contentPublisher.data.count)")
+            .font(.caption)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        ContentAddWorkflowHeaderView(namespace, onAction: {
+          onAction(.addWorkflow(workflowId: UUID().uuidString))
+        })
+      }
+      .padding(.bottom, 4)
+      .padding(.leading, 14)
+      .id(group)
+    }
+
+    Text("Workflows")
+      .sidebarLabel()
+      .padding(.leading, 8)
+      .frame(maxWidth: .infinity, alignment: .leading)
   }
 }

--- a/App/Sources/UI/Views/ContentImagesView.swift
+++ b/App/Sources/UI/Views/ContentImagesView.swift
@@ -27,11 +27,11 @@ struct ContentImagesView: View {
     } else {
       ZStack {
         if images.count == 1 {
-          ForEach(images) { image in
+          ForEach(images.lazy) { image in
             ContentImageView(image: image, size: size - 2)
           }
-        } else {
-          ForEach(images) { image in
+        } else if images.count > 1 {
+          ForEach(images.lazy) { image in
             ContentImageView(image: image, size: size - 2)
               .rotationEffect(.degrees(-(isHovered ? -20 * image.offset : 3.75 * image.offset)))
               .offset(.init(width: -(image.offset * (isHovered ? -8 : 1.25)),

--- a/App/Sources/UI/Views/ContentListView.swift
+++ b/App/Sources/UI/Views/ContentListView.swift
@@ -26,8 +26,8 @@ struct ContentListView: View {
   @EnvironmentObject private var groupsPublisher: GroupsPublisher
   @EnvironmentObject private var publisher: ContentPublisher
 
-  @ObservedObject private var contentSelectionManager: SelectionManager<ContentViewModel>
-  @ObservedObject private var groupSelectionManager: SelectionManager<GroupViewModel>
+  private let contentSelectionManager: SelectionManager<ContentViewModel>
+  private let groupSelectionManager: SelectionManager<GroupViewModel>
 
   @State var searchTerm: String = ""
 
@@ -38,8 +38,8 @@ struct ContentListView: View {
        groupSelectionManager: SelectionManager<GroupViewModel>,
        focusPublisher: FocusPublisher<ContentViewModel>,
        onAction: @escaping (Action) -> Void) {
-    _contentSelectionManager = .init(initialValue: contentSelectionManager)
-    _groupSelectionManager = .init(initialValue: groupSelectionManager)
+    self.contentSelectionManager = contentSelectionManager
+    self.groupSelectionManager = groupSelectionManager
     self.focusPublisher = focusPublisher
     self.focus = focus
     self.onAction = onAction
@@ -73,7 +73,7 @@ struct ContentListView: View {
       ScrollViewReader { proxy in
         ScrollView {
           LazyVStack(spacing: 0) {
-            ForEach(publisher.data.filter(search), id: \.id) { element in
+            ForEach(publisher.data.filter(search).lazy, id: \.id) { element in
               ContentItemView(element, focusPublisher: focusPublisher, publisher: publisher,
                               contentSelectionManager: contentSelectionManager, onAction: onAction)
               .onTapGesture {

--- a/App/Sources/UI/Views/Focus/FocusView.swift
+++ b/App/Sources/UI/Views/Focus/FocusView.swift
@@ -80,8 +80,8 @@ private struct FocusOverlayView<Element>: View where Element: Hashable, Element:
         .strokeBorder(manager.selectedColor.opacity(0.5), lineWidth: 1.5)
         .padding(1.5)
     }
-      .allowsHitTesting(false)
-      .opacity(focusOpacity())
+    .allowsHitTesting(false)
+    .opacity(focusOpacity())
   }
 
   private func focusOpacity() -> Double {

--- a/App/Sources/UI/Views/Managers/DebounceSelectionManager.swift
+++ b/App/Sources/UI/Views/Managers/DebounceSelectionManager.swift
@@ -13,6 +13,7 @@ final class DebounceSelectionManager<Snapshot: DebounceSnapshot> {
     self._snapshot = .init(initialValue: initialValue)
     self.onUpdate = onUpdate
     self.subscription = subject
+      .dropFirst()
       .debounce(for: .milliseconds(milliseconds), scheduler: DispatchQueue.main)
       .sink { onUpdate($0) }
   }

--- a/App/Sources/UI/Views/Managers/SelectionManager.swift
+++ b/App/Sources/UI/Views/Managers/SelectionManager.swift
@@ -39,7 +39,9 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
 
   @MainActor
   func publish(_ newSelections: Set<T.ID>) {
-    self.selections <- newSelections
+    if self.selections != newSelections {
+      self.selections = newSelections
+    }
     store(self.selections)
   }
 
@@ -69,14 +71,18 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
 
   func handleOnTap(_ data: [T], element: T) {
     let copyOfSelections = selections
+    var newSelections: Set<T.ID> = []
     if NSEvent.modifierFlags.contains(.shift) {
-      selections = onShiftTap(data, elementID: element.id, selections: copyOfSelections)
+      newSelections = onShiftTap(data, elementID: element.id, selections: copyOfSelections)
     } else if NSEvent.modifierFlags.contains(.command) {
-      selections = onCommandTap(element, selections: copyOfSelections)
+      newSelections = onCommandTap(element, selections: copyOfSelections)
     } else {
-      selections = onTap(element)
+      newSelections = onTap(element)
     }
-    store(selections)
+    store(newSelections)
+    if newSelections != selections {
+      selections = newSelections
+    }
   }
 
   // MARK: Private methods
@@ -118,7 +124,9 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
   }
 
   private func onTap(_ element: T) -> Set<T.ID> {
-    lastSelection = element.id
+    if lastSelection != element.id {
+      lastSelection = element.id
+    }
     return [element.id]
   }
 
@@ -129,7 +137,9 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
     } else {
       newSelections.insert(element.id)
     }
-    lastSelection = element.id
+    if lastSelection != element.id {
+      lastSelection = element.id
+    }
     return newSelections
   }
 
@@ -165,7 +175,9 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
       }
     }
 
-    self.lastSelection = elementID
+    if lastSelection != elementID {
+      self.lastSelection = elementID
+    }
 
     return newSelections
   }

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -68,7 +68,10 @@ struct SingleDetailView: View {
         }
         .padding([.top, .leading, .trailing])
         .padding(.bottom, 32)
-        .background(alignment: .bottom, content: { SingleDetailBackgroundView() })
+        .background(alignment: .bottom, content: { 
+          SingleDetailBackgroundView()
+            .drawingGroup()
+        })
 
       WorkflowCommandListHeaderView(namespace: namespace, onAction: onAction)
       WorkflowCommandListView(

--- a/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
@@ -32,7 +32,7 @@ struct WorkflowApplicationTriggerView: View {
     VStack(alignment: .leading) {
       HStack {
         Menu {
-          ForEach(applicationStore.applications) { application in
+          ForEach(applicationStore.applications.lazy, id: \.id) { application in
             Button(action: {
               let uuid = UUID()
               withAnimation(WorkflowCommandListView.animation) {
@@ -62,7 +62,7 @@ struct WorkflowApplicationTriggerView: View {
       }
 
       LazyVStack(spacing: 4) {
-        ForEach($data) { element in
+        ForEach($data.lazy, id: \.id) { element in
           WorkflowApplicationTriggerItemView(element, data: $data,
                                              focusPublisher: focusPublisher,
                                              selectionManager: selectionManager,

--- a/App/Sources/UI/Views/WorkflowCommandEmptyListView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandEmptyListView.swift
@@ -2,67 +2,71 @@ import SwiftUI
 
 struct WorkflowCommandEmptyListView: View {
   @Environment(\.openWindow) var openWindow
-  @ObservedObject private var detailPublisher: DetailPublisher
+  @EnvironmentObject private var detailPublisher: DetailPublisher
 
   var namespace: Namespace.ID
   private var onAction: (SingleDetailView.Action) -> Void
 
-  init(namespace: Namespace.ID, detailPublisher: DetailPublisher, onAction: @escaping (SingleDetailView.Action) -> Void) {
+  init(namespace: Namespace.ID, onAction: @escaping (SingleDetailView.Action) -> Void) {
     self.namespace = namespace
-    self.detailPublisher = detailPublisher
     self.onAction = onAction
   }
 
   var body: some View {
-    VStack {
-      Button(action: {
-        openWindow(value: NewCommandWindow.Context.newCommand(workflowId: detailPublisher.data.id))
-      }) {
-        HStack {
-          Image(systemName: "plus.app")
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 16, height: 16)
-          Divider()
-            .opacity(0.5)
-
-          Text("Add a command")
-          Text("bla bla bla")
-        }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 8)
-      }
-      .buttonStyle(AppButtonStyle(.init(nsColor: .systemGreen, hoverEffect: false)))
-      .matchedGeometryEffect(id: "add-command-button", in: namespace, properties: .position)
-    }
-    .dropDestination(for: DropItem.self) { items, location in
-      var urls = [URL]()
-      for item in items {
-        switch item {
-        case .text(let text):
-          if let url = URL(string: text) {
-            urls.append(url)
+    if detailPublisher.data.commands.isEmpty {
+      VStack {
+        Button(action: {
+          openWindow(value: NewCommandWindow.Context.newCommand(workflowId: detailPublisher.data.id))
+        }) {
+          HStack {
+            Image(systemName: "plus.app")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 16, height: 16)
+            Divider()
+              .opacity(0.5)
+            
+            Text("Add a command")
           }
-        case .url(let url):
-          urls.append(url)
-        case .none:
-          continue
+          .padding(.vertical, 4)
+          .padding(.horizontal, 8)
         }
+        .buttonStyle(AppButtonStyle(.init(nsColor: .systemGreen, hoverEffect: false)))
+        .fixedSize()
+        .matchedGeometryEffect(id: "add-command-button", in: namespace, properties: .position)
+        Spacer()
       }
-
-      if !urls.isEmpty {
-        onAction(.dropUrls(workflowId: detailPublisher.data.id, urls: urls))
-        return true
+      .dropDestination(for: DropItem.self) { items, location in
+        var urls = [URL]()
+        for item in items {
+          switch item {
+          case .text(let text):
+            if let url = URL(string: text) {
+              urls.append(url)
+            }
+          case .url(let url):
+            urls.append(url)
+          case .none:
+            continue
+          }
+        }
+        
+        if !urls.isEmpty {
+          onAction(.dropUrls(workflowId: detailPublisher.data.id, urls: urls))
+          return true
+        }
+        return false
       }
-      return false
+      .frame(maxWidth: .infinity)
+      .matchedGeometryEffect(id: "command-list", in: namespace)
     }
-    .frame(maxWidth: .infinity)
   }
 }
 
 struct WorkflowCommandEmptyListView_Previews: PreviewProvider {
   @Namespace static var namespace
   static var previews: some View {
-    WorkflowCommandEmptyListView(namespace: namespace, detailPublisher: DesignTime.detailPublisher) { _ in }
+    WorkflowCommandEmptyListView(namespace: namespace) { _ in }
+      .designTime()
   }
 }

--- a/App/Sources/UI/Views/WorkflowCommandListHeaderAddView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListHeaderAddView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct WorkflowCommandListHeaderAddView: View {
+  @EnvironmentObject var detailPublisher: DetailPublisher
+  @Environment(\.openWindow) var openWindow
+  private let namespace: Namespace.ID
+
+  init(_ namespace: Namespace.ID) {
+    self.namespace = namespace
+  }
+
+  var body: some View {
+    if !detailPublisher.data.commands.isEmpty {
+      Button(action: {
+        openWindow(value: NewCommandWindow.Context.newCommand(workflowId: detailPublisher.data.id))
+      }) {
+        HStack(spacing: 4) {
+          Image(systemName: "plus.app")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: 12, maxHeight: 12)
+            .padding(2)
+            .layoutPriority(-1)
+        }
+      }
+      .padding(.horizontal, 4)
+      .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, grayscaleEffect: true)))
+      .matchedGeometryEffect(id: "add-command-button", in: namespace, properties: .position)
+    }
+
+  }
+}

--- a/App/Sources/UI/Views/WorkflowCommandListHeaderView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListHeaderView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct WorkflowCommandListHeaderView: View {
   @EnvironmentObject var detailPublisher: DetailPublisher
   @Environment(\.openWindow) var openWindow
-  let namespace: Namespace.ID
+  private let namespace: Namespace.ID
 
   init(namespace: Namespace.ID, onAction: @escaping (SingleDetailView.Action) -> Void) {
     self.namespace = namespace
@@ -39,29 +39,15 @@ struct WorkflowCommandListHeaderView: View {
           .padding(.horizontal, 18)
           .padding(.vertical, 4)
           .offset(x: -4, y: 1)
+          .drawingGroup()
       })
       .menuStyle(AppMenuStyle(.init(nsColor: .systemGray), menuIndicator: .visible))
       .frame(maxWidth: detailPublisher.data.execution == .concurrent ? 144 : 110,
              alignment: .leading)
       .opacity(detailPublisher.data.commands.isEmpty ? 0 : 1)
 
-      if !detailPublisher.data.commands.isEmpty {
-        Button(action: {
-          openWindow(value: NewCommandWindow.Context.newCommand(workflowId: detailPublisher.data.id))
-        }) {
-          HStack(spacing: 4) {
-            Image(systemName: "plus.app")
-              .resizable()
-              .aspectRatio(contentMode: .fit)
-              .frame(maxWidth: 12, maxHeight: 12)
-              .padding(2)
-              .layoutPriority(-1)
-          }
-        }
-        .padding(.horizontal, 4)
-        .buttonStyle(.gradientStyle(config: .init(nsColor: .systemGreen, grayscaleEffect: true)))
-        .matchedGeometryEffect(id: "add-command-button", in: namespace, properties: .position)
-      }
+      WorkflowCommandListHeaderAddView(namespace)
+
     }
     .padding(.horizontal)
   }

--- a/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct WorkflowCommandListScrollView: View {
+  @ObserveInjection var inject
+  @Environment(\.openWindow) var openWindow
+  var namespace: Namespace.ID
+  @EnvironmentObject var applicationStore: ApplicationStore
+  private let detailPublisher: DetailPublisher
+  @ObservedObject private var selectionManager: SelectionManager<CommandViewModel>
+  @State private var dropOverlayIsVisible: Bool = false
+  @State private var dropUrls = Set<URL>()
+  private var focusPublisher = FocusPublisher<CommandViewModel>()
+  private let scrollViewProxy: ScrollViewProxy?
+  private let onAction: (SingleDetailView.Action) -> Void
+  private let focus: FocusState<AppFocus?>.Binding
+
+  @FocusState var isFocused: Bool
+
+  init(_ focus: FocusState<AppFocus?>.Binding,
+       detailPublisher: DetailPublisher,
+       namespace: Namespace.ID,
+       selectionManager: SelectionManager<CommandViewModel>,
+       scrollViewProxy: ScrollViewProxy? = nil,
+       onAction: @escaping (SingleDetailView.Action) -> Void) {
+    self.detailPublisher = detailPublisher
+    self.focus = focus
+    self.namespace = namespace
+    self.selectionManager = selectionManager
+    self.scrollViewProxy = scrollViewProxy
+    self.onAction = onAction
+  }
+
+  var body: some View {
+    if !detailPublisher.data.commands.isEmpty {
+      ScrollView {
+        LazyVStack(spacing: 0) {
+          ForEach(detailPublisher.data.commands.lazy, id: \.id) { command in
+            CommandView(Binding.readonly(command),
+                        detailPublisher: detailPublisher,
+                        focusPublisher: focusPublisher,
+                        selectionManager: selectionManager,
+                        workflowId: detailPublisher.data.id,
+                        onCommandAction: onAction, onAction: { action in
+              onAction(.commandView(workflowId: detailPublisher.data.id, action: action))
+            })
+            .contextMenu(menuItems: {
+              WorkflowCommandListContextMenuView(
+                command,
+                detailPublisher: detailPublisher,
+                selectionManager: selectionManager,
+                onAction: onAction
+              )
+            })
+            .onTapGesture {
+              selectionManager.handleOnTap(detailPublisher.data.commands, element: command)
+              focusPublisher.publish(command.id)
+            }
+          }
+          .focused($isFocused)
+          .onChange(of: isFocused, perform: { newValue in
+            guard newValue else { return }
+
+            guard let lastSelection = selectionManager.lastSelection else { return }
+
+            withAnimation {
+              scrollViewProxy?.scrollTo(lastSelection)
+            }
+          })
+          .padding(.vertical, 5)
+          .onCommand(#selector(NSResponder.insertBacktab(_:)), perform: {
+            switch detailPublisher.data.trigger {
+            case .applications:
+              focus.wrappedValue = .detail(.applicationTriggers)
+            case .keyboardShortcuts:
+              focus.wrappedValue = .detail(.keyboardShortcuts)
+            case .none:
+              focus.wrappedValue = .detail(.name)
+            }
+          })
+          .onCommand(#selector(NSResponder.insertTab(_:)), perform: {
+            focus.wrappedValue = .groups
+          })
+          .onCommand(#selector(NSResponder.selectAll(_:)), perform: {
+            selectionManager.selections = Set(detailPublisher.data.commands.map(\.id))
+          })
+          .onMoveCommand(perform: { direction in
+            if let elementID = selectionManager.handle(direction, detailPublisher.data.commands,
+                                                       proxy: scrollViewProxy) {
+              focusPublisher.publish(elementID)
+            }
+          })
+          .onDeleteCommand {
+            if selectionManager.selections.count == detailPublisher.data.commands.count {
+              withAnimation {
+                onAction(.removeCommands(workflowId: detailPublisher.data.id, commandIds: selectionManager.selections))
+              }
+            } else {
+              onAction(.removeCommands(workflowId: detailPublisher.data.id, commandIds: selectionManager.selections))
+            }
+          }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .focused(focus, equals: .detail(.commands))
+        .matchedGeometryEffect(id: "command-list", in: namespace)
+      }
+    }
+  }
+}

--- a/App/Sources/UI/Views/WorkflowCommandListView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListView.swift
@@ -4,17 +4,11 @@ import UniformTypeIdentifiers
 struct WorkflowCommandListView: View {
   static let animation: Animation = .spring(response: 0.3, dampingFraction: 0.65, blendDuration: 0.2)
 
-  @FocusState var isFocused: Bool
-
-  @ObserveInjection var inject
   @Environment(\.openWindow) var openWindow
   var namespace: Namespace.ID
-  @EnvironmentObject var applicationStore: ApplicationStore
-  @ObservedObject private var detailPublisher: DetailPublisher
   @ObservedObject private var selectionManager: SelectionManager<CommandViewModel>
-  @State private var dropOverlayIsVisible: Bool = false
-  @State private var dropUrls = Set<URL>()
   private var focusPublisher = FocusPublisher<CommandViewModel>()
+  private let detailPublisher: DetailPublisher
   private let scrollViewProxy: ScrollViewProxy?
   private let onAction: (SingleDetailView.Action) -> Void
   private let focus: FocusState<AppFocus?>.Binding
@@ -26,8 +20,8 @@ struct WorkflowCommandListView: View {
        scrollViewProxy: ScrollViewProxy? = nil,
        onAction: @escaping (SingleDetailView.Action) -> Void) {
     self.focus = focus
+    self.detailPublisher = publisher
     self.namespace = namespace
-    _detailPublisher = .init(initialValue: publisher)
     self.selectionManager = selectionManager
     self.scrollViewProxy = scrollViewProxy
     self.onAction = onAction
@@ -35,85 +29,13 @@ struct WorkflowCommandListView: View {
 
   @ViewBuilder
   var body: some View {
-    if detailPublisher.data.commands.isEmpty {
-      WorkflowCommandEmptyListView(namespace: namespace,
-                                   detailPublisher: detailPublisher, onAction: onAction)
-      .matchedGeometryEffect(id: "command-list", in: namespace)
-    } else {
-      ScrollView {
-        LazyVStack(spacing: 0) {
-          ForEach($detailPublisher.data.commands, id: \.id) { element in
-            let command = element
-            CommandView(command,
-                        detailPublisher: detailPublisher,
-                        focusPublisher: focusPublisher,
-                        selectionManager: selectionManager,
-                        workflowId: detailPublisher.data.id,
-                        onCommandAction: onAction, onAction: { action in
-              onAction(.commandView(workflowId: detailPublisher.data.id, action: action))
-            })
-            .contextMenu(menuItems: {
-              WorkflowCommandListContextMenuView(
-                command.wrappedValue,
-                detailPublisher: detailPublisher,
-                selectionManager: selectionManager,
-                onAction: onAction
-              )
-            })
-            .onTapGesture {
-              selectionManager.handleOnTap(detailPublisher.data.commands, element: element.wrappedValue)
-              focusPublisher.publish(element.id)
-            }
-          }
-          .focused($isFocused)
-          .onChange(of: isFocused, perform: { newValue in
-            guard newValue else { return }
-
-            guard let lastSelection = selectionManager.lastSelection else { return }
-
-            withAnimation {
-              scrollViewProxy?.scrollTo(lastSelection)
-            }
-          })
-          .padding(.vertical, 5)
-          .onCommand(#selector(NSResponder.insertBacktab(_:)), perform: {
-            switch detailPublisher.data.trigger {
-            case .applications:
-              focus.wrappedValue = .detail(.applicationTriggers)
-            case .keyboardShortcuts:
-              focus.wrappedValue = .detail(.keyboardShortcuts)
-            case .none:
-              focus.wrappedValue = .detail(.name)
-            }
-          })
-          .onCommand(#selector(NSResponder.insertTab(_:)), perform: {
-            focus.wrappedValue = .groups
-          })
-          .onCommand(#selector(NSResponder.selectAll(_:)), perform: {
-            selectionManager.selections = Set(detailPublisher.data.commands.map(\.id))
-          })
-          .onMoveCommand(perform: { direction in
-            if let elementID = selectionManager.handle(direction, detailPublisher.data.commands,
-                                                       proxy: scrollViewProxy) {
-              focusPublisher.publish(elementID)
-            }
-          })
-          .onDeleteCommand {
-            if selectionManager.selections.count == detailPublisher.data.commands.count {
-              withAnimation {
-                onAction(.removeCommands(workflowId: detailPublisher.data.id, commandIds: selectionManager.selections))
-              }
-            } else {
-              onAction(.removeCommands(workflowId: detailPublisher.data.id, commandIds: selectionManager.selections))
-            }
-          }
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .focused(focus, equals: .detail(.commands))
-        .matchedGeometryEffect(id: "command-list", in: namespace)
-      }
-    }
+    WorkflowCommandEmptyListView(namespace: namespace, onAction: onAction)
+    WorkflowCommandListScrollView(focus,
+                                  detailPublisher: detailPublisher,
+                                  namespace: namespace,
+                                  selectionManager: selectionManager,
+                                  scrollViewProxy: scrollViewProxy,
+                                  onAction: onAction)
   }
 }
 


### PR DESCRIPTION
- Make sure to only set new values when it comes to selections
- Refactor icon loading to be faster if the icon is already in memory
- Add new `sidebarLabel()` extension on `Text`
- Apply `drawingGroup` for backgrounds to improve performance
- Remove the overuse of `Binding` when it was not needed
- Remove redundant `@Environment` & `EnvironmentObject` properties
- Add new `ContentAddWorkflowHeaderView`
- Add `dropFirst` to the debounce publisher
- Use `.lazy` to improve iterating over large collections in `ForEach`
- Add `id:\.id` for `ForEach` declarations
