### PR TITLE
Improve indexing of open windows for the active application

### DIFF
--- a/App/Sources/Core/Runners/System/SystemCommandRunner.swift
+++ b/App/Sources/Core/Runners/System/SystemCommandRunner.swift
@@ -39,6 +39,7 @@ final class SystemCommandRunner {
       .sink { [weak self]  in
         guard let self else { return }
         self.frontmostApplication = $0
+        self.indexFrontmost($0)
         if self.interactive == false { self.index($0) }
       }
   }


### PR DESCRIPTION
- Before, the user had to stop using the modifier keys for Keyboard Cowboy
  to start indexing windows for the front most application. Now it will
  index the active application when the running application changes which
  makes the whole functionality much easier and more reliable.
