### PR TITLE
Improve UI for keyboard shortcuts

### DIFF
--- a/App/Sources/UI/Views/Commands/KeyboardCommandView.swift
+++ b/App/Sources/UI/Views/Commands/KeyboardCommandView.swift
@@ -44,7 +44,7 @@ struct KeyboardCommandView: View {
           .scaleEffect(0.8)
         }
       }, content: { command in
-        VStack {
+        VStack(spacing: 10) {
           HStack(spacing: 0) {
             TextField("", text: $metaData.name)
               .textFieldStyle(.regular(Color(.windowBackgroundColor)))
@@ -61,8 +61,7 @@ struct KeyboardCommandView: View {
           .onChange(of: model.keys) { newValue in
             onAction(.updateKeyboardShortcuts(newValue))
           }
-          .padding(.vertical, 4)
-          .background(Color(.textBackgroundColor).opacity(0.45).cornerRadius(4))
+          .roundedContainer(padding: 0, margin: 0)
         }
       },
       subContent: { _ in },

--- a/App/Sources/UI/Views/EditableKeyboardShortcutsItemView.swift
+++ b/App/Sources/UI/Views/EditableKeyboardShortcutsItemView.swift
@@ -28,7 +28,7 @@ struct EditableKeyboardShortcutsItemView: View {
         .fixedSize(horizontal: true, vertical: true)
     }
     .contentShape(Rectangle())
-    .padding(4)
+    .padding(2)
     .overlay(BorderedOverlayView(cornerRadius: 4))
     .overlay(alignment: .topTrailing, content: {
       Button(action: {
@@ -45,10 +45,11 @@ struct EditableKeyboardShortcutsItemView: View {
       .animation(.smooth, value: isHovered)
     })
     .background(
-      RoundedRectangle(cornerRadius: 6, style: .continuous)
-        .stroke(Color(.disabledControlTextColor))
+      RoundedRectangle(cornerRadius: 5, style: .continuous)
+        .stroke(Color(.disabledControlTextColor).opacity(0.6))
         .opacity(0.5)
     )
+    .padding(.horizontal, 2)
     .draggable(keyboardShortcut.draggablePayload(prefix: "WKS|", selections: selectionManager.selections))
     .dropDestination(for: String.self) { items, location in
       guard let payload = items.draggablePayload(prefix: "WKS|"),

--- a/App/Sources/UI/Views/KeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/KeyboardTriggerView.swift
@@ -1,8 +1,10 @@
-import Combine
-import SwiftUI
 import Bonzai
+import Combine
+import Inject
+import SwiftUI
 
 struct KeyboardTriggerView: View {
+  @ObserveInjection var inject
   @State private var holdDurationText = ""
   @State private var passthrough: Bool
   @State private var trigger: DetailViewModel.KeyboardTrigger
@@ -33,7 +35,7 @@ struct KeyboardTriggerView: View {
   }
 
   var body: some View {
-    VStack {
+    VStack(spacing: 8) {
       HStack {
         Label("Keyboard Shortcuts Sequence", image: "")
         Spacer()
@@ -74,6 +76,7 @@ struct KeyboardTriggerView: View {
       .font(.caption2)
     }
     .padding(.horizontal, 8)
+    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/NewCommand/NewCommandKeyboardShortcutView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandKeyboardShortcutView.swift
@@ -1,6 +1,9 @@
+import Bonzai
+import Inject
 import SwiftUI
 
 struct NewCommandKeyboardShortcutView: View {
+  @ObserveInjection var inject
   enum CurrentState: Hashable {
     case recording
   }
@@ -40,10 +43,6 @@ struct NewCommandKeyboardShortcutView: View {
         onTab: { _ in })
         .overlay(NewCommandValidationView($validation))
         .frame(minHeight: 48, maxHeight: 48)
-        .background(
-          RoundedRectangle(cornerRadius: 4)
-            .fill(Color(.textBackgroundColor).opacity(0.25))
-        )
     }
     .onChange(of: keyboardShortcuts, perform: { newValue in
       validation = updateAndValidatePayload()
@@ -55,6 +54,7 @@ struct NewCommandKeyboardShortcutView: View {
     .onAppear {
       validation = .unknown
     }
+    .enableInjection()
   }
 
   @discardableResult

--- a/App/Sources/UI/Views/WorkflowShortcutsView.swift
+++ b/App/Sources/UI/Views/WorkflowShortcutsView.swift
@@ -1,7 +1,9 @@
-import SwiftUI
 import Bonzai
+import Inject
+import SwiftUI
 
 struct WorkflowShortcutsView: View {
+  @ObserveInjection var inject
   @Binding private var data: [KeyShortcut]
   private var focus: FocusState<AppFocus?>.Binding
   private let onUpdate: ([KeyShortcut]) -> Void
@@ -29,16 +31,13 @@ struct WorkflowShortcutsView: View {
         focus.wrappedValue = .detail(.name)
       }
     })
-      .frame(minHeight: 48, maxHeight: 48)
-      .background(
-        RoundedRectangle(cornerRadius: 8)
-          .fill(Color(.textBackgroundColor).opacity(0.65))
-      )
-      .padding(.vertical, 6)
-      .onChange(of: data, perform: { newValue in
-        onUpdate(newValue)
-      })
-      .focused(focus, equals: .detail(.keyboardShortcuts))
+    .roundedContainer(padding: 2, margin: 0)
+    .frame(minHeight: 45, maxHeight: 45)
+    .onChange(of: data, perform: { newValue in
+      onUpdate(newValue)
+    })
+    .focused(focus, equals: .detail(.keyboardShortcuts))
+    .enableInjection()
   }
 }
 


### PR DESCRIPTION
- Tweak the layout by changing padding and margins
- Use `Bonzai.roundedContainer` as background for the horizontal
  keyboard shortcut container
