### PR TITLE
Add support for animation to window management commands

### DIFF
--- a/App/Sources/Core/Models/Command.swift
+++ b/App/Sources/Core/Models/Command.swift
@@ -271,7 +271,7 @@ extension Command {
     case .system:
       return Command.systemCommand(.init(id: UUID().uuidString, name: "", kind: .missionControl, notification: false))
     case .window:
-      return Command.windowManagement(.init(id: UUID().uuidString, name: "", kind: .center, notification: false))
+      return Command.windowManagement(.init(id: UUID().uuidString, name: "", kind: .center, notification: false, animationDuration: 0))
     }
   }
 

--- a/App/Sources/Core/Models/Commands/WindowCommand.swift
+++ b/App/Sources/Core/Models/Commands/WindowCommand.swift
@@ -135,10 +135,27 @@ struct WindowCommand: MetaDataProviding {
   }
 
   var kind: Kind
+  var animationDuration: Double
   var meta: Command.MetaData
 
-  init(id: String = UUID().uuidString, name: String, kind: Kind, notification: Bool) {
+  enum CodingKeys: CodingKey {
+    case kind
+    case animationDuration
+    case meta
+  }
+
+  init(id: String = UUID().uuidString, name: String, 
+       kind: Kind, notification: Bool, animationDuration: Double) {
     self.kind = kind
     self.meta = Command.MetaData(id: id, name: name, isEnabled: true, notification: notification)
+    self.animationDuration = animationDuration
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.kind = try container.decode(Kind.self, forKey: .kind)
+    self.animationDuration = try container.decodeIfPresent(Double.self, forKey: .animationDuration) ?? 0
+    self.meta = try container.decode(Command.MetaData.self, forKey: .meta)
   }
 }

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -184,7 +184,8 @@ final class DetailCoordinator {
       command = Command.windowManagement(.init(id: UUID().uuidString,
                                                name: "Window Management Command",
                                                kind: kind,
-                                               notification: false))
+                                               notification: false,
+                                               animationDuration: 0))
     }
 
     workflow.updateOrAddCommand(command)

--- a/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
@@ -222,8 +222,10 @@ final class DetailCommandActionReducer {
         case .onUpdate(let newModel):
           if case .windowManagement(let oldCommand) = command {
             command = .windowManagement(.init(id: oldCommand.id,
-                                              name: oldCommand.name, kind: newModel.kind,
-                                              notification: oldCommand.notification))
+                                              name: oldCommand.name, 
+                                              kind: newModel.kind,
+                                              notification: oldCommand.notification,
+                                              animationDuration: newModel.animationDuration))
             workflow.updateOrAddCommand(command)
           }
         }

--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -222,7 +222,7 @@ struct CommandResolverView: View {
         }
       }
       .fixedSize(horizontal: false, vertical: true)
-      .frame(height: 80)
+      .frame(minHeight: 80, maxHeight: 140)
     }
   }
 

