### PR TITLE
Fix bugs related to command views not updating properly

### DIFF
--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -125,7 +125,7 @@ struct CommandResolverView: View {
     case .plain:
       UnknownView(command: .constant(command))
     case .menuBar(let model):
-      MenuBarCommandView($command.meta, model: model) { action in
+      MenuBarCommandView(command.meta, model: model) { action in
         switch action {
         case .editCommand(let command):
           openWindow(value: NewCommandWindow.Context.editCommand(workflowId: workflowId, commandId: command.id))
@@ -135,7 +135,7 @@ struct CommandResolverView: View {
         }
       }
     case .open(let model):
-      OpenCommandView(command.meta, model: model){ action in
+      OpenCommandView(command.meta, model: model) { action in
           switch action {
           case .commandAction(let action):
             handleCommandContainerAction(action)
@@ -182,7 +182,7 @@ struct CommandResolverView: View {
           }
         }
     case .type(let model):
-      TypeCommandView($command.meta, model: Binding(get: { model }, set: { _ in })) { action in
+      TypeCommandView(command.meta, model: model) { action in
           switch action {
           case .commandAction(let action):
             handleCommandContainerAction(action)
@@ -191,7 +191,7 @@ struct CommandResolverView: View {
           }
         }
     case .systemCommand(let model):
-      SystemCommandView($command.meta, model: model) { action in
+      SystemCommandView(command.meta, model: model) { action in
         switch action {
         case .commandAction(let action):
           handleCommandContainerAction(action)
@@ -200,7 +200,7 @@ struct CommandResolverView: View {
         }
       }
     case .windowManagement(let model):
-      WindowManagementCommandView($command.meta, model: model) { action in
+      WindowManagementCommandView(command.meta, model: model) { action in
         switch action {
         case .onUpdate:
           onAction(.modify(.window(action: action, workflowId: workflowId, commandId: command.id)))

--- a/App/Sources/UI/Views/Commands/CommandContainerView.swift
+++ b/App/Sources/UI/Views/Commands/CommandContainerView.swift
@@ -59,6 +59,8 @@ struct CommandContainerView<IconContent, Content, SubContent>: View where IconCo
           .padding(.trailing, 5)
 
           HStack {
+            // Fix this bug that you can't notify when running
+            // modifying a menubar command.
             AppCheckbox("Notify", style: .small, isOn: $metaData.notification) {
               onAction(.toggleNotify($0))
             }

--- a/App/Sources/UI/Views/Commands/MenuBarCommandView.swift
+++ b/App/Sources/UI/Views/Commands/MenuBarCommandView.swift
@@ -6,14 +6,14 @@ struct MenuBarCommandView: View {
     case commandAction(CommandContainerAction)
   }
   @Environment(\.openWindow) private var openWindow
-  @Binding var metaData: CommandViewModel.MetaData
+  @State var metaData: CommandViewModel.MetaData
   @Binding var model: CommandViewModel.Kind.MenuBarModel
   private let onAction: (Action) -> Void
 
-  init(_ metaData: Binding<CommandViewModel.MetaData>,
+  init(_ metaData: CommandViewModel.MetaData,
        model: CommandViewModel.Kind.MenuBarModel,
        onAction: @escaping (Action) -> Void) {
-    _metaData = metaData
+    _metaData = .init(initialValue: metaData)
     _model = Binding<CommandViewModel.Kind.MenuBarModel>(model)
     self.onAction = onAction
   }
@@ -99,7 +99,7 @@ struct MenuBarCommandView: View {
 struct MenuBarCommandView_Previews: PreviewProvider {
   static let command = DesignTime.menuBarCommand
   static var previews: some View {
-    MenuBarCommandView(.constant(command.model.meta), model: command.kind) { _ in }
+    MenuBarCommandView(command.model.meta, model: command.kind) { _ in }
       .designTime()
       .frame(maxHeight: 80)
   }

--- a/App/Sources/UI/Views/Commands/SystemCommandView.swift
+++ b/App/Sources/UI/Views/Commands/SystemCommandView.swift
@@ -5,15 +5,15 @@ struct SystemCommandView: View {
     case updateKind(newKind: SystemCommand.Kind)
     case commandAction(CommandContainerAction)
   }
-  @Binding var metaData: CommandViewModel.MetaData
-  @State var model: CommandViewModel.Kind.SystemModel
+  @State var metaData: CommandViewModel.MetaData
+  @Binding var model: CommandViewModel.Kind.SystemModel
   let onAction: (Action) -> Void
 
-  init(_ metaData: Binding<CommandViewModel.MetaData>,
+  init(_ metaData: CommandViewModel.MetaData,
        model: CommandViewModel.Kind.SystemModel,
        onAction: @escaping (Action) -> Void) {
-    _metaData = metaData
-    _model = .init(initialValue: model)
+    _metaData = .init(initialValue: metaData)
+    _model = Binding<CommandViewModel.Kind.SystemModel>(model)
     self.onAction = onAction
   }
 
@@ -78,7 +78,7 @@ extension SystemCommand.Kind {
 struct SystemCommandView_Previews: PreviewProvider {
   static let command = DesignTime.systemCommand
   static var previews: some View {
-    SystemCommandView(.constant(command.model.meta), model: command.kind) { _ in }
+    SystemCommandView(command.model.meta, model: command.kind) { _ in }
       .designTime()
   }
 }

--- a/App/Sources/UI/Views/Commands/TypeCommandView.swift
+++ b/App/Sources/UI/Views/Commands/TypeCommandView.swift
@@ -7,16 +7,16 @@ struct TypeCommandView: View {
     case updateMode(newMode: TypeCommand.Mode)
     case commandAction(CommandContainerAction)
   }
-  @Binding var metaData: CommandViewModel.MetaData
-  @Binding var model: CommandViewModel.Kind.TypeModel
+  @State var metaData: CommandViewModel.MetaData
+  @State var model: CommandViewModel.Kind.TypeModel
   private let debounce: DebounceManager<String>
   private let onAction: (Action) -> Void
 
-  init(_ metaData: Binding<CommandViewModel.MetaData>,
-       model: Binding<CommandViewModel.Kind.TypeModel>,
+  init(_ metaData: CommandViewModel.MetaData,
+       model: CommandViewModel.Kind.TypeModel,
        onAction: @escaping (Action) -> Void) {
-    _metaData = metaData
-    _model = model
+    _metaData = .init(initialValue: metaData)
+    _model = .init(initialValue: model)
     debounce = DebounceManager(for: .milliseconds(500)) { newInput in
       onAction(.updateSource(newInput: newInput))
     }
@@ -38,7 +38,7 @@ struct TypeCommandView: View {
         TypeCommandTextEditor(text: $model.input)
           .onChange(of: model.input) { debounce.send($0) }
       }, subContent: { _ in
-        TypeCommandModeView(mode: $model.mode) { newMode in
+        TypeCommandModeView(mode: model.mode) { newMode in
           onAction(.updateMode(newMode: newMode))
         }
       }, onAction: { onAction(.commandAction($0)) })
@@ -46,18 +46,21 @@ struct TypeCommandView: View {
 }
 
 fileprivate struct TypeCommandModeView: View {
-  @Binding var mode: TypeCommand.Mode
+  @State var mode: TypeCommand.Mode
   private let onAction: (TypeCommand.Mode) -> Void
 
-  init(mode: Binding<TypeCommand.Mode>, onAction: @escaping (TypeCommand.Mode) -> Void) {
-    _mode = mode
+  init(mode: TypeCommand.Mode, onAction: @escaping (TypeCommand.Mode) -> Void) {
+    _mode = .init(initialValue: mode)
     self.onAction = onAction
   }
 
   var body: some View {
     Menu(content: {
       ForEach(TypeCommand.Mode.allCases) { mode in
-        Button(action: { onAction(mode) }, label: { Text(mode.rawValue) })
+        Button(action: {
+          self.mode = mode
+          onAction(mode)
+        }, label: { Text(mode.rawValue) })
       }
     }, label: {
       Text(mode.rawValue)
@@ -70,8 +73,8 @@ fileprivate struct TypeCommandModeView: View {
 struct TypeCommandView_Previews: PreviewProvider {
   static let command = DesignTime.typeCommand
   static var previews: some View {
-    TypeCommandView(.constant(command.model.meta), 
-                    model: .constant(command.kind)) { _ in }
+    TypeCommandView(command.model.meta, 
+                    model: command.kind) { _ in }
       .designTime()
       .frame(idealHeight: 120, maxHeight: 180)
   }

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -7,7 +7,7 @@ struct WindowManagementCommandView: View {
   }
 
   @Namespace var namespace
-  @Binding var metaData: CommandViewModel.MetaData
+  @State var metaData: CommandViewModel.MetaData
   @State var model: CommandViewModel.Kind.WindowManagementModel
   @State var padding: String
   @State var pixels: String
@@ -15,10 +15,10 @@ struct WindowManagementCommandView: View {
 
   private let onAction: (Action) -> Void
 
-  init(_ metaData: Binding<CommandViewModel.MetaData>,
+  init(_ metaData: CommandViewModel.MetaData,
        model: CommandViewModel.Kind.WindowManagementModel,
        onAction: @escaping (Action) -> Void) {
-    _metaData = metaData
+    _metaData = .init(initialValue: metaData)
     _model = .init(initialValue: model)
     self.onAction = onAction
 
@@ -303,7 +303,7 @@ struct WindowManagementCommandView_Previews: PreviewProvider {
     VStack {
       ForEach(models, id: \.model) { container in
         WindowManagementCommandView(
-          .constant(container.model.meta),
+          container.model.meta,
           model: .init(id: container.model.id, kind: container.kind)
         ) { _ in }
           .frame(maxHeight: 180)


### PR DESCRIPTION
Fix issues in command views where the updates didn't update
the view itself. Views now get the model and uses that has
`@State`. And when updates are made, we also modify the local
state and send the update to the coordinator.
