### PR TITLE
Increase the minimum size of the new command window

### DIFF
--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -174,7 +174,7 @@ struct KeyboardCowboy: App {
         core.contentCoordinator.handle(.refresh(groupIds))
       }
     }
-    .defaultSize(.init(width: 520, height: 280))
+    .defaultSize(.init(width: 520, height: 500))
     .defaultPosition(.center)
 
     EditWorkflowGroupWindow(core.contentStore, configurationPublisher: core.configCoordinator.configurationPublisher) { context in

--- a/App/Sources/UI/Views/NewCommand/NewCommandView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandView.swift
@@ -90,7 +90,7 @@ struct NewCommandView: View {
           })
       }
     }
-    .frame(minWidth: 710, minHeight: 410)
+    .frame(minWidth: 710, minHeight: 500)
   }
 
   private func sidebar() -> some View {


### PR DESCRIPTION
The new command window is now larger in height so that the user can see all the command types.
