### PR TITLE
Fix scroll to functionality in the workflow list

### DIFF
--- a/App/Sources/UI/Views/ContentListView.swift
+++ b/App/Sources/UI/Views/ContentListView.swift
@@ -137,7 +137,10 @@ struct ContentListView: View {
           })
           .onAppear {
             if let firstSelection = contentSelectionManager.selections.first {
-              proxy.scrollTo(firstSelection)
+              // We need to wait before we tell the proxy to scroll to the first selection.
+              DispatchQueue.main.async {
+                proxy.scrollTo(firstSelection)
+              }
             }
           }
           .toolbar {


### PR DESCRIPTION
Add a small dispatch switch to get the scrollTo method to invoked correctly when the view appears