### PR TITLE
Fix focusable issues on Sonoma

### DIFF
--- a/App/Sources/UI/Styles/LargeTextFieldStyle.swift
+++ b/App/Sources/UI/Styles/LargeTextFieldStyle.swift
@@ -18,8 +18,8 @@ struct LargeTextFieldStyle: TextFieldStyle {
           .shadow(color: Color(isFocused ? .controlAccentColor : .clear), radius: 2)
           .opacity(isFocused ? 0.75 : isHovered ? 0.25 : 0)
       )
+      .fixedSize(horizontal: false, vertical: true)
       .onHover(perform: { newValue in  withAnimation { isHovered <- newValue } })
-      .focusable()
       .focused($isFocused)
   }
 }

--- a/App/Sources/UI/Views/Commands/TypeCommandView.swift
+++ b/App/Sources/UI/Views/Commands/TypeCommandView.swift
@@ -119,7 +119,6 @@ struct TypeCommandTextEditor: View {
       }
     )
     .onHover(perform: { newValue in  withAnimation(.easeInOut(duration: 0.2)) { isHovered = newValue } })
-    .focusable()
     .focused($isFocused)
   }
 }

--- a/App/Sources/UI/Views/NewCommand/NewCommandButtonView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandButtonView.swift
@@ -18,10 +18,7 @@ struct NewCommandButtonView<Content>: View where Content: View {
       content()
         .contentShape(RoundedRectangle(cornerRadius: 8))
         .foregroundColor(isFocused ? Color(.controlAccentColor) : Color(.textColor))
-        .shadow(color: Color(.controlAccentColor).opacity(isFocused ? 0.5 : 0), radius: 4)
     }
     .buttonStyle(.plain)
-    .focusable()
-    .focused($isFocused)
   }
 }

--- a/App/Sources/UI/Views/NewCommand/NewCommandView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandView.swift
@@ -137,7 +137,6 @@ struct NewCommandView: View {
             focused = nil
           }
           .keyboardShortcut(kind.key, modifiers: .command)
-          .focusable()
           .focused($focused, equals: .application)
           .padding(.horizontal, 4)
         }

--- a/App/Sources/UI/Views/Styles/AppTextFieldStyle.swift
+++ b/App/Sources/UI/Views/Styles/AppTextFieldStyle.swift
@@ -37,7 +37,6 @@ struct AppTextFieldStyle: TextFieldStyle {
         .onHover(perform: { newValue in
           isHovered <- newValue
         })
-        .focusable()
         .focused($isFocused)
     }
   }

--- a/App/Sources/UI/Views/Styles/FileSystemTextFieldStyle.swift
+++ b/App/Sources/UI/Views/Styles/FileSystemTextFieldStyle.swift
@@ -17,7 +17,6 @@ struct FileSystemTextFieldStyle: TextFieldStyle {
           .opacity(isFocused ? 0.75 : isHovered ? 0.25 : 0)
       )
       .onHover(perform: { newValue in  withAnimation { isHovered = newValue } })
-      .focusable()
       .focused($isFocused)
   }
 }

--- a/App/Sources/UI/Views/WorkflowInfoView.swift
+++ b/App/Sources/UI/Views/WorkflowInfoView.swift
@@ -26,6 +26,7 @@ struct WorkflowInfoView: View {
   var body: some View {
     HStack(spacing: 0) {
       TextField("Workflow name", text: $workflowName)
+        .focused(focus, equals: .detail(.name))
         .onCommand(#selector(NSTextField.insertTab(_:)), perform: {
           switch detailPublisher.data.trigger {
           case .applications:
@@ -39,8 +40,8 @@ struct WorkflowInfoView: View {
         .onCommand(#selector(NSTextField.insertBacktab(_:)), perform: {
           focus.wrappedValue = .workflows
         })
-        .focused(focus, equals: .detail(.name))
         .frame(height: 32)
+        .fixedSize(horizontal: false, vertical: true)
         .textFieldStyle(LargeTextFieldStyle())
         .onChange(of: workflowName) { debounce.send($0) }
 


### PR DESCRIPTION
- Eliminated the `.focusable` view modifier to prevent Sonoma from misallocating focus to the incorrect view.
