### PR TITLE
Fix shellscripts returning warnings

### DIFF
--- a/App/Sources/Core/Runners/Scripting/Plugins/ShellScriptPlugin.swift
+++ b/App/Sources/Core/Runners/Scripting/Plugins/ShellScriptPlugin.swift
@@ -38,6 +38,8 @@ final class ShellScriptPlugin {
         var environment: [String: String] = ProcessInfo.processInfo.environment
         let url = URL(filePath: documentPath)
 
+        environment["TERM"] = "xterm-256color"
+
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
           environment["DIRECTORY"] = (components.path as NSString).deletingLastPathComponent
           environment["FILE"] = url.lastPathComponent
@@ -57,10 +59,10 @@ final class ShellScriptPlugin {
 
     let output: String
 
-    if let errorPipe = try errorPipe.fileHandleForReading.readToEnd() {
-      output = String(data: errorPipe, encoding: .utf8) ?? ""
-    } else if let data = try pipe.fileHandleForReading.readToEnd() {
+    if let data = try pipe.fileHandleForReading.readToEnd() {
       output = String(data: data, encoding: .utf8) ?? ""
+    } else if let errorPipe = try errorPipe.fileHandleForReading.readToEnd() {
+      output = String(data: errorPipe, encoding: .utf8) ?? ""
     } else {
       output = ""
     }

--- a/App/Sources/UI/Views/NewCommand/NewCommandShortcutView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandShortcutView.swift
@@ -41,7 +41,7 @@ struct NewCommandShortcutView: View {
       }
       .background(NewCommandValidationView($validation))
     }
-    .menuStyle(AppMenuStyle(.init(nsColor: .systemGray), fixedSize: false))
+    .menuStyle(AppMenuStyle(.init(nsColor: .systemPurple), fixedSize: false))
     .onChange(of: validation, perform: { newValue in
       guard newValue == .needsValidation else { return }
       withAnimation { validation = updateAndValidatePayload() }


### PR DESCRIPTION
- Change order ot output pipe and error pipe. Regular output is now prioritized.
- Minor UI changes to the new script command view
- Set missing `TERM` in environment for scripts
