### PR TITLE
Add support for additional application directories

### DIFF
--- a/App/Sources/Core/AppCache.swift
+++ b/App/Sources/Core/AppCache.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum AppCache {
+  static var rootDirectory: URL {
+    try! FileManager.default.url(for: .cachesDirectory,
+                                 in: .userDomainMask,
+                                 appropriateFor: nil,
+                                 create: true)
+    .appendingPathComponent(Bundle.main.bundleIdentifier!)
+  }
+
+  static func domain(_ name: String) throws -> URL {
+    let url = AppCache
+      .rootDirectory
+      .appendingPathComponent(name)
+
+    if !FileManager.default.fileExists(atPath: url.path) {
+      try FileManager.default.createDirectory(
+        at: url,
+        withIntermediateDirectories: true,
+        attributes: nil)
+    }
+
+    return url
+  }
+}

--- a/App/Sources/Core/AppCache.swift
+++ b/App/Sources/Core/AppCache.swift
@@ -23,4 +23,35 @@ enum AppCache {
 
     return url
   }
+
+  static func load<T: Decodable>(_ domain: String, name: String, decoder: JSONDecoder = .init()) throws -> T? {
+    let url = AppCache
+      .rootDirectory
+      .appendingPathComponent(domain)
+      .appending(path: name)
+
+    guard FileManager.default.fileExists(atPath: url.path()) else {
+      return nil
+    }
+
+    let data = try Data(contentsOf: url)
+    return try decoder.decode(T.self, from: data)
+  }
+
+  static func entry(_ domain: String, name: String) -> Entry {
+    let url = AppCache
+      .rootDirectory
+      .appendingPathComponent(domain)
+      .appending(path: name)
+    return Entry(url: url)
+  }
+
+  struct Entry {
+    let url: URL
+    func write<T: Encodable>(_ object: T) throws {
+      let encoder = JSONEncoder()
+      let data = try encoder.encode(object)
+      try data.write(to: url)
+    }
+  }
 }

--- a/App/Sources/Core/AppDelegate.swift
+++ b/App/Sources/Core/AppDelegate.swift
@@ -2,7 +2,7 @@ import Cocoa
 import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-  lazy var coordinator = NotificationCoordinator(.init())
