### PR TITLE
Fix minor offset bug in the WindowRunner.moveToNextDisplay

### DIFF
--- a/App/Sources/Core/Runners/WindowCommandRunner.swift
+++ b/App/Sources/Core/Runners/WindowCommandRunner.swift
@@ -414,7 +414,7 @@ final class WindowCommandRunner {
       let diff = currentPoint - zeroPoint
       let transformedDiff = diff * heightRatio
 
-      y = CGFloat.formula(NSScreen.maxY) { fn in
+      y = CGFloat.formula(mainDisplay.frame.maxY) { fn in
         fn.subtract(nextScreen.frame.origin.y)
         fn.subtract(size.height)
         fn.add(transformedDiff)


### PR DESCRIPTION
- Always rely on the `mainDisplay.frame.maxY` value for the initial
  value when calculating the new y offset.
