### PR TITLE
Fix colors not updating when a group changes colors

### DIFF
--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -223,6 +223,7 @@ struct KeyboardCowboy: App {
     EditWorkflowGroupWindow(core.contentStore) { context in
       core.sidebarCoordinator.handle(context)
       core.contentCoordinator.handle(context)
+      core.detailCoordinator.handle(context)
     }
       .windowResizability(.contentSize)
       .windowStyle(.hiddenTitleBar)

--- a/App/Sources/UI/Coordinators/ContentCoordinator.swift
+++ b/App/Sources/UI/Coordinators/ContentCoordinator.swift
@@ -75,9 +75,11 @@ final class ContentCoordinator {
     switch context {
     case .add(let workflowGroup):
       render([workflowGroup.id])
+      contentSelectionManager.selectedColor = Color(hex: workflowGroup.color)
     case .edit(let workflowGroup):
-      let group = SidebarMapper.map(workflowGroup, applicationStore: applicationStore)
-      groupPublisher.publish(group)
+      let workflowGroup = SidebarMapper.map(workflowGroup, applicationStore: applicationStore)
+      contentSelectionManager.selectedColor = Color(hex: workflowGroup.color)
+      groupPublisher.publish(workflowGroup)
       render([workflowGroup.id])
     }
   }

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -47,6 +47,14 @@ final class DetailCoordinator {
     enableInjection(self, selector: #selector(injected(_:)))
   }
 
+  func handle(_ context: EditWorkflowGroupWindow.Context) {
+    switch context {
+    case .add(let workflowGroup), .edit(let workflowGroup):
+      contentSelectionManager.selectedColor = Color(hex: workflowGroup.color)
+      commandSelectionManager.selectedColor = Color(hex: workflowGroup.color)
+    }
+  }
+
   func handle(_ action: SidebarView.Action) {
     switch action {
     case .refresh, .updateConfiguration, .openScene, .addConfiguration, .deleteConfiguraiton:

--- a/App/Sources/UI/Coordinators/SidebarCoordinator.swift
+++ b/App/Sources/UI/Coordinators/SidebarCoordinator.swift
@@ -39,9 +39,11 @@ final class SidebarCoordinator {
     case .add(let group):
       groupId = group.id
       store.add(group)
+      selectionManager.selectedColor = Color(hex: group.color)
     case .edit(let group):
       groupId = group.id
       store.updateGroups([group])
+      selectionManager.selectedColor = Color(hex: group.color)
     }
     selectionManager.publish([groupId])
     if storeWasEmpty {


### PR DESCRIPTION
Push updates to the selection managers when a group is updated.
Previously, the won't change until the group was selected again.