### PR TITLE
Apply scroll to fix to the groups view and use anchoring in content list

### DIFF
--- a/App/Sources/UI/Views/ContentListView.swift
+++ b/App/Sources/UI/Views/ContentListView.swift
@@ -139,7 +139,7 @@ struct ContentListView: View {
             if let firstSelection = contentSelectionManager.selections.first {
               // We need to wait before we tell the proxy to scroll to the first selection.
               DispatchQueue.main.async {
-                proxy.scrollTo(firstSelection)
+                proxy.scrollTo(firstSelection, anchor: .center)
               }
             }
           }

--- a/App/Sources/UI/Views/GroupsListView.swift
+++ b/App/Sources/UI/Views/GroupsListView.swift
@@ -105,6 +105,14 @@ struct GroupsListView: View {
           })
         }
       }
+      .onAppear {
+        if let firstSelection = selectionManager.selections.first {
+          // We need to wait before we tell the proxy to scroll to the first selection.
+          DispatchQueue.main.async {
+            proxy.scrollTo(firstSelection, anchor: .center)
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Just a minor scroll to fix. Groups and the content list now share the same kind of behavior when the views appear.