### PR TITLE
Fix selection bug in the workflow ContentListView

### DIFF
--- a/App/Sources/UI/Views/ContentListView.swift
+++ b/App/Sources/UI/Views/ContentListView.swift
@@ -26,7 +26,7 @@ struct ContentListView: View {
   @EnvironmentObject private var groupsPublisher: GroupsPublisher
   @EnvironmentObject private var publisher: ContentPublisher
 
-  private let contentSelectionManager: SelectionManager<ContentViewModel>
+  @ObservedObject private var contentSelectionManager: SelectionManager<ContentViewModel>
   private let groupSelectionManager: SelectionManager<GroupViewModel>
 
   @State var searchTerm: String = ""
@@ -38,7 +38,7 @@ struct ContentListView: View {
        groupSelectionManager: SelectionManager<GroupViewModel>,
        focusPublisher: FocusPublisher<ContentViewModel>,
        onAction: @escaping (Action) -> Void) {
-    self.contentSelectionManager = contentSelectionManager
+    _contentSelectionManager = .init(initialValue: contentSelectionManager)
     self.groupSelectionManager = groupSelectionManager
     self.focusPublisher = focusPublisher
     self.focus = focus


### PR DESCRIPTION
- Add `@ObservedObject` to the `contentSelectionManager` property.
  Without it, the `onChange` operator doesn't get called when the
  selection changes.
