### PR TITLE
Refactor shortcut related actions for streamlined user experience

### DIFF
--- a/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailCommandActionReducer.swift
@@ -152,6 +152,8 @@ final class DetailCommandActionReducer {
         }
       case .shortcut(let action, _, _):
         switch action {
+        case .createShortcut:
+          try? SBShortcuts.createShortcut()
         case .updateShortcut(let shortcutName):
           command = .shortcut(
             .init(
@@ -166,16 +168,8 @@ final class DetailCommandActionReducer {
         case .updateName(let newName):
           command.name = newName
           workflow.updateOrAddCommand(command)
-        case .openShortcuts:
-          Task {
-            guard let shortcutsApp = ApplicationStore.shared.applications
-              .first(where: { $0.bundleIdentifier.lowercased() == "com.apple.shortcuts" }) else {
-              return
-            }
-            let command = ApplicationCommand(application: shortcutsApp)
-            try await commandRunner.run(.application(command), 
-                                        snapshot: .init())
-          }
+        case .openShortcut:
+          try? SBShortcuts.openShortcut(command.name)
         case .commandAction(let action):
           DetailCommandContainerActionReducer.reduce(action, command: &command, workflow: &workflow)
           workflow.updateOrAddCommand(command)

--- a/App/Sources/UI/Views/Commands/ShortcutCommandView.swift
+++ b/App/Sources/UI/Views/Commands/ShortcutCommandView.swift
@@ -5,7 +5,8 @@ struct ShortcutCommandView: View {
   enum Action {
     case updateName(newName: String)
     case updateShortcut(shortcutName: String)
-    case openShortcuts
+    case createShortcut
+    case openShortcut
     case commandAction(CommandContainerAction)
   }
 
@@ -56,8 +57,12 @@ struct ShortcutCommandView: View {
       }
     }, subContent: { command in
       HStack {
-        Button("Open Shortcuts", action: { onAction(.openShortcuts) })
-          .buttonStyle(.zen(.init(color: .systemPurple)))
+        Button("Open Shortcut", action: { onAction(.openShortcut) })
+          .buttonStyle(.zen(.init(color: .systemPurple, grayscaleEffect: .constant(true))))
+          .font(.caption)
+
+        Button("Create Shortcut", action: { onAction(.createShortcut) })
+          .buttonStyle(.zen(.init(color: .systemPurple, grayscaleEffect: .constant(true))))
           .font(.caption)
       }
     }, onAction: { onAction(.commandAction($0)) })


### PR DESCRIPTION
Replace `Open Shortcuts` button with `Open Shortcut`, the new button will now opens the shortcut in the Shortcuts app.
Add new to create a new shortcut in the Shortcuts app

Special thanks to swiftbar ❤️
https://github.com/swiftbar/SwiftBar
