### PR TITLE
Improve support for UserSpace environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           echo -e "APP_SCHEME=Keyboard-Cowboy" >> .env
           echo -e "APP_BUNDLE_IDENTIFIER=com.zenangst.Keyboard-Cowboy" >> .env
           echo -e "TEAM_ID=XXXXXXXXXX" >> .env
+          echo -e "PACKAGE_DEVELOPMENT=false" >> .env
           brew install tuist
           tuist fetch
           tuist generate -n

--- a/App/Sources/Core/Runners/CommandRunner.swift
+++ b/App/Sources/Core/Runners/CommandRunner.swift
@@ -161,7 +161,7 @@ final class CommandRunner: CommandRunning, @unchecked Sendable {
       case .open(let openCommand):
         let path = snapshot.interpolateUserSpaceVariables(openCommand.path)
         try await runners.open.run(path, application: openCommand.application)
-        output = command.name
+        output = path
       case .script(let scriptCommand):
         let result = try await self.runners.script.run(
           scriptCommand,

--- a/App/Sources/Core/Runners/Open/Plugins/OpenFolderInFinder.swift
+++ b/App/Sources/Core/Runners/Open/Plugins/OpenFolderInFinder.swift
@@ -12,8 +12,7 @@ final class OpenFolderInFinder {
   }
 
   func validate(_ bundleIdentifier: String?) -> Bool {
-    bundleIdentifier?.lowercased() == finderBundleIdentifier ||
-    workspace.frontApplication?.bundleIdentifier?.lowercased() == finderBundleIdentifier
+    bundleIdentifier?.lowercased() == finderBundleIdentifier
   }
 
   func execute(_ path: String) async throws {

--- a/App/Sources/Core/UserSpace.swift
+++ b/App/Sources/Core/UserSpace.swift
@@ -39,7 +39,7 @@ final class UserSpace {
           interpolatedString = interpolatedString
             .replacingOccurrences(of: "$CURRENT_WORKING_DIRECTORY", with: cwd)
             .replacingOccurrences(of: "$DIRECTORY", with: (directory as NSString).deletingLastPathComponent)
-            .replacingOccurrences(of: "$FILEPATH", with: components.path)
+            .replacingOccurrences(of: "$FILEPATH", with: components.path.replacingOccurrences(of: "%20", with: " "))
             .replacingOccurrences(of: "$FILENAME", with: (url.lastPathComponent as NSString).deletingPathExtension)
             .replacingOccurrences(of: "$FILE", with: lastPathComponent as String)
             .replacingOccurrences(of: "$EXTENSION", with: (url.lastPathComponent as NSString).pathExtension)
@@ -65,7 +65,7 @@ final class UserSpace {
           environment["CURRENT_WORKING_DIRECTORY"] = cwd
           environment["DIRECTORY"] = (directory as NSString).deletingLastPathComponent
           environment["FILE"] = url.lastPathComponent
-          environment["FILEPATH"] = components.path
+          environment["FILEPATH"] = components.path.replacingOccurrences(of: "%20", with: " ")
           environment["FILENAME"] = (url.lastPathComponent as NSString).deletingPathExtension
           environment["EXTENSION"] = (url.lastPathComponent as NSString).pathExtension
         }

--- a/App/Sources/Core/UserSpace.swift
+++ b/App/Sources/Core/UserSpace.swift
@@ -1,4 +1,5 @@
 import AXEssibility
+import ScriptingBridge
 import Cocoa
 import Foundation
 
@@ -12,24 +13,35 @@ final class UserSpace {
   struct Snapshot {
     let documentPath: String?
     let selectedText: String
+    let selections: [String]
+
+    init(documentPath: String? = nil, selectedText: String = "", selections: [String] = []) {
+      self.documentPath = documentPath
+      self.selectedText = selectedText
+      self.selections = selections
+    }
 
     func interpolateUserSpaceVariables(_ value: String) -> String {
       var interpolatedString = value.replacingOccurrences(of: "$SELECTED_TEXT", with: selectedText)
 
-      if let documentPath {
-        // Create a URL from the document path
-        let url = URL(fileURLWithPath: documentPath)
+      if let filePath = documentPath, let url = URL(string: filePath) {
         // Attempt to create URLComponents from the URL
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
           // Extract the directory from the path, replacing any URL-encoded spaces
           let directory = (components.path as NSString)
-            .deletingLastPathComponent
             .replacingOccurrences(of: "%20", with: " ")
           // Replace placeholders in the interpolated string with actual values
+          let lastPathComponent = (url.lastPathComponent as NSString)
+          let cwd = lastPathComponent.contains(".")
+              ? (directory as NSString).deletingLastPathComponent
+              : directory
+
           interpolatedString = interpolatedString
-            .replacingOccurrences(of: "$DIRECTORY", with: directory)
-            .replacingOccurrences(of: "$FILE", with: url.lastPathComponent)
+            .replacingOccurrences(of: "$CURRENT_WORKING_DIRECTORY", with: cwd)
+            .replacingOccurrences(of: "$DIRECTORY", with: (directory as NSString).deletingLastPathComponent)
+            .replacingOccurrences(of: "$FILEPATH", with: components.path)
             .replacingOccurrences(of: "$FILENAME", with: (url.lastPathComponent as NSString).deletingPathExtension)
+            .replacingOccurrences(of: "$FILE", with: lastPathComponent as String)
             .replacingOccurrences(of: "$EXTENSION", with: (url.lastPathComponent as NSString).pathExtension)
         }
       }
@@ -40,14 +52,20 @@ final class UserSpace {
       var environment = ProcessInfo.processInfo.environment
       environment["TERM"] = "xterm-256color"
 
-      if let documentPath {
-        let url = URL(filePath: documentPath)
+      if let filePath = documentPath {
+        let url = URL(filePath: filePath)
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
           let directory = (components.path as NSString)
-            .deletingLastPathComponent
             .replacingOccurrences(of: "%20", with: " ")
-          environment["DIRECTORY"] = directory
+          let lastPathComponent = (url.lastPathComponent as NSString)
+          let cwd = lastPathComponent.contains(".")
+          ? (directory as NSString).deletingLastPathComponent
+          : directory
+
+          environment["CURRENT_WORKING_DIRECTORY"] = cwd
+          environment["DIRECTORY"] = (directory as NSString).deletingLastPathComponent
           environment["FILE"] = url.lastPathComponent
+          environment["FILEPATH"] = components.path
           environment["FILENAME"] = (url.lastPathComponent as NSString).deletingPathExtension
           environment["EXTENSION"] = (url.lastPathComponent as NSString).pathExtension
         }
@@ -57,33 +75,92 @@ final class UserSpace {
     }
   }
 
-
   static let shared = UserSpace()
 
   private init() {}
 
   func snapshot() -> Snapshot {
-    Snapshot(documentPath: try? documentPath(),
-             selectedText: selectedText())
+    var selections = [String]()
+    var documentPath: String?
+    var selectedText: String = ""
+
+    if let frontmostApplication = try? frontmostApplication() {
+      if let documentPathFromAX = try? self.documentPath(for: frontmostApplication) {
+        documentPath = documentPathFromAX
+      } else if let bundleIdentifier = frontmostApplication.bundleIdentifier,
+                let application: ApplicationWithSelection = SBApplication(bundleIdentifier: bundleIdentifier) {
+        if let items = application.selection?.get() as? [SBObject] {
+          if items.isEmpty, let windows = application.windows?.get() as? [SBObject] {
+            // Check for location of the first open Finder window
+            for ref in windows {
+              let url = (ref as WindowObject).target?.URL
+              documentPath = url
+              break
+            }
+          } else {
+            // There is at least one item in the selection
+            for ref in items {
+              let item = ref as FileObject
+              if let urlString = item.URL {
+                if documentPath == nil { documentPath = urlString }
+                selections.append(urlString)
+              }
+            }
+          }
+        }
+      }
+
+      if let resolvedText = try? self.selectedText(for: frontmostApplication) {
+        selectedText = resolvedText
+      }
+    }
+
+    return Snapshot(documentPath: documentPath,
+                    selectedText: selectedText,
+                    selections: selections)
   }
 
-  private func currentApplication() throws -> AppAccessibilityElement {
+  private func frontmostApplication() throws -> NSRunningApplication {
     guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else {
       throw WindowCommandRunnerError.unableToResolveFrontmostApplication
     }
 
-    return AppAccessibilityElement(frontmostApplication.processIdentifier)
+    return frontmostApplication
   }
 
-  private func documentPath() throws -> String? {
-    try currentApplication()
+  private func currentApplication(for runningApplication: NSRunningApplication) throws -> AppAccessibilityElement {
+    return AppAccessibilityElement(runningApplication.processIdentifier)
+  }
+
+  private func documentPath(for runningApplication: NSRunningApplication) throws -> String? {
+    try currentApplication(for: runningApplication)
       .focusedWindow()
       .document
   }
 
-  private func selectedText() -> String {
-    (try? currentApplication()
+  private func selectedText(for runningApplication: NSRunningApplication) throws -> String {
+    try currentApplication(for: runningApplication)
       .focusedUIElement()
-      .selectedText()) ?? ""
+      .selectedText() ?? ""
   }
 }
+
+@objc protocol ApplicationWithSelection {
+  @objc optional var selection: SBElementArray { get }
+  @objc optional var windows: SBElementArray { get }
+}
+
+@objc protocol WindowObject {
+  @objc optional var target: FileObject { get }
+  @objc optional var name: String { get }
+  @objc optional var index: Int { get }
+}
+
+@objc protocol FileObject {
+  @objc optional var name: String { get }
+  @objc optional var URL: String { get }
+}
+
+extension SBApplication: ApplicationWithSelection {}
+extension SBObject: FileObject {}
+extension SBObject: WindowObject {}

--- a/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
@@ -173,7 +173,8 @@ final class DetailCommandActionReducer {
               return
             }
             let command = ApplicationCommand(application: shortcutsApp)
-            try await commandRunner.run(.application(command), snapshot: .init(documentPath: nil, selectedText: ""))
+            try await commandRunner.run(.application(command), 
+                                        snapshot: .init())
           }
         case .commandAction(let action):
           DetailCommandContainerActionReducer.reduce(action, command: &command, workflow: &workflow)

--- a/Project.swift
+++ b/Project.swift
@@ -133,6 +133,7 @@ let project = Project(
     FileElement(stringLiteral: "ci_scripts"),
     FileElement(stringLiteral: "Fixtures"),
     FileElement(stringLiteral: "Project.swift"),
+    FileElement(stringLiteral: "README.md"),
     FileElement(stringLiteral: "Tuist/Dependencies.swift"),
     FileElement(stringLiteral: "appcast.xml"),
     FileElement(stringLiteral: "gh-pages"),

--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ For more information about [tuist](https://tuist.io), refer to the projects READ
 Create a new `.env` file in the root folder.
 Add the following contents to the `.env`-file.
 
-```
+```fish
 APP_NAME=Keyboard Cowboy
 APP_SCHEME=Keyboard-Cowboy
 APP_BUNDLE_IDENTIFIER=com.zenangst.Keyboard-Cowboy
 TEAM_ID=XXXXXXXXXX
+PACKAGE_DEVELOPMENT=false
 ```
 
 #### Generating an Xcode project


### PR DESCRIPTION
 - Use the interpolated path for the notification output for the open commands
 - Fix validation checking if the current application is Finder in the `validate` function
 - Add support for getting selections and extended support for `documentPath` when using Finder
 - Add $CURRENT_WORKING_DIRECTORY env variable in `UserSpace`
 - Leverage from `ScriptingBridge` to get the current Finder selection(s) as URL strings