--- a/App/Sources/UI/Views/Commands/CommandContainerDelayView.swift
+++ b/App/Sources/UI/Views/Commands/CommandContainerDelayView.swift
@@ -23,12 +23,15 @@ struct CommandContainerDelayView: View {
         delayOverlay = true
       } label: {
         HStack {
-          if let delay = metaData.delay {
-            Text("\(Int(delay)) milliseconds")
-              .font(.caption)
-          } else {
-            Text("No delay")
-              .font(.caption)
+          HStack(spacing: 4) {
+            Image(systemName: "hourglass")
+            if let delay = metaData.delay {
+              Text("\(Int(delay)) milliseconds")
+                .font(.caption)
+            } else {
+              Text("No delay")
+                .font(.caption)
+            }
           }
           Divider()
             .frame(height: 6)

--- a/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct WindowManagementAnimationDurationView: View {
+  @State private var animationDurationVisible: Bool = false
+  @Binding private var windowCommand: CommandViewModel.Kind.WindowManagementModel
+  private let onChange: (Double) -> Void
+
+  init(windowCommand: Binding<CommandViewModel.Kind.WindowManagementModel>, onChange: @escaping (Double) -> Void) {
+    _windowCommand = windowCommand
+    self.onChange = onChange
+  }
+
+  var body: some View {
+    Button {
+      animationDurationVisible = true
+    } label: {
+      HStack {
+        if windowCommand.animationDuration > 0 {
+          Text("\(Int(windowCommand.animationDuration * 1000)) milliseconds")
+            .font(.caption)
+        } else {
+          Text("No animation")
+            .font(.caption)
+        }
+        Divider()
+          .frame(height: 6)
+        Image(systemName: "chevron.down")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 6, height: 6)
+      }
+    }
+    .buttonStyle(AppButtonStyle(.init(nsColor: .systemGray)))
+    .popover(isPresented: $animationDurationVisible, content: {
+      WindowManagementAnimationPopoverView($windowCommand, onChange: onChange)
+    })
+  }
+}
+
+struct WindowManagementAnimationDurationView_Previews: PreviewProvider {
+  static let windowCommand = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: .center, animationDuration: 0.375)
+  static var previews: some View {
+    WindowManagementAnimationDurationView(windowCommand: .constant(windowCommand)) { _ in }
+      .frame(width: 200)
+  }
+}

--- a/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
@@ -16,7 +16,7 @@ struct WindowManagementAnimationDurationView: View {
     } label: {
       HStack {
         HStack(spacing: 4) {
-          Image(systemName: "speedometer")
+          Image(systemName: "sparkles")
           if windowCommand.animationDuration > 0 {
             Text("\(Int(windowCommand.animationDuration * 1000)) milliseconds")
               .font(.caption)

--- a/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementAnimationDurationView.swift
@@ -15,12 +15,15 @@ struct WindowManagementAnimationDurationView: View {
       animationDurationVisible = true
     } label: {
       HStack {
-        if windowCommand.animationDuration > 0 {
-          Text("\(Int(windowCommand.animationDuration * 1000)) milliseconds")
-            .font(.caption)
-        } else {
-          Text("No animation")
-            .font(.caption)
+        HStack(spacing: 4) {
+          Image(systemName: "speedometer")
+          if windowCommand.animationDuration > 0 {
+            Text("\(Int(windowCommand.animationDuration * 1000)) milliseconds")
+              .font(.caption)
+          } else {
+            Text("No animation")
+              .font(.caption)
+          }
         }
         Divider()
           .frame(height: 6)

--- a/App/Sources/UI/Views/Commands/WindowManagementAnimationPopoverView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementAnimationPopoverView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct WindowManagementAnimationPopoverView: View {
+  @State private var animationDuration: String
+  @Binding private var windowCommand: CommandViewModel.Kind.WindowManagementModel
+
+  private let onChange: (Double) -> Void
+
+  init(_ windowCommand: Binding<CommandViewModel.Kind.WindowManagementModel>,
+       onChange: @escaping (Double) -> Void) {
+    _windowCommand = windowCommand
+    _animationDuration = .init(initialValue: String(windowCommand.wrappedValue.animationDuration))
+    self.onChange = onChange
+  }
+
+  var body: some View {
+    HStack {
+      TextField("Animation duration", text: $animationDuration) { isEditing in
+        if !isEditing {
+          if let value = Double(self.animationDuration) {
+            if value > 0 {
+              windowCommand.animationDuration = value
+            } else {
+              windowCommand.animationDuration = 0
+            }
+            onChange(value)
+          }
+        }
+      }
+    }
+    .padding(16)
+  }
+}
+

--- a/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
+++ b/App/Sources/UI/Views/Commands/WindowManagementCommandView.swift
@@ -167,7 +167,7 @@ struct WindowManagementCommandView: View {
                     return
                   }
                   model.kind = kind
-                  onAction(.onUpdate(.init(id: metaData.id, kind: kind)))
+                  onAction(.onUpdate(.init(id: metaData.id, kind: kind, animationDuration: model.animationDuration)))
                 } label: {
                   Text(element.displayValue(increment: model.kind.isIncremental))
                 }
@@ -196,7 +196,7 @@ struct WindowManagementCommandView: View {
                     return
                   }
                   model.kind = kind
-                  onAction(.onUpdate(.init(id: metaData.id, kind: kind)))
+                  onAction(.onUpdate(.init(id: metaData.id, kind: kind, animationDuration: model.animationDuration)))
                 })
                 .textFieldStyle(AppTextFieldStyle())
                 .frame(width: 64)
@@ -222,7 +222,7 @@ struct WindowManagementCommandView: View {
                   return
                 }
                 model.kind = kind
-                onAction(.onUpdate(.init(id: metaData.id, kind: kind)))
+                onAction(.onUpdate(.init(id: metaData.id, kind: kind, animationDuration: model.animationDuration)))
               }
               .font(.caption)
             }
@@ -242,8 +242,7 @@ struct WindowManagementCommandView: View {
                 return
               }
               model.kind = kind
-              onAction(.onUpdate(.init(id: metaData.id, kind: kind)))
-
+              onAction(.onUpdate(.init(id: metaData.id, kind: kind, animationDuration: model.animationDuration)))
             })
               .textFieldStyle(AppTextFieldStyle())
               .frame(width: 32)
@@ -255,10 +254,14 @@ struct WindowManagementCommandView: View {
         }
         
       }
