### PR TITLE
Implement animation curves when using window commands

### DIFF
--- a/App/Sources/UI/Views/CommandView.swift
+++ b/App/Sources/UI/Views/CommandView.swift
@@ -222,7 +222,7 @@ struct CommandResolverView: View {
         }
       }
       .fixedSize(horizontal: false, vertical: true)
-      .frame(minHeight: 80, maxHeight: 140)
+      .frame(minHeight: 80, maxHeight: 160)
     }
   }
 


### PR DESCRIPTION
- Make window commands interuptable by adding Swift concurrency
- Add support for toggling center position, the method will now
  store the previous location of the window and toggle between
  them if the user invokes the command again
- Implement support for animation curves when using window commands
- Increase the maximum height of the `WindowManagementCommandView`
