### PR TITLE
Refactor core setup of the application

### DIFF
--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -1,0 +1,105 @@
+import Foundation
+import InputSources
+
+@MainActor
+final class Core {
+  static private var appStorage: AppStorageStore = .init()
+
+#if DEBUG
+  static let config: AppPreferences = .designTime()
+#else
+  static let config: AppPreferences = .user()
+#endif
+
+  // MARK: - Coordinators
+
+  lazy private(set) var configCoordinator = ConfigurationCoordinator(
+    contentStore: contentStore,
+    selectionManager: configSelectionManager,
+    store: configurationStore)
+
+  lazy private(set) var sidebarCoordinator = SidebarCoordinator(
+    groupStore,
+    applicationStore: applicationStore,
+    configSelectionManager: configSelectionManager,
+    groupSelectionManager: groupSelectionManager)
+
+  lazy private(set) var contentCoordinator = ContentCoordinator(
+    groupStore,
+    applicationStore: applicationStore,
+    contentSelectionManager: contentSelectionManager,
+    groupSelectionManager: groupSelectionManager
+  )
+
+  lazy private(set) var detailCoordinator = DetailCoordinator(
+    applicationStore: applicationStore,
+    applicationTriggerSelectionManager: applicationTriggerSelectionManager,
+    commandRunner: commandRunner,
+    commandSelectionManager: commandSelectionManager,
+    contentSelectionManager: contentSelectionManager,
+    contentStore: contentStore,
+    groupSelectionManager: groupSelectionManager,
+    keyboardCowboyEngine: engine,
+    keyboardShortcutSelectionManager: keyboardShortcutSelectionManager,
+    groupStore: contentStore.groupStore)
+
+  // MARK: - Selection managers
+
+  lazy private(set) var keyboardShortcutSelectionManager = SelectionManager<KeyShortcut>()
+  lazy private(set) var applicationTriggerSelectionManager = SelectionManager<DetailViewModel.ApplicationTrigger>()
+  lazy private(set) var commandSelectionManager = SelectionManager<CommandViewModel>()
+
+  lazy private(set) var configSelectionManager = SelectionManager<ConfigurationViewModel>(initialSelection: [Self.appStorage.configId]) {
+    Self.appStorage.configId = $0.first ?? ""
+  }
+
+  lazy private(set) var groupSelectionManager = SelectionManager<GroupViewModel>(initialSelection: Self.appStorage.groupIds) {
+    Self.appStorage.groupIds = $0
+  }
+
+  lazy private(set) var contentSelectionManager = SelectionManager<ContentViewModel>(initialSelection: Self.appStorage.workflowIds) {
+    Self.appStorage.workflowIds = $0
+  }
+
+
+  // MARK: - Stores
+
+  lazy private(set) var applicationStore = ApplicationStore()
+  lazy private(set) var configurationStore = ConfigurationStore()
+  lazy private(set) var contentStore = ContentStore(
+    Self.config,
+    applicationStore: applicationStore,
+    configurationStore: configurationStore,
+    groupStore: groupStore,
+    keyboardShortcutsController: keyboardShortcutsController,
+    recorderStore: recorderStore,
+    shortcutStore: shortcutStore,
+    scriptCommandRunner: scriptCommandRunner)
+  lazy private(set) var groupStore = GroupStore()
+  lazy private(set) var keyCodeStore = KeyCodesStore(InputSourceController())
+  lazy private(set) var engine = KeyboardCowboyEngine(
+    contentStore,
+    commandRunner: commandRunner,
+    keyboardCommandRunner: keyboardCommandRunner,
+    keyboardShortcutsController: keyboardShortcutsController,
+    keyCodeStore: keyCodeStore,
+    scriptCommandRunner: scriptCommandRunner,
+    shortcutStore: shortcutStore,
+    workspace: .shared)
+  lazy private(set) var recorderStore = KeyShortcutRecorderStore()
+  lazy private(set) var shortcutStore = ShortcutStore(scriptCommandRunner)
+
+  // MARK: - Runners
+  lazy private(set) var commandRunner = CommandRunner(
+    applicationStore: applicationStore,
+    scriptCommandRunner: scriptCommandRunner,
+    keyboardCommandRunner: keyboardCommandRunner)
+  lazy private(set) var keyboardCommandRunner = KeyboardCommandRunner(store: keyCodeStore)
+  lazy private(set) var scriptCommandRunner = ScriptCommandRunner(workspace: .shared)
+
+  // MARK: - Controllers
+
+  lazy private(set) var keyboardShortcutsController = KeyboardShortcutsController()
+
+  init() { }
+}

--- a/App/Sources/Core/GlobalVars.swift
+++ b/App/Sources/Core/GlobalVars.swift
@@ -3,4 +3,4 @@ import LaunchArguments
 import CoreGraphics
 
 let launchArguments = LaunchArgumentsController<LaunchArgument>()
-
+let isRunningPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -6,120 +6,32 @@ import LaunchArguments
 import InputSources
 @_exported import Inject
 
-private let isRunningPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
-
 @main
 struct KeyboardCowboy: App {
-  static private var appStorage: AppStorageStore = .init()
-  @Namespace var namespace
-  @Environment(\.resetFocus) var resetFocus
-  @FocusState var focus: AppFocus?
-  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-
-  private let sidebarCoordinator: SidebarCoordinator
-  private let configurationCoordinator: ConfigurationCoordinator
-  private let contentCoordinator: ContentCoordinator
-  private let detailCoordinator: DetailCoordinator
-
-  @ObservedObject private var contentStore: ContentStore
-  private let groupStore: GroupStore
-  private let scriptCommandRunner: ScriptCommandRunner
-  private let engine: KeyboardCowboyEngine
 #if DEBUG
-  static let config: AppPreferences = .designTime()
   static let env: AppEnvironment = isRunningPreview ? .designTime : .development
 #else
-  static let config: AppPreferences = .user()
   static let env: AppEnvironment = .production
 #endif
+
+  static private var appStorage: AppStorageStore = .init()
+  @Namespace var namespace
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
   private var open: Bool = true
+  private let core: Core
+  @ObservedObject var contentStore: ContentStore
 
   @Environment(\.openWindow) private var openWindow
   @Environment(\.scenePhase) private var scenePhase
 
   init() {
+    let core = Core()
+    contentStore = core.contentStore
+    self.core = core
+
     Inject.animation = .spring()
-
-    // Core functionality
-    let scriptCommandRunner = ScriptCommandRunner(workspace: .shared)
-    let keyboardShortcutsController = KeyboardShortcutsController()
-    let applicationStore = ApplicationStore()
-    let shortcutStore = ShortcutStore(scriptCommandRunner)
-    let contentStore = ContentStore(Self.config,
-                                    applicationStore: applicationStore,
-                                    keyboardShortcutsController: keyboardShortcutsController,
-                                    shortcutStore: shortcutStore,
-                                    scriptCommandRunner: scriptCommandRunner)
-    let keyCodeStore = KeyCodesStore(InputSourceController())
-    let keyboardCommandRunner = KeyboardCommandRunner(store: keyCodeStore)
-    let engine = KeyboardCowboyEngine(contentStore,
-                                      keyboardCommandRunner: keyboardCommandRunner,
-                                      keyboardShortcutsController: keyboardShortcutsController,
-                                      keyCodeStore: keyCodeStore,
-                                      scriptCommandRunner: scriptCommandRunner,
-                                      shortcutStore: shortcutStore,
-                                      workspace: .shared)
-
-    // Selections
-    let configSelectionManager = SelectionManager<ConfigurationViewModel>(initialSelection: [Self.appStorage.configId]) {
-      Self.appStorage.configId = $0.first ?? ""
-    }
-    let groupSelectionManager = SelectionManager<GroupViewModel>(initialSelection: Self.appStorage.groupIds) {
-      Self.appStorage.groupIds = $0
-    }
-    let contentSelectionManager = SelectionManager<ContentViewModel>(initialSelection: Self.appStorage.workflowIds) {
-      Self.appStorage.workflowIds = $0
-    }
-
-    let keyboardShortcutSelectionManager = SelectionManager<KeyShortcut>()
-    let applicationTriggerSelectionManager = SelectionManager<DetailViewModel.ApplicationTrigger>()
-    let commandSelectionManager = SelectionManager<CommandViewModel>()
-
-    // Coordinators
-    let configCoordinator = ConfigurationCoordinator(
-      contentStore: contentStore,
-      selectionManager: configSelectionManager,
-      store: contentStore.configurationStore)
-
-    let sidebarCoordinator = SidebarCoordinator(
-      contentStore.groupStore,
-      applicationStore: applicationStore,
-      configSelectionManager: configSelectionManager,
-      groupSelectionManager: groupSelectionManager)
-
-    let contentCoordinator = ContentCoordinator(
-      contentStore.groupStore,
-      applicationStore: applicationStore,
-      contentSelectionManager: contentSelectionManager,
-      groupSelectionManager: groupSelectionManager
-    )
-
-    let detailCoordinator = DetailCoordinator(applicationStore: applicationStore,
-                                              applicationTriggerSelectionManager: applicationTriggerSelectionManager,
-                                              commandRunner: CommandRunner(applicationStore: applicationStore,
-                                                                           scriptCommandRunner: scriptCommandRunner,
-                                                                           keyboardCommandRunner: keyboardCommandRunner),
-                                              commandSelectionManager: commandSelectionManager,
-                                              contentSelectionManager: contentSelectionManager,
-                                              contentStore: contentStore,
-                                              groupSelectionManager: groupSelectionManager,
-                                              keyboardCowboyEngine: engine,
-                                              keyboardShortcutSelectionManager: keyboardShortcutSelectionManager,
-                                              groupStore: contentStore.groupStore)
-
-
-    self.sidebarCoordinator = sidebarCoordinator
-    self.configurationCoordinator = configCoordinator
-    self.contentCoordinator = contentCoordinator
-    self.detailCoordinator = detailCoordinator
-
-    self.contentStore = contentStore
-    self.groupStore = contentStore.groupStore
-    self.engine = engine
-    self.scriptCommandRunner = scriptCommandRunner
-
     Benchmark.isEnabled = launchArguments.isEnabled(.benchmark)
-
     if launchArguments.isEnabled(.injection) { _ = Inject.load }
   }
 
@@ -144,19 +56,18 @@ struct KeyboardCowboy: App {
     })
 
     WindowGroup(id: KeyboardCowboy.mainWindowIdentifier) {
-      Group {
-        switch contentStore.state {
+      VStack {
+        switch core.contentStore.state {
         case .initialized:
-          ContainerView(focus: $focus,
-                        applicationTriggerSelectionManager: detailCoordinator.applicationTriggerSelectionManager,
-                        commandSelectionManager: detailCoordinator.commandSelectionManager,
-                        configSelectionManager: configurationCoordinator.selectionManager,
-                        contentSelectionManager: contentCoordinator.contentSelectionManager,
-                        groupsSelectionManager: sidebarCoordinator.selectionManager,
-                        keyboardShortcutSelectionManager: detailCoordinator.keyboardShortcutSelectionManager
+          ContainerView(applicationTriggerSelectionManager: core.applicationTriggerSelectionManager,
+                        commandSelectionManager: core.commandSelectionManager,
+                        configSelectionManager: core.configSelectionManager,
+                        contentSelectionManager: core.contentSelectionManager,
+                        groupsSelectionManager: core.groupSelectionManager,
+                        keyboardShortcutSelectionManager: core.keyboardShortcutSelectionManager
           ) { action, undoManager in
 
-            let oldConfiguration = configurationCoordinator.store.selectedConfiguration
+            let oldConfiguration = core.configurationStore.selectedConfiguration
 
             switch action {
             case .openScene(let scene):
@@ -166,42 +77,42 @@ struct KeyboardCowboy: App {
               case .openScene(let scene):
                 handleScene(scene)
               default:
-                configurationCoordinator.handle(sidebarAction)
-                sidebarCoordinator.handle(sidebarAction)
-                contentCoordinator.handle(sidebarAction)
-                detailCoordinator.handle(sidebarAction)
+                core.configCoordinator.handle(sidebarAction)
+                core.sidebarCoordinator.handle(sidebarAction)
+                core.contentCoordinator.handle(sidebarAction)
+                core.detailCoordinator.handle(sidebarAction)
               }
             case .content(let contentAction):
-              contentCoordinator.handle(contentAction)
-              detailCoordinator.handle(contentAction)
-              if case .addWorkflow = contentAction {
-                Task { @MainActor in focus = .detail(.name) }
-              }
+              core.contentCoordinator.handle(contentAction)
+              core.detailCoordinator.handle(contentAction)
             case .detail(let detailAction):
-              detailCoordinator.handle(detailAction)
-              contentCoordinator.handle(detailAction)
+              core.detailCoordinator.handle(detailAction)
+              core.contentCoordinator.handle(detailAction)
             }
 
-            undoManager?.registerUndo(withTarget: configurationCoordinator.store, handler: { store in
+            undoManager?.registerUndo(withTarget: core.configurationStore, handler: { store in
               store.update(oldConfiguration)
-              contentStore.use(oldConfiguration)
-              sidebarCoordinator.handle(.refresh)
-              contentCoordinator.handle(.refresh(contentCoordinator.groupSelectionManager.selections))
-              detailCoordinator.handle(.selectWorkflow(workflowIds: contentCoordinator.contentSelectionManager.selections,
-                                                       groupIds: contentCoordinator.groupSelectionManager.selections))
+              core.contentStore.use(oldConfiguration)
+              core.sidebarCoordinator.handle(.refresh)
+              core.contentCoordinator.handle(.refresh(core.groupSelectionManager.selections))
+              core.detailCoordinator.handle(.selectWorkflow(workflowIds: core.contentSelectionManager.selections,
+                                                            groupIds: core.groupSelectionManager.selections))
             })
           }
           .focusScope(namespace)
-          .environmentObject(contentStore.configurationStore)
-          .environmentObject(contentStore.applicationStore)
-          .environmentObject(contentStore.groupStore)
-          .environmentObject(contentStore.shortcutStore)
-          .environmentObject(configurationCoordinator.publisher)
-          .environmentObject(sidebarCoordinator.publisher)
-          .environmentObject(contentCoordinator.publisher)
-          .environmentObject(detailCoordinator.statePublisher)
-          .environmentObject(detailCoordinator.detailPublisher)
-          .environmentObject(contentStore.recorderStore)
+
+          .environmentObject(core.applicationStore)
+          .environmentObject(core.contentStore)
+          .environmentObject(core.groupStore)
+          .environmentObject(core.shortcutStore)
+          .environmentObject(core.recorderStore)
+
+          .environmentObject(core.configCoordinator.publisher)
+          .environmentObject(core.sidebarCoordinator.publisher)
+          .environmentObject(core.contentCoordinator.publisher)
+          .environmentObject(core.detailCoordinator.statePublisher)
+          .environmentObject(core.detailCoordinator.detailPublisher)
+
           .environmentObject(OpenPanelController())
           .matchedGeometryEffect(id: "content-window", in: namespace)
         case .loading:
@@ -210,14 +121,14 @@ struct KeyboardCowboy: App {
             .matchedGeometryEffect(id: "content-window", in: namespace)
         case .noConfiguration:
           EmptyConfigurationView(namespace) {
-            contentStore.handle($0)
+            core.contentStore.handle($0)
           }
             .matchedGeometryEffect(id: "content-window", in: namespace)
             .frame(width: 560, height: 380)
-            .animation(.none, value: contentStore.state)
+            .animation(.none, value: core.contentStore.state)
         }
       }
-      .animation(.easeInOut, value: contentStore.state)
+      .animation(.easeInOut, value: core.contentStore.state)
     }
     .windowResizability(.contentSize)
     .windowStyle(.hiddenTitleBar)
@@ -234,21 +145,21 @@ struct KeyboardCowboy: App {
       }
     }
 
-    NewCommandWindow(contentStore: contentStore) { workflowId, commandId, title, payload in
-      let groupIds = contentCoordinator.groupSelectionManager.selections
+    NewCommandWindow(contentStore: core.contentStore) { workflowId, commandId, title, payload in
+      let groupIds = core.groupSelectionManager.selections
       Task {
-        await detailCoordinator.addOrUpdateCommand(payload, workflowId: workflowId,
-                                                   title: title, commandId: commandId)
-        contentCoordinator.handle(.selectWorkflow(workflowIds: [workflowId], groupIds: groupIds))
-        contentCoordinator.handle(.refresh(groupIds))
+        await core.detailCoordinator.addOrUpdateCommand(payload, workflowId: workflowId,
+                                                               title: title, commandId: commandId)
+        core.contentCoordinator.handle(.selectWorkflow(workflowIds: [workflowId], groupIds: groupIds))
+        core.contentCoordinator.handle(.refresh(groupIds))
       }
     }
     .defaultSize(.init(width: 520, height: 280))
     .defaultPosition(.center)
 
-    EditWorkflowGroupWindow(contentStore) { context in
-      sidebarCoordinator.handle(context)
-      contentCoordinator.handle(context)
+    EditWorkflowGroupWindow(core.contentStore) { context in
+      core.sidebarCoordinator.handle(context)
+      core.contentCoordinator.handle(context)
     }
       .windowResizability(.contentSize)
       .windowStyle(.hiddenTitleBar)
@@ -271,7 +182,7 @@ struct KeyboardCowboy: App {
     case .addGroup:
       openWindow(value: EditWorkflowGroupWindow.Context.add(WorkflowGroup.empty()))
     case .editGroup(let groupId):
-      if let workflowGroup = groupStore.group(withId: groupId) {
+      if let workflowGroup = core.groupStore.group(withId: groupId) {
         openWindow(value: EditWorkflowGroupWindow.Context.edit(workflowGroup))
       } else {
         assertionFailure("Unable to find workflow group")

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -24,6 +24,7 @@ final class KeyboardCowboyEngine {
   private var machPortController: MachPortEventController?
 
   init(_ contentStore: ContentStore,
+       commandRunner: CommandRunner,
        keyboardCommandRunner: KeyboardCommandRunner,
        keyboardShortcutsController: KeyboardShortcutsController,
        keyCodeStore: KeyCodesStore,
@@ -32,12 +33,6 @@ final class KeyboardCowboyEngine {
        shortcutStore: ShortcutStore,
        workspace: NSWorkspace = .shared) {
     
-    let commandRunner = CommandRunner(
-      workspace,
-      applicationStore: contentStore.applicationStore,
-      scriptCommandRunner: scriptCommandRunner,
-      keyboardCommandRunner: keyboardCommandRunner
-    )
     self.contentStore = contentStore
     self.keyCodeStore = keyCodeStore
     self.commandRunner = commandRunner

--- a/App/Sources/Core/Stores/ContentStore.swift
+++ b/App/Sources/Core/Stores/ContentStore.swift
@@ -21,28 +21,30 @@ final class ContentStore: ObservableObject {
 
   private(set) var configurationStore: ConfigurationStore
   private(set) var groupStore: GroupStore
-  private(set) var recorderStore = KeyShortcutRecorderStore()
+  private(set) var recorderStore: KeyShortcutRecorderStore
   private(set) var shortcutStore: ShortcutStore
 
-  @Published private var configurationId: String
+  private var configurationId: String
   let applicationStore: ApplicationStore
 
   init(_ preferences: AppPreferences,
        applicationStore: ApplicationStore,
-       keyboardShortcutsController: KeyboardShortcutsController = .init(),
-       shortcutStore shortcutStoreOverride: ShortcutStore? = nil,
+       configurationStore: ConfigurationStore,
+       groupStore: GroupStore,
+       keyboardShortcutsController: KeyboardShortcutsController,
+       recorderStore: KeyShortcutRecorderStore,
+       shortcutStore: ShortcutStore,
        scriptCommandRunner: ScriptCommandRunner = .init(workspace: .shared),
        workspace: NSWorkspace = .shared) {
-    _configurationId = .init(initialValue: Self.appStorage.configId)
-
-    let groupStore = GroupStore()
+    self.configurationId = Self.appStorage.configId
     self.applicationStore = applicationStore
-    self.shortcutStore = shortcutStoreOverride ?? ShortcutStore(scriptCommandRunner)
+    self.shortcutStore = shortcutStore
     self.groupStore = groupStore
-    self.configurationStore = ConfigurationStore()
+    self.configurationStore = configurationStore
     self.keyboardShortcutsController = keyboardShortcutsController
     self.preferences = preferences
     self.storage = Storage(preferences.storageConfiguration)
+    self.recorderStore = recorderStore
 
     guard KeyboardCowboy.env != .designTime else { return }
 
@@ -114,7 +116,6 @@ final class ContentStore: ObservableObject {
       .removeDuplicates()
       .sink { [weak self] groups in
         self?.updateConfiguration(groups)
-
     }.store(in: &subscriptions)
   }
 

--- a/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
+++ b/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
@@ -4,10 +4,12 @@ import SwiftUI
 @MainActor
 final class ConfigurationCoordinator {
   private var subscription: AnyCancellable?
-  let contentStore: ContentStore
-  let store: ConfigurationStore
+
+  private let contentStore: ContentStore
+  private let selectionManager: SelectionManager<ConfigurationViewModel>
+  private let store: ConfigurationStore
+
   let publisher: ConfigurationPublisher
-  let selectionManager: SelectionManager<ConfigurationViewModel>
 
   init(contentStore: ContentStore, selectionManager: SelectionManager<ConfigurationViewModel>,
        store: ConfigurationStore) {

--- a/App/Sources/UI/Coordinators/ContentCoordinator.swift
+++ b/App/Sources/UI/Coordinators/ContentCoordinator.swift
@@ -3,12 +3,12 @@ import SwiftUI
 
 @MainActor
 final class ContentCoordinator {
-  private let store: GroupStore
-  private let mapper: ContentModelMapper
   private let applicationStore: ApplicationStore
+  private let contentSelectionManager: SelectionManager<ContentViewModel>
+  private let groupSelectionManager: SelectionManager<GroupViewModel>
+  private let mapper: ContentModelMapper
+  private let store: GroupStore
 
-  let contentSelectionManager: SelectionManager<ContentViewModel>
-  let groupSelectionManager: SelectionManager<GroupViewModel>
   let publisher: ContentPublisher = ContentPublisher()
 
   init(_ store: GroupStore,

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -4,17 +4,18 @@ import SwiftUI
 
 @MainActor
 final class DetailCoordinator {
-  let applicationStore: ApplicationStore
-  let applicationTriggerSelectionManager: SelectionManager<DetailViewModel.ApplicationTrigger>
-  let commandRunner: CommandRunner
-  let commandSelectionManager: SelectionManager<CommandViewModel>
-  let contentSelectionManager: SelectionManager<ContentViewModel>
-  let contentStore: ContentStore
+  private let applicationStore: ApplicationStore
+  private let applicationTriggerSelectionManager: SelectionManager<DetailViewModel.ApplicationTrigger>
+  private let commandRunner: CommandRunner
+  private let commandSelectionManager: SelectionManager<CommandViewModel>
+  private let contentSelectionManager: SelectionManager<ContentViewModel>
+  private let contentStore: ContentStore
+  private let groupSelectionManager: SelectionManager<GroupViewModel>
+  private let groupStore: GroupStore
+  private let keyboardCowboyEngine: KeyboardCowboyEngine
+  private let keyboardShortcutSelectionManager: SelectionManager<KeyShortcut>
+
   let detailPublisher: DetailPublisher = .init(DesignTime.emptyDetail)
-  let groupSelectionManager: SelectionManager<GroupViewModel>
-  let groupStore: GroupStore
-  let keyboardCowboyEngine: KeyboardCowboyEngine
-  let keyboardShortcutSelectionManager: SelectionManager<KeyShortcut>
   let mapper: DetailModelMapper
   let statePublisher: DetailStatePublisher = .init(.empty)
 

--- a/App/Sources/UI/Coordinators/SidebarCoordinator.swift
+++ b/App/Sources/UI/Coordinators/SidebarCoordinator.swift
@@ -6,12 +6,11 @@ final class SidebarCoordinator {
   private var subscription: AnyCancellable?
 
   private let applicationStore: ApplicationStore
+  private let configSelectionManager: SelectionManager<ConfigurationViewModel>
+  private let selectionManager: SelectionManager<GroupViewModel>
   private let store: GroupStore
 
   let publisher = GroupsPublisher()
-
-  let configSelectionManager: SelectionManager<ConfigurationViewModel>
-  let selectionManager: SelectionManager<GroupViewModel>
 
   init(_ store: GroupStore, applicationStore: ApplicationStore,
        configSelectionManager: SelectionManager<ConfigurationViewModel>,
@@ -25,7 +24,6 @@ final class SidebarCoordinator {
     // Initial load
     // Configurations are loaded asynchronously, so we need to wait for them to be loaded
     subscription = store.$groups
-      .dropFirst()
       .sink { [weak self] groups in
         self?.render(groups)
         self?.subscription = nil

--- a/App/Sources/UI/Extensions/PreviewProvider+Extentions.swift
+++ b/App/Sources/UI/Extensions/PreviewProvider+Extentions.swift
@@ -4,7 +4,11 @@ extension PreviewProvider {
   static var applicationStore: ApplicationStore { contentStore.applicationStore }
   static var configurationStore: ConfigurationStore { contentStore.configurationStore }
   static var contentStore: ContentStore {
-    ContentStore(.designTime(), applicationStore: applicationStore)
+    ContentStore(.designTime(), applicationStore: Self.applicationStore,
+                 configurationStore: Self.configurationStore, groupStore: GroupStore(),
+                 keyboardShortcutsController: KeyboardShortcutsController(),
+                 recorderStore: KeyShortcutRecorderStore(),
+                 shortcutStore: ShortcutStore(.init(workspace: .shared)))
   }
   static var groupStore: GroupStore { contentStore.groupStore }
   static func autoCompletionStore(_ completions: [String],

--- a/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ApplicationCommandView.swift
@@ -10,7 +10,6 @@ struct IconMenuStyle: MenuStyle {
 }
 
 struct ApplicationCommandView: View {
-  @ObserveInjection var inject
   enum Action {
     case changeApplication(Application)
     case updateName(newName: String)


### PR DESCRIPTION
Add new `Core` class that holds all the dependecies of the application.
It cleans up the `KeyboardCowboy` application struct and makes it easier
to ensure that we don't create more class instances than we need.

With a bit more work, it should be easier to test the application.

This change also cleans up some SwiftUI related components which
should bring some slight performance gains because the views no
longer will respond to "bogus" updates.