-    },
-                         subContent: { _ in }) {
+    }, subContent: { _ in
+      WindowManagementAnimationDurationView(windowCommand: $model) { newDuration in
+        model.animationDuration = newDuration
+        onAction(.onUpdate(.init(id: metaData.id, kind: model.kind, animationDuration: newDuration)))
+      }
+    }, onAction: {
       onAction(.commandAction($0))
-    }
+    })
   }
 
   private func resolveAlignment(_ kind: WindowCommand.Kind) -> Alignment {
@@ -304,7 +307,7 @@ struct WindowManagementCommandView_Previews: PreviewProvider {
       ForEach(models, id: \.model) { container in
         WindowManagementCommandView(
           container.model.meta,
-          model: .init(id: container.model.id, kind: container.kind)
+          model: .init(id: container.model.id, kind: container.kind, animationDuration: 0)
         ) { _ in }
           .frame(maxHeight: 180)
         Divider()

--- a/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
+++ b/App/Sources/UI/Views/DesignTime/DesignTimePublishers.swift
@@ -196,7 +196,7 @@ enum DesignTime {
   }
 
   static func windowCommand(_ kind: WindowCommand.Kind) -> (model: CommandViewModel, kind: WindowCommand.Kind) {
-    let model = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: kind)
+    let model = CommandViewModel.Kind.WindowManagementModel(id: UUID().uuidString, kind: kind, animationDuration: 0)
     return (.init(meta: metadata(name: "Window Management", icon: nil), kind: .windowManagement(model)), kind)
   }
 

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -100,7 +100,7 @@ private extension Command {
     case .systemCommand(let systemCommand):
       kind = .systemCommand(.init(id: systemCommand.id, kind: systemCommand.kind))
     case .windowManagement(let windowCommand):
-      kind = .windowManagement(.init(id: windowCommand.id, kind: windowCommand.kind))
+      kind = .windowManagement(.init(id: windowCommand.id, kind: windowCommand.kind, animationDuration: windowCommand.animationDuration))
     }
 
     return kind

--- a/App/Sources/UI/Views/Models/CommandViewModel.swift
+++ b/App/Sources/UI/Views/Models/CommandViewModel.swift
@@ -81,6 +81,7 @@ struct CommandViewModel: Codable, Hashable, Identifiable {
     struct WindowManagementModel: Codable, Hashable, Identifiable, Sendable {
       let id: String
       var kind: WindowCommand.Kind
+      var animationDuration: Double
     }
   }
 }


### PR DESCRIPTION
- You can now set an animation duration when performing window mangement commands.
  What it means is that it will resize or center windows with a animation.
- Fix clipped window management command views.