+  lazy var coordinator = NotificationCoordinator(.shared)
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     NSApp.appearance = NSAppearance(named: .darkAqua)

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -20,19 +20,19 @@ final class Core {
 
   lazy private(set) var sidebarCoordinator = SidebarCoordinator(
     groupStore,
-    applicationStore: applicationStore,
+    applicationStore: ApplicationStore.shared,
     configSelectionManager: configSelectionManager,
     groupSelectionManager: groupSelectionManager)
 
   lazy private(set) var contentCoordinator = ContentCoordinator(
     groupStore,
-    applicationStore: applicationStore,
+    applicationStore: ApplicationStore.shared,
     contentSelectionManager: contentSelectionManager,
     groupSelectionManager: groupSelectionManager
   )
 
   lazy private(set) var detailCoordinator = DetailCoordinator(
-    applicationStore: applicationStore,
+    applicationStore: ApplicationStore.shared,
     applicationTriggerSelectionManager: applicationTriggerSelectionManager,
     commandRunner: commandRunner,
     commandSelectionManager: commandSelectionManager,
@@ -63,11 +63,10 @@ final class Core {
 
   // MARK: - Stores
 
-  lazy private(set) var applicationStore = ApplicationStore()
   lazy private(set) var configurationStore = ConfigurationStore()
   lazy private(set) var contentStore = ContentStore(
     Self.config,
-    applicationStore: applicationStore,
+    applicationStore: ApplicationStore.shared,
     configurationStore: configurationStore,
     groupStore: groupStore,
     keyboardShortcutsController: keyboardShortcutsController,
@@ -90,7 +89,7 @@ final class Core {
 
   // MARK: - Runners
   lazy private(set) var commandRunner = CommandRunner(
-    applicationStore: applicationStore,
+    applicationStore: ApplicationStore.shared,
     scriptCommandRunner: scriptCommandRunner,
     keyboardCommandRunner: keyboardCommandRunner)
   lazy private(set) var keyboardCommandRunner = KeyboardCommandRunner(store: keyCodeStore)

--- a/App/Sources/Core/FileWatcher.swift
+++ b/App/Sources/Core/FileWatcher.swift
@@ -1,0 +1,40 @@
+import Dispatch
+import Foundation
+
+enum FileWatcherError: Error {
+  case fileNotFound
+}
+
+final class FileWatcher {
+  let fileSystemMonitor: DispatchSourceFileSystemObject
+
+  init(_ fileURL: URL, handler: @escaping (URL) -> Void) throws {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      throw FileWatcherError.fileNotFound
+    }
+
+    let handle = open(fileURL.path, O_EVTONLY)
+    let eventMask: DispatchSource.FileSystemEvent = [
+      .delete, .write, .extend, .attrib, .link, .rename, .revoke
+    ]
+    let fileSystemMonitor = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: handle,
+      eventMask: eventMask,
+      queue: .main
+    )
+
+    self.fileSystemMonitor = fileSystemMonitor
+
+    fileSystemMonitor.setEventHandler(handler: {
+      handler(fileURL)
+    })
+  }
+
+  func start() {
+    fileSystemMonitor.resume()
+  }
+
+  func stop() {
+    fileSystemMonitor.cancel()
+  }
+}

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -57,11 +57,17 @@ struct KeyboardCowboy: App {
 
     Settings {
       TabView {
+        ApplicationSettingsView()
+          .tabItem { Label("Applications", systemImage: "appclip") }
         PermissionsSettings()
           .tabItem { Label("Permissions", systemImage: "hand.raised.circle.fill") }
       }
-      .frame(width: 360, height: 180, alignment: .top)
+      .environmentObject(OpenPanelController())
     }
+    .windowStyle(.hiddenTitleBar)
+    .windowResizability(.contentSize)
+    .windowToolbarStyle(.unified)
+
 
     WindowGroup(id: KeyboardCowboy.permissionsSettingsWindowIdentifier) {
       PermissionsSettings()
@@ -117,7 +123,7 @@ struct KeyboardCowboy: App {
           }
           .focusScope(namespace)
 
-          .environmentObject(core.applicationStore)
+          .environmentObject(ApplicationStore.shared)
           .environmentObject(core.contentStore)
           .environmentObject(core.groupStore)
           .environmentObject(core.shortcutStore)

--- a/App/Sources/Core/Stores/ContentStore.swift
+++ b/App/Sources/Core/Stores/ContentStore.swift
@@ -50,7 +50,7 @@ final class ContentStore: ObservableObject {
 
     Task {
       Benchmark.start("ContentStore.init")
-      await applicationStore.reload()
+      await applicationStore.load()
       shortcutStore.index()
       let configurations: [KeyboardCowboyConfiguration]
 

--- a/App/Sources/UI/Stores/AppStorageStore.swift
+++ b/App/Sources/UI/Stores/AppStorageStore.swift
@@ -11,4 +11,5 @@ struct AppStorageStore {
   @AppStorage("selectedConfiguration", store: Self.store) var configId: String = ""
   @AppStorage("selectedGroupIds", store: Self.store) var groupIds = Set<String>()
   @AppStorage("selectedWorkflowIds", store: Self.store) var workflowIds = Set<String>()
+  @AppStorage("additionalApplicationPaths", store: Self.store) var additionalApplicationPaths = [String]()
 }

--- a/App/Sources/UI/Stores/ApplicationStore.swift
+++ b/App/Sources/UI/Stores/ApplicationStore.swift
@@ -1,10 +1,25 @@
 import Apps
+import Combine
 import Cocoa
 
 final class ApplicationStore: ObservableObject {
+  static var appStorage: AppStorageStore = .init()
+  private var passthrough = PassthroughSubject<Void, Never>()
+  private var subscription: AnyCancellable?
   private(set) var applicationsByPath = [String: Application]()
   @Published private(set) var applications = [Application]()
   @Published private(set) var dictionary = [String: Application]()
+
+  static let shared = ApplicationStore()
+
+  private init() {
+    subscription = passthrough
+      .debounce(for: 1.0, scheduler: DispatchQueue.main)
+      .sink { [weak self] _ in
+        guard let self else { return }
+        Task { await self.reload() }
+      }
+  }
 
   func applicationsToOpen(_ path: String) -> [Application] {
     guard let url = URL(string: path) else { return [] }
@@ -24,7 +39,9 @@ final class ApplicationStore: ObservableObject {
 
   func reload() async {
     Benchmark.start("ApplicationController.load")
-    let newApplications = await ApplicationController.load()
+    let newApplications = await ApplicationController.load(
+      Self.appStorage.additionalApplicationPaths.map { URL(filePath: $0) }
+    )
     Benchmark.finish("ApplicationController.load")
     var applicationDictionary = [String: Application]()
     var applicationsByPath = [String: Application]()

--- a/App/Sources/UI/Stores/IconCache.swift
+++ b/App/Sources/UI/Stores/IconCache.swift
@@ -62,7 +62,7 @@ actor IconCache {
   // MARK: Private methods
 
   private func load(_ identifier: String) throws -> Data? {
-    let url = try applicationCacheDirectory().appending(component: identifier)
+    let url = try AppCache.domain("IconCache").appending(component: identifier)
 
     if FileManager.default.fileExists(atPath: url.path()) {
       return try? Data(contentsOf: url)
@@ -72,7 +72,7 @@ actor IconCache {
   }
 
   private func save(_ image: NSImage, identifier: String) throws -> Data {
-    let url = try applicationCacheDirectory().appending(component: identifier)
+    let url = try AppCache.domain("IconCache").appending(component: identifier)
 
     guard let tiff = image.tiffRepresentation else {
       throw IconCacheError.unableToObtainTiffRepresentation
@@ -91,23 +91,6 @@ actor IconCache {
     cache.setObject(data as NSData, forKey: identifier as NSString)
 
     return data
-  }
-
-  private func applicationCacheDirectory() throws -> URL {
-    let url = try FileManager.default.url(for: .cachesDirectory,
-                                          in: .userDomainMask,
-                                          appropriateFor: nil,
-                                          create: true)
-      .appendingPathComponent(Bundle.main.bundleIdentifier!)
-      .appendingPathComponent("IconCache")
-
-    if !FileManager.default.fileExists(atPath: url.path) {
-      try FileManager.default.createDirectory(at: url,
-                                              withIntermediateDirectories: true,
-                                              attributes: nil)
-    }
-
-    return url
   }
 }
 

--- a/App/Sources/UI/Views/Extensions/DesignTime+Extensions.swift
+++ b/App/Sources/UI/Views/Extensions/DesignTime+Extensions.swift
@@ -10,7 +10,7 @@ extension View {
       .environmentObject(DesignTime.detailPublisher)
       .environmentObject(DesignTime.groupsPublisher)
       .environmentObject(KeyShortcutRecorderStore())
-      .environmentObject(ApplicationStore())
+      .environmentObject(ApplicationStore.shared)
       .environmentObject(ShortcutStore(ScriptCommandRunner(workspace: .shared)))
   }
 }

--- a/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
+++ b/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
@@ -88,7 +88,7 @@ struct EditWorfklowGroupView_Previews: PreviewProvider {
   static let group = WorkflowGroup.designTime()
   static var previews: some View {
     EditWorfklowGroupView(
-      applicationStore: ApplicationStore(),
+      applicationStore: ApplicationStore.shared,
       group: group,
       action: { _ in })
   }

--- a/App/Sources/UI/Views/Groups/RuleListView.swift
+++ b/App/Sources/UI/Views/Groups/RuleListView.swift
@@ -59,7 +59,7 @@ struct RuleListView: View {
 struct RuleListView_Previews: PreviewProvider {
   static let group = WorkflowGroup.designTime()
   static var previews: some View {
-    RuleListView(applicationStore: ApplicationStore(),
+    RuleListView(applicationStore: ApplicationStore.shared,
                  group: .constant(group))
   }
 }

--- a/App/Sources/UI/Views/Notifications/NotificationListView.swift
+++ b/App/Sources/UI/Views/Notifications/NotificationListView.swift
@@ -70,7 +70,7 @@ struct NotificationView: View {
 }
 
 struct NotificationView_Previews: PreviewProvider {
-  static var coordinator = NotificationCoordinator(.init())
+  static var coordinator = NotificationCoordinator(.shared)
 
   static var previews: some View {
     NotificationListView(publisher: coordinator.publisher)

--- a/App/Sources/UI/Views/Settings/Applications/ApplicationSettingsView.swift
+++ b/App/Sources/UI/Views/Settings/Applications/ApplicationSettingsView.swift
@@ -1,0 +1,96 @@
+import Apps
+import SwiftUI
+
+struct ApplicationSettingsView: View {
+  @EnvironmentObject var openPanel: OpenPanelController
+  @AppStorage("additionalApplicationPaths", store: AppStorageStore.store) var additionalApplicationPaths = [String]()
+
+  @State private var isPresentingPopover: Bool = false
+
+  var body: some View {
+    ScrollView(.vertical) {
+      VStack(alignment: .leading) {
+        Text("Additional directories")
+          .font(.headline)
+
+        VStack {
+          if additionalApplicationPaths.isEmpty {
+            Text("No additional directories")
+              .frame(maxWidth: .infinity)
+          } else {
+            ForEach(additionalApplicationPaths, id: \.self) { path in
+              HStack {
+                Text(path)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                Button(action: {
+                  additionalApplicationPaths.removeAll(where: { $0 == path })
+                }, label: {
+                  Image(systemName: "trash")
+                })
+              }
+            }
+          }
+        }
+
+        Divider()
+
+        HStack {
+          Spacer()
+          Button(action: {
+            openPanel.perform(.selectFolder(handler: { string in
+              guard !additionalApplicationPaths.contains(string) else { return }
+              additionalApplicationPaths.append(string)
+            }))
+          }, label: {
+            HStack(spacing: 4) {
+              Image(systemName: "folder")
+              Divider()
+              Text("Add Folder")
+            }
+          })
+          .buttonStyle(AppButtonStyle(.init(nsColor: .systemBlue)))
+          .font(.callout)
+
+          Button(action: {
+            isPresentingPopover = true
+          }, label: {
+            Image(systemName: "questionmark.app.fill")
+          })
+          .buttonStyle(AppButtonStyle(.init(nsColor: .systemYellow, cornerRadius: 48)))
+          .popover(isPresented: $isPresentingPopover,
+                   arrowEdge: .bottom,
+                   content: {
+            ApplicationSettingsPopoverView()
+          })
+        }
+
+      }
+      .padding(16)
+    }
+    .frame(minWidth: 480, minHeight: 160)
+  }
+}
+
+struct ApplicationSettingsPopoverView: View {
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("Default search directories")
+        .font(.headline)
+        .padding(.horizontal)
+      Divider()
+        .padding(.bottom)
+      ForEach(ApplicationController.commonPaths(), id: \.self) { url in
+        Text(url.absoluteString.replacingOccurrences(of: "file://", with: ""))
+          .padding(.horizontal)
+      }
+      .font(.footnote)
+    }
+    .padding(.vertical)
+  }
+}
+
+#Preview {
+  ApplicationSettingsView()
+    .padding()
+    .environmentObject(OpenPanelController())
+}

--- a/App/Sources/UI/Views/Settings/Permissions/PermissionsSettings.swift
+++ b/App/Sources/UI/Views/Settings/Permissions/PermissionsSettings.swift
@@ -29,6 +29,7 @@ struct PermissionsSettings: View {
       }
     }
     .padding(24)
+    .frame(minWidth: 480)
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
@@ -107,6 +107,6 @@ struct WorkflowApplicationTriggerView_Previews: PreviewProvider {
       selectionManager: SelectionManager(),
       onAction: { _ in }
     )
-    .environmentObject(ApplicationStore())
+    .environmentObject(ApplicationStore.shared)
   }
 }

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let dependencies = Dependencies(
     swiftPackageManager: [
       .remote(url: "https://github.com/krzysztofzablocki/Inject.git", requirement: .exact("1.1.0")),
-      .remote(url: "https://github.com/zenangst/Apps.git", requirement: .exact("1.3.2")),
+      .remote(url: "https://github.com/zenangst/Apps.git", requirement: .exact("1.4.0")),
       .remote(url: "https://github.com/zenangst/AXEssibility.git", requirement: .exact("0.0.6")),
       .remote(url: "https://github.com/zenangst/Dock.git", requirement: .exact("1.0.1")),
       .remote(url: "https://github.com/zenangst/InputSources.git", requirement: .exact("1.0.1")),


### PR DESCRIPTION
We've got some exciting updates in this PR! We've added a cool new feature that allows you to add custom application search paths. This means you can now have Keyboard Cowboy index Window applications that are stored in your home directory, specifically under "~/Applications (Parallels)".

But wait, there's more! We've also rolled out support for application folder monitoring. So, if you're someone who's constantly installing new applications, you're going to love this. No need to restart Keyboard Cowboy every time you install a new app - it'll just show up when you need it.

That's all for now. Looking forward to your feedback!

Fixes https://github.com/zenangst/KeyboardCowboy/issues/378

### Changes
- Add additional application paths to `@AppStorage` 
- Add passthrough subject to `ApplicationStore`, this will be used later when we watch for changes in the application search directories 
- Update Apps framework 
- Add `AppCache` implementation to create cache domains for the application 
- Use `AppCache` in `IconCache` 
- Add application settings view to application settings
- Implement application caching, this improves startup performance
- Monitor application folders for file changes, if there is a change, it will re-index all installed applications.
