### PR TITLE
Add keyboard shortcut for filtering workflows

### DIFF
--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -185,6 +185,13 @@ struct KeyboardCowboy: App {
         )
         .environmentObject(contentStore.groupStore)
       }
+
+      CommandGroup(replacing: .toolbar) {
+        ViewMenu(onFilter: {
+          focus = .search
+        })
+      }
+
       CommandGroup(replacing: .help) {
         HelpMenu()
       }

--- a/App/Sources/UI/Menubar/ViewMenu.swift
+++ b/App/Sources/UI/Menubar/ViewMenu.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct ViewMenu: View {
+  var onFilter: () -> Void
+
+  var body: some View {
+    Button("Filter Workflows", action: onFilter)
+      .keyboardShortcut("f", modifiers: [.option, .command])
+  }
+}


### PR DESCRIPTION
- Add new `ViewMenu` with `Filter Workflows`
- Filter Workflows can be invoked with `Option+Command+F`
