### PR TITLE
Minor update

### DIFF
--- a/App/Sources/Core/Controllers/ApplicationTriggerController.swift
+++ b/App/Sources/Core/Controllers/ApplicationTriggerController.swift
@@ -1,5 +1,6 @@
 import Combine
 import Cocoa
+import MachPort
 
 final class ApplicationTriggerController {
   private let commandRunner: CommandRunning
@@ -94,12 +95,15 @@ final class ApplicationTriggerController {
 
   private func runCommands(in workflow: Workflow) {
     let commands = workflow.commands.filter(\.isEnabled)
+    guard let machPortEvent = MachPortEvent.empty() else { return }
     switch workflow.execution {
     case .concurrent:
       commandRunner.concurrentRun(
         commands,
         checkCancellation: true,
         resolveUserEnvironment: workflow.resolveUserEnvironment(),
+        shortcut: .empty(),
+        machPortEvent: machPortEvent,
         repeatingEvent: false
       )
     case .serial:
@@ -107,6 +111,8 @@ final class ApplicationTriggerController {
         commands,
         checkCancellation: true,
         resolveUserEnvironment: workflow.resolveUserEnvironment(),
+        shortcut: .empty(),
+        machPortEvent: machPortEvent,
         repeatingEvent: false
       )
     }

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -72,13 +72,20 @@ final class Core {
     recorderStore: recorderStore,
     shortcutStore: shortcutStore,
     scriptCommandRunner: scriptCommandRunner)
+  lazy private(set) var macroCoordinator = MacroCoordinator()
   lazy private(set) var groupStore = GroupStore()
   lazy private(set) var keyCodeStore = KeyCodesStore(InputSourceController())
+  lazy private(set) var workflowRunner = WorkflowRunner(commandRunner: commandRunner,
+                                                        store: keyCodeStore, notifications: notifications)
+  lazy private(set) var notifications = MachPortUINotifications(keyboardShortcutsController: keyboardShortcutsController)
   lazy private(set) var machPortCoordinator = MachPortCoordinator(store: keyboardCommandRunner.store,
                                                                   commandRunner: commandRunner,
                                                                   keyboardCommandRunner: keyboardCommandRunner,
                                                                   keyboardShortcutsController: keyboardShortcutsController,
-                                                                  mode: .intercept)
+                                                                  macroCoordinator: macroCoordinator,
+                                                                  mode: .intercept,
+                                                                  notifications: notifications,
+                                                                  workflowRunner: workflowRunner)
   lazy private(set) var engine = KeyboardCowboyEngine(
     contentStore,
     commandRunner: commandRunner,

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -104,7 +104,7 @@ final class Core {
   // MARK: - Runners
   lazy private(set) var commandRunner = CommandRunner(
     applicationStore: ApplicationStore.shared,
-    builtInCommandRunner: BuiltInCommandRunner(configurationStore: configurationStore),
+    builtInCommandRunner: BuiltInCommandRunner(configurationStore: configurationStore, macroRunner: macroRunner),
     scriptCommandRunner: scriptCommandRunner,
     keyboardCommandRunner: keyboardCommandRunner,
     uiElementCommandRunner: uiElementCommandRunner
@@ -112,6 +112,7 @@ final class Core {
   lazy private(set) var keyboardCommandRunner = KeyboardCommandRunner(store: keyCodeStore)
   lazy private(set) var uiElementCommandRunner = UIElementCommandRunner()
   lazy private(set) var scriptCommandRunner = ScriptCommandRunner(workspace: .shared)
+  lazy private(set) var macroRunner = MacroRunner(coordinator: macroCoordinator)
 
   // MARK: - Controllers
 

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -79,7 +79,6 @@ final class Core {
                                                         store: keyCodeStore, notifications: notifications)
   lazy private(set) var notifications = MachPortUINotifications(keyboardShortcutsController: keyboardShortcutsController)
   lazy private(set) var machPortCoordinator = MachPortCoordinator(store: keyboardCommandRunner.store,
-                                                                  commandRunner: commandRunner,
                                                                   keyboardCommandRunner: keyboardCommandRunner,
                                                                   keyboardShortcutsController: keyboardShortcutsController,
                                                                   macroCoordinator: macroCoordinator,

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -61,6 +61,7 @@ struct KeyboardCowboy: App {
 
     PermissionsWindow()
     PermissionsScene(onAction: handlePermissionAction(_:))
+    ReleaseNotesScene()
 
     NewCommandWindow(contentStore: core.contentStore, 
                      uiElementCaptureStore: core.uiElementCaptureStore,
@@ -91,6 +92,11 @@ struct KeyboardCowboy: App {
           handleAppScene(.permissions)
           return
         }
+
+        if AppStorageContainer.shared.releaseNotes < KeyboardCowboy.marektingVersion {
+          openWindow(id: KeyboardCowboy.releaseNotesWindowIdentifier)
+        }
+
       }
     case .openMainWindow:
       handleAppScene(.mainWindow)
@@ -131,5 +137,11 @@ struct KeyboardCowboy: App {
       openWindow(id: KeyboardCowboy.permissionsSettingsWindowIdentifier)
       AccessibilityPermission.shared.requestPermission()
     }
+  }
+}
+
+private extension String {
+  static func < (lhs: String, rhs: String) -> Bool {
+    return lhs.compare(rhs, options: .numeric) == .orderedAscending
   }
 }

--- a/App/Sources/Core/Models/Commands/BuildInCommand.swift
+++ b/App/Sources/Core/Models/Commands/BuildInCommand.swift
@@ -40,7 +40,6 @@ struct BuiltInCommand: MetaDataProviding {
       switch self {
         case .macro(let action):
           switch action.kind {
-            case .list: "List Macros"
             case .remove: "Remove Macro"
             case .record: "Record Macro"
           }

--- a/App/Sources/Core/Models/Commands/BuildInCommand.swift
+++ b/App/Sources/Core/Models/Commands/BuildInCommand.swift
@@ -11,34 +11,45 @@ struct BuiltInCommand: MetaDataProviding {
       case toggle
     }
 
+    case macro(MacroAction)
     case userMode(UserMode, Action)
 
     var id: String {
       switch self {
-        case .userMode(let id, let action):
+        case .macro(let macro):
+          return macro.id
+      case .userMode(let id, let action):
         return switch action {
-        case .enable: "enable-\(id)"
-        case .disable: "disable-\(id)"
-        case .toggle: "toggle-\(id)"
+          case .enable: "enable-\(id)"
+          case .disable: "disable-\(id)"
+          case .toggle: "toggle-\(id)"
         }
       }
     }
 
     var userModeId: UserMode.ID {
       switch self {
+        case .macro(let action):
+          return action.id
         case .userMode(let model, _):
-        return model.id
+          return model.id
       }
     }
 
     public var displayValue: String {
       switch self {
+        case .macro(let action):
+          switch action.kind {
+            case .list: "List Macros"
+            case .remove: "Remove Macro"
+            case .record: "Record Macro"
+          }
         case .userMode(_, let action):
-        return switch action {
-        case .enable: "Enable User Mode"
-        case .disable: "Disable User Mode"
-        case .toggle: "Toggle User Mode"
-        }
+          switch action {
+            case .enable: "Enable User Mode"
+            case .disable: "Disable User Mode"
+            case .toggle: "Toggle User Mode"
+          }
       }
     }
   }

--- a/App/Sources/Core/Models/KeyboardCowboyMode.swift
+++ b/App/Sources/Core/Models/KeyboardCowboyMode.swift
@@ -1,6 +1,7 @@
 enum KeyboardCowboyMode {
   case intercept
   case recordKeystroke
+  case recordMacro
   case captureUIElement
   case disabled
 }

--- a/App/Sources/Core/Models/MacroAction.swift
+++ b/App/Sources/Core/Models/MacroAction.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct MacroAction: Identifiable, Codable, Hashable, Sendable  {
+  let id: String
+  let kind: Kind
+
+  enum Kind: Codable {
+    case list
+    case record
+    case remove
+  }
+}

--- a/App/Sources/Core/Models/MacroAction.swift
+++ b/App/Sources/Core/Models/MacroAction.swift
@@ -5,7 +5,6 @@ struct MacroAction: Identifiable, Codable, Hashable, Sendable  {
   let kind: Kind
 
   enum Kind: Codable {
-    case list
     case record
     case remove
   }
@@ -20,7 +19,6 @@ struct MacroAction: Identifiable, Codable, Hashable, Sendable  {
     self.kind = kind
   }
 
-  static var list: MacroAction { MacroAction(.list) }
   static var record: MacroAction { MacroAction(.record) }
   static var remove: MacroAction { MacroAction(.remove) }
 }

--- a/App/Sources/Core/Models/MacroAction.swift
+++ b/App/Sources/Core/Models/MacroAction.swift
@@ -9,4 +9,18 @@ struct MacroAction: Identifiable, Codable, Hashable, Sendable  {
     case record
     case remove
   }
+
+  init(id: String, kind: Kind) {
+    self.id = id
+    self.kind = kind
+  }
+
+  init(_ kind: Kind, id: String = UUID().uuidString) {
+    self.id = id
+    self.kind = kind
+  }
+
+  static var list: MacroAction { MacroAction(.list) }
+  static var record: MacroAction { MacroAction(.record) }
+  static var remove: MacroAction { MacroAction(.remove) }
 }

--- a/App/Sources/Core/Runners/BuiltInCommandRunner.swift
+++ b/App/Sources/Core/Runners/BuiltInCommandRunner.swift
@@ -2,17 +2,22 @@ import Foundation
 
 final class BuiltInCommandRunner {
   let configurationStore: ConfigurationStore
+  let macroRunner: MacroRunner
 
-  init(configurationStore: ConfigurationStore) {
+  init(configurationStore: ConfigurationStore,
+       macroRunner: MacroRunner) {
     self.configurationStore = configurationStore
+    self.macroRunner = macroRunner
   }
 
   func run(_ command: BuiltInCommand) async throws -> String {
     return switch command.kind {
-    case .userMode(let model, let action): try await UserModesRunner(
-      configurationStore: configurationStore
-    )
-    .run(model, builtInCommand: command, action: action)
+      case .macro(let action):
+        await macroRunner.run(action)
+      case .userMode(let model, let action): try await UserModesRunner(
+        configurationStore: configurationStore
+      )
+      .run(model, builtInCommand: command, action: action)
     }
   }
 }

--- a/App/Sources/Core/Runners/BuiltInCommandRunner.swift
+++ b/App/Sources/Core/Runners/BuiltInCommandRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MachPort
 
 final class BuiltInCommandRunner {
   let configurationStore: ConfigurationStore
@@ -10,14 +11,16 @@ final class BuiltInCommandRunner {
     self.macroRunner = macroRunner
   }
 
-  func run(_ command: BuiltInCommand) async throws -> String {
+  func run(_ command: BuiltInCommand, 
+           shortcut: KeyShortcut,
+           machPortEvent: MachPortEvent) async throws -> String {
     return switch command.kind {
       case .macro(let action):
-        await macroRunner.run(action)
-      case .userMode(let model, let action): try await UserModesRunner(
-        configurationStore: configurationStore
-      )
-      .run(model, builtInCommand: command, action: action)
+        await macroRunner
+          .run(action, shortcut: shortcut, machPortEvent: machPortEvent)
+      case .userMode(let model, let action):
+        try await UserModesRunner(configurationStore: configurationStore)
+        .run(model, builtInCommand: command, action: action)
     }
   }
 }

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -161,7 +161,7 @@ final class MachPortCoordinator {
 
     // If there is a match, then run the workflow
     let readyToRunMacro = mode == .intercept && macroCoordinator.state == .idle
-    if readyToRunMacro, let macro = macroCoordinator.match(shortcut) {
+    if readyToRunMacro, let macro = macroCoordinator.match(keyboardShortcut) {
       if machPortEvent.type == .keyUp {
         for element in macro {
           switch element {
@@ -176,6 +176,11 @@ final class MachPortCoordinator {
       }
 
       machPortEvent.result = nil
+      return
+    } else if macroCoordinator.state == .removing {
+      if machPortEvent.type == .keyDown {
+        macroCoordinator.remove(keyboardShortcut, machPortEvent: machPortEvent)
+      }
       return
     }
 

--- a/App/Sources/Core/Runners/MacroCoordinator.swift
+++ b/App/Sources/Core/Runners/MacroCoordinator.swift
@@ -42,6 +42,15 @@ final class MacroCoordinator {
               kind: MacroKind,
               machPortEvent: MachPortEvent) {
     if let recordingKey {
+      if shortcut.machPortKeyId == recordingKey.machPortKeyId {
+        machPortEvent.result = nil
+        state = .idle
+        Task { @MainActor [bezelId] in
+          BezelNotificationController.shared.post(.init(id: bezelId, text: "Recorded Macro for \(shortcut.modifersDisplayValue) \(shortcut.key)"))
+        }
+        return
+      }
+
       if macros[recordingKey] == nil {
         macros[recordingKey] = [kind]
       } else {

--- a/App/Sources/Core/Runners/MacroCoordinator.swift
+++ b/App/Sources/Core/Runners/MacroCoordinator.swift
@@ -1,0 +1,86 @@
+import Foundation
+import MachPort
+
+enum MacroKind {
+  case event(_ machPortEvent: MachPortEvent)
+  case workflow(_ workflow: Workflow)
+}
+
+final class MacroCoordinator {
+  private var currentBundleIdentifier: String = Bundle.main.bundleIdentifier!
+  private var macros = [MacroKey: [MacroKind]]()
+  private var newMacroKey: MachPortKeyboardShortcut?
+  private var recordingKey: MacroKey?
+
+  private let bezelId = "com.apple.zenangst.Keyboard-Cowboy.macros"
+  private let recordKey = MacroRecordKey(key: "r", modifiers: [.function, .command])
+  private let userSpace = UserSpace.shared
+
+  func matchesRecorderKey(_ shortcut: MachPortKeyboardShortcut, 
+                          mode: inout KeyboardCowboyMode,
+                          machPortEvent: MachPortEvent) -> Bool {
+    guard recordKey.matches(shortcut) else { return false }
+
+    if machPortEvent.type == .keyUp {
+      let text: String
+      if let newMacroKey {
+        text = "Recorded Macro for \(newMacroKey.original.modifersDisplayValue) \(newMacroKey.uppercase.key)"
+        self.recordingKey = nil
+        self.newMacroKey = nil
+        mode = .intercept
+      } else {
+        text = "Choose Macro key..."
+        mode = .recordMacro
+      }
+
+      Task { @MainActor [bezelId] in
+        BezelNotificationController.shared.post(.init(id: bezelId, text: text))
+      }
+    }
+
+    return true
+  }
+
+  func record(_ shortcut: MachPortKeyboardShortcut,
+              kind: MacroKind,
+              machPortEvent: MachPortEvent) {
+    if let recordingKey {
+      if macros[recordingKey] == nil {
+        macros[recordingKey] = [kind]
+      } else {
+        macros[recordingKey]?.append(kind)
+      }
+    } else {
+      let recordingKey = MacroKey(bundleIdentifier: userSpace.frontMostApplication.bundleIdentifier,
+                                  machPortKeyId: shortcut.id)
+      self.newMacroKey = shortcut
+      macros[recordingKey] = nil
+      self.recordingKey = recordingKey
+      Task { @MainActor [bezelId] in
+        BezelNotificationController.shared.post(.init(id: bezelId, text: "Recording Macro for \(shortcut.original.modifersDisplayValue) \(shortcut.uppercase.key)"))
+      }
+      machPortEvent.result = nil
+    }
+  }
+
+  func matchesMacroKey(_ shortcut: MachPortKeyboardShortcut, machPortEvent: MachPortEvent) -> [MacroKind]? {
+    let macroKey = MacroKey(bundleIdentifier: userSpace.frontMostApplication.bundleIdentifier,
+                            machPortKeyId: shortcut.id)
+    return macros[macroKey]
+  }
+}
+
+struct MacroKey: Hashable {
+  let bundleIdentifier: String
+  let machPortKeyId: String
+}
+
+struct MacroRecordKey {
+  let key: String
+  let modifiers: [ModifierKey]
+
+  func matches(_ shortcut: MachPortKeyboardShortcut) -> Bool {
+    shortcut.original.key == key &&
+    Set(shortcut.original.modifiers) == Set(modifiers)
+  }
+}

--- a/App/Sources/Core/Runners/MacroRunner.swift
+++ b/App/Sources/Core/Runners/MacroRunner.swift
@@ -19,7 +19,7 @@ final class MacroRunner {
       case .record:
         if let newMacroKey = coordinator.newMacroKey {
           coordinator.state = .idle
-          output = "Recorded Macro for \(newMacroKey.modifersDisplayValue) \(newMacroKey.key)"
+          output = "Recorded Macro for \(newMacroKey.original.modifersDisplayValue) \(newMacroKey.uppercase.key)"
         } else {
           coordinator.state = .recording
           output = "Choose Macro key..."

--- a/App/Sources/Core/Runners/MacroRunner.swift
+++ b/App/Sources/Core/Runners/MacroRunner.swift
@@ -1,13 +1,37 @@
 import Foundation
+import MachPort
 
 final class MacroRunner {
   private let coordinator: MacroCoordinator
+  private let bezelId = "com.zenangst.Keyboard-Cowboy.MacroRunner"
 
   init(coordinator: MacroCoordinator) {
     self.coordinator = coordinator
   }
 
-  func run(_ macroAction: MacroAction) async -> String {
-    ""
+  func run(_ macroAction: MacroAction, 
+           shortcut: KeyShortcut,
+           machPortEvent: MachPortEvent) async -> String {
+    let output: String
+    switch macroAction.kind {
+      case .list:
+        output = "List Macros"
+      case .record:
+        if let newMacroKey = coordinator.newMacroKey {
+          coordinator.state = .idle
+          output = "Recorded Macro for \(newMacroKey.modifersDisplayValue) \(newMacroKey.key)"
+        } else {
+          coordinator.state = .recording
+          output = "Choose Macro key..."
+        }
+      case .remove:
+        output = "Remove Macro key..."
+    }
+
+    Task { @MainActor [bezelId] in
+      BezelNotificationController.shared.post(.init(id: bezelId, text: output))
+    }
+
+    return output
   }
 }

--- a/App/Sources/Core/Runners/MacroRunner.swift
+++ b/App/Sources/Core/Runners/MacroRunner.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class MacroRunner {
+  private let coordinator: MacroCoordinator
+
+  init(coordinator: MacroCoordinator) {
+    self.coordinator = coordinator
+  }
+
+  func run(_ macroAction: MacroAction) async -> String {
+    ""
+  }
+}

--- a/App/Sources/Core/Runners/MacroRunner.swift
+++ b/App/Sources/Core/Runners/MacroRunner.swift
@@ -25,6 +25,7 @@ final class MacroRunner {
           output = "Choose Macro key..."
         }
       case .remove:
+        coordinator.state = .removing
         output = "Remove Macro key..."
     }
 

--- a/App/Sources/Core/Runners/MacroRunner.swift
+++ b/App/Sources/Core/Runners/MacroRunner.swift
@@ -14,8 +14,6 @@ final class MacroRunner {
            machPortEvent: MachPortEvent) async -> String {
     let output: String
     switch macroAction.kind {
-      case .list:
-        output = "List Macros"
       case .record:
         if let newMacroKey = coordinator.newMacroKey {
           coordinator.state = .idle

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -1,0 +1,47 @@
+import Carbon
+import Foundation
+
+final class WorkflowRunner {
+  private let commandRunner: CommandRunner
+  private let store: KeyCodesStore
+  private let notifications: MachPortUINotifications
+
+  init(commandRunner: CommandRunner, store: KeyCodesStore, 
+       notifications: MachPortUINotifications) {
+    self.commandRunner = commandRunner
+    self.store = store
+    self.notifications = notifications
+  }
+
+  func run(_ workflow: Workflow, repeatingEvent: Bool) {
+    notifications.notifyRunningWorkflow(workflow)
+    let commands = workflow.commands.filter(\.isEnabled)
+
+    /// Determines whether the command runner should check for cancellation.
+    /// If the workflow is triggered by a keyboard shortcut that is a passthrough and consists of only one shortcut,
+    /// and that shortcut is the escape key, then cancellation checking is disabled.
+    var checkCancellation: Bool = true
+    if let trigger = workflow.trigger,
+       case .keyboardShortcuts(let keyboardShortcutTrigger) = trigger,
+       keyboardShortcutTrigger.passthrough,
+       keyboardShortcutTrigger.shortcuts.count == 1 {
+      let shortcut = keyboardShortcutTrigger.shortcuts[0]
+      let displayValue = store.displayValue(for: kVK_Escape)
+      if shortcut.key == displayValue {
+        checkCancellation = false
+      }
+    }
+
+    let resolveUserEnvironment = workflow.resolveUserEnvironment()
+    switch workflow.execution {
+    case .concurrent:
+      commandRunner.concurrentRun(commands, checkCancellation: checkCancellation,
+                                  resolveUserEnvironment: resolveUserEnvironment,
+                                  repeatingEvent: repeatingEvent)
+    case .serial:
+      commandRunner.serialRun(commands, checkCancellation: checkCancellation,
+                              resolveUserEnvironment: resolveUserEnvironment,
+                              repeatingEvent: repeatingEvent)
+    }
+  }
+}

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -1,5 +1,6 @@
 import Carbon
 import Foundation
+import MachPort
 
 final class WorkflowRunner {
   private let commandRunner: CommandRunner
@@ -13,7 +14,8 @@ final class WorkflowRunner {
     self.notifications = notifications
   }
 
-  func run(_ workflow: Workflow, repeatingEvent: Bool) {
+  func run(_ workflow: Workflow, for shortcut: KeyShortcut,
+           machPortEvent: MachPortEvent, repeatingEvent: Bool) {
     notifications.notifyRunningWorkflow(workflow)
     let commands = workflow.commands.filter(\.isEnabled)
 
@@ -37,10 +39,12 @@ final class WorkflowRunner {
     case .concurrent:
       commandRunner.concurrentRun(commands, checkCancellation: checkCancellation,
                                   resolveUserEnvironment: resolveUserEnvironment,
+                                  shortcut: shortcut, machPortEvent: machPortEvent,
                                   repeatingEvent: repeatingEvent)
     case .serial:
       commandRunner.serialRun(commands, checkCancellation: checkCancellation,
                               resolveUserEnvironment: resolveUserEnvironment,
+                              shortcut: shortcut, machPortEvent: machPortEvent,
                               repeatingEvent: repeatingEvent)
     }
   }

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -15,6 +15,7 @@ final class WorkflowRunner {
   }
 
   func run(_ workflow: Workflow, for shortcut: KeyShortcut,
+           executionOverride: Workflow.Execution? = nil,
            machPortEvent: MachPortEvent, repeatingEvent: Bool) {
     notifications.notifyRunningWorkflow(workflow)
     let commands = workflow.commands.filter(\.isEnabled)
@@ -35,7 +36,7 @@ final class WorkflowRunner {
     }
 
     let resolveUserEnvironment = workflow.resolveUserEnvironment()
-    switch workflow.execution {
+    switch executionOverride ?? workflow.execution {
     case .concurrent:
       commandRunner.concurrentRun(commands, checkCancellation: checkCancellation,
                                   resolveUserEnvironment: resolveUserEnvironment,

--- a/App/Sources/Core/Stores/WindowStore.swift
+++ b/App/Sources/Core/Stores/WindowStore.swift
@@ -146,10 +146,15 @@ final class WindowStore {
 
   private func indexFrontmost() {
     do {
+      let forbiddenSubroles = [
+        NSAccessibility.Subrole.systemDialog.rawValue,
+        NSAccessibility.Subrole.dialog.rawValue
+      ]
       state.frontMostApplicationWindows = try state.appAccessibilityElement.windows()
         .filter({
           $0.id > 0 &&
-          ($0.size?.height ?? 0) > 20
+          ($0.size?.height ?? 0) > 20 &&
+          !forbiddenSubroles.contains($0.subrole ?? "")
         })
     } catch { }
   }

--- a/App/Sources/UI/Menubar/HelpMenu.swift
+++ b/App/Sources/UI/Menubar/HelpMenu.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct HelpMenu: View {
+  @Environment(\.openWindow) private var openWindow
+
   var body: some View {
+    Button { openWindow(id: KeyboardCowboy.releaseNotesWindowIdentifier) } label: { Text("What's new?") }
+
     Button(action: {
       NSWorkspace.shared.open(URL(string: "https://github.com/zenangst/KeyboardCowboy/wiki")!)
     }, label: {

--- a/App/Sources/UI/Reducers/DetailViewActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailViewActionReducer.swift
@@ -1,5 +1,6 @@
 import Apps
 import Foundation
+import MachPort
 import SwiftUI
 
 enum DetailViewActionReducerResult {
@@ -143,27 +144,29 @@ final class DetailViewActionReducer {
           }
         }
       case .updateExecution(_, let execution):
-        switch execution {
-        case .concurrent:
-          workflow.execution = .concurrent
-        case .serial:
-          workflow.execution = .serial
-        }
+          switch execution {
+            case .concurrent:
+              workflow.execution = .concurrent
+            case .serial:
+              workflow.execution = .serial
+          }
       case .runWorkflow:
+        guard let machPortEvent = MachPortEvent.empty() else { return .none }
+
         let commands = workflow.commands.filter(\.isEnabled)
         switch workflow.execution {
         case .concurrent:
           commandRunner.concurrentRun(
-            commands,
-            checkCancellation: true,
-            resolveUserEnvironment: true,
+            commands, checkCancellation: true,
+            resolveUserEnvironment: true, shortcut: .empty(),
+            machPortEvent: machPortEvent,
             repeatingEvent: false
           )
         case .serial:
           commandRunner.serialRun(
-            commands,
-            checkCancellation: true,
-            resolveUserEnvironment: true,
+            commands, checkCancellation: true,
+            resolveUserEnvironment: true, shortcut: .empty(),
+            machPortEvent: machPortEvent,
             repeatingEvent: false
           )
         }

--- a/App/Sources/UI/Stores/AppStorageContainer.swift
+++ b/App/Sources/UI/Stores/AppStorageContainer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-final class AppStorageContainer {
+final class AppStorageContainer: @unchecked Sendable {
   #if DEBUG
   static let store = UserDefaults(suiteName: "com.zenangst.Keyboard-Cowboy.debug")
   #else
@@ -16,4 +16,5 @@ final class AppStorageContainer {
   @AppStorage("selectedGroupIds", store: store) var groupIds = Set<String>()
   @AppStorage("selectedWorkflowIds", store: store) var workflowIds = Set<String>()
   @AppStorage("additionalApplicationPaths", store: store) var additionalApplicationPaths = [String]()
+  @AppStorage("ReleaseNotes") var releaseNotes: String = ""
 }

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -28,12 +28,20 @@ struct BuiltInCommandView: View {
   var body: some View {
     Group {
       CommandContainerView($metaData, placeholder: model.placheolder) { command in
-        switch command.icon.wrappedValue {
-        case .some(let icon):
-          IconView(icon: icon, size: iconSize)
-        case .none:
-          EmptyView()
+
+        switch model.kind {
+        case .macro(let macroAction):
+          switch macroAction.kind {
+          case .record: MacroIconView(.record, size: iconSize.width)
+          case .remove: MacroIconView(.remove, size: iconSize.width)
+          }
+        case .userMode:
+          switch command.icon.wrappedValue {
+          case .some(let icon): IconView(icon: icon, size: iconSize)
+          case .none: EmptyView()
+          }
         }
+
       } content: { _ in
         HStack {
           Menu(content: {
@@ -53,15 +61,6 @@ struct BuiltInCommandView: View {
               model.kind = newKind
             }, label: {
               Text("Remove Macro").font(.subheadline)
-            })
-
-            Button(action: {
-              let newKind: BuiltInCommand.Kind = .macro(.list)
-              onAction(.update(.init(id: model.id, kind: newKind, notification: true)))
-              model.name = newKind.displayValue
-              model.kind = newKind
-            }, label: {
-              Text("List Macros").font(.subheadline)
             })
 
             Button(

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -72,12 +72,11 @@ struct BuiltInCommandView: View {
             ForEach(configurationPublisher.data.userModes) { userMode in
               Button(action: {
                 let action: BuiltInCommand.Kind.Action
-                switch model.kind {
-                   case .userMode(_, let resolvedAction):
+                if case .userMode(_, let resolvedAction) = model.kind {
                   action = resolvedAction
+                  onAction(.update(.init(id: model.id, kind: .userMode(userMode, action), notification: true)))
+                  model.kind = .userMode(userMode, action)
                 }
-                onAction(.update(.init(id: model.id, kind: .userMode(userMode, action), notification: true)))
-                model.kind = .userMode(userMode, action)
               }, label: { Text(userMode.name).font(.subheadline) })
             }
           }, label: {

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -37,6 +37,33 @@ struct BuiltInCommandView: View {
       } content: { _ in
         HStack {
           Menu(content: {
+            Button(action: {
+              let newKind: BuiltInCommand.Kind = .macro(.record)
+              onAction(.update(.init(id: model.id, kind: newKind, notification: true)))
+              model.name = newKind.displayValue
+              model.kind = newKind
+            }, label: {
+              Text("Record Macro").font(.subheadline)
+            })
+
+            Button(action: {
+              let newKind: BuiltInCommand.Kind = .macro(.remove)
+              onAction(.update(.init(id: model.id, kind: newKind, notification: true)))
+              model.name = newKind.displayValue
+              model.kind = newKind
+            }, label: {
+              Text("Remove Macro").font(.subheadline)
+            })
+
+            Button(action: {
+              let newKind: BuiltInCommand.Kind = .macro(.list)
+              onAction(.update(.init(id: model.id, kind: newKind, notification: true)))
+              model.name = newKind.displayValue
+              model.kind = newKind
+            }, label: {
+              Text("List Macros").font(.subheadline)
+            })
+
             Button(
               action: {
                 let newKind: BuiltInCommand.Kind = .userMode(.init(id: model.kind.userModeId, name: model.name, isEnabled: true), .toggle)
@@ -68,21 +95,28 @@ struct BuiltInCommandView: View {
               .font(.subheadline)
           })
           .fixedSize()
-          Menu(content: {
-            ForEach(configurationPublisher.data.userModes) { userMode in
-              Button(action: {
-                let action: BuiltInCommand.Kind.Action
-                if case .userMode(_, let resolvedAction) = model.kind {
-                  action = resolvedAction
-                  onAction(.update(.init(id: model.id, kind: .userMode(userMode, action), notification: true)))
-                  model.kind = .userMode(userMode, action)
+
+          switch model.kind {
+            case .macro(let macroAction):
+              EmptyView()
+            case .userMode(let userMode, let action):
+              Menu(content: {
+                ForEach(configurationPublisher.data.userModes) { userMode in
+                  Button(action: {
+                    let action: BuiltInCommand.Kind.Action
+                    if case .userMode(_, let resolvedAction) = model.kind {
+                      action = resolvedAction
+                      onAction(.update(.init(id: model.id, kind: .userMode(userMode, action), notification: true)))
+                      model.kind = .userMode(userMode, action)
+                    }
+                  }, label: { Text(userMode.name).font(.subheadline) })
                 }
-              }, label: { Text(userMode.name).font(.subheadline) })
-            }
-          }, label: {
-            Text(configurationPublisher.data.userModes.first(where: { model.kind.id.contains($0.id) })?.name ?? "Pick a User Mode")
-              .font(.subheadline)
-          })
+              }, label: {
+                Text(configurationPublisher.data.userModes.first(where: { model.kind.id.contains($0.id) })?.name ?? "Pick a User Mode")
+                  .font(.subheadline)
+              })
+          }
+
         }
           .menuStyle(.regular)
       } subContent: { _ in

--- a/App/Sources/UI/Views/ContentImageView.swift
+++ b/App/Sources/UI/Views/ContentImageView.swift
@@ -12,8 +12,20 @@ struct ContentImageView: View {
       ContentIconImageView(icon: icon, size: size)
     case .command(let kind):
       switch kind {
-      case .application, .open, .builtIn:
+      case .application, .open:
         EmptyView()
+      case .builtIn(let model):
+        switch model.kind {
+        case .macro(let action):
+          switch action.kind {
+          case .record:
+            MacroIconView(.record, size: size - 6)
+          case .remove:
+            MacroIconView(.remove, size: size - 6)
+          }
+        case .userMode:
+          EmptyView()
+        }
       case .keyboard(let model):
         if let firstKey = model.keys.first {
           KeyboardIconView(firstKey.key.uppercased(), size: size - 6)

--- a/App/Sources/UI/Views/Extensions/KeyboardCowboy+Extensions.swift
+++ b/App/Sources/UI/Views/Extensions/KeyboardCowboy+Extensions.swift
@@ -4,6 +4,7 @@ extension KeyboardCowboy {
   static let mainWindowIdentifier = "MainWindow"
   static let permissionsSettingsWindowIdentifier = "PermissionsSettingsWindow"
   static let permissionsWindowIdentifier = "PermissionsWindow"
+  static let releaseNotesWindowIdentifier = "ReleaseNotesWindow"
 
   static var bundleIdentifier: String { Bundle.main.bundleIdentifier! }
 

--- a/App/Sources/UI/Views/Extensions/View+Extensions.swift
+++ b/App/Sources/UI/Views/Extensions/View+Extensions.swift
@@ -22,6 +22,41 @@ extension View {
   }
 
   @ViewBuilder
+  func iconOverlay() -> some View {
+    AngularGradient(stops: [
+      .init(color: Color.clear, location: 0.0),
+      .init(color: Color.white.opacity(0.2), location: 0.2),
+      .init(color: Color.clear, location: 1.0),
+    ], center: .bottomLeading)
+
+    LinearGradient(stops: [
+      .init(color: Color.white.opacity(0.2), location: 0),
+      .init(color: Color.clear, location: 0.3),
+    ], startPoint: .top, endPoint: .bottom)
+
+    LinearGradient(stops: [
+      .init(color: Color.clear, location: 0.8),
+      .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
+    ], startPoint: .top, endPoint: .bottom)
+
+    LinearGradient(stops: [
+      .init(color: Color.clear, location: 0.8),
+      .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
+    ], startPoint: .top, endPoint: .bottom)
+  }
+
+  func iconBorder(_ size: CGFloat) -> some View {
+    LinearGradient(stops: [
+      .init(color: Color(.white).opacity(0.15), location: 0.25),
+      .init(color: Color(.black).opacity(0.25), location: 1.0),
+    ], startPoint: .top, endPoint: .bottom)
+    .mask {
+      RoundedRectangle(cornerRadius: size * 0.2)
+        .stroke(lineWidth: size * 0.025)
+    }
+  }
+
+  @ViewBuilder
   func transform<Transform: View>(_ transform: (Self) -> Transform) -> some View {
     transform(self)
   }

--- a/App/Sources/UI/Views/Icons/ActivateLastApplicationIconView.swift
+++ b/App/Sources/UI/Views/Icons/ActivateLastApplicationIconView.swift
@@ -5,35 +5,26 @@ struct ActivateLastApplicationIconView: View {
   var body: some View {
     Rectangle()
       .fill(Color(nsColor: .systemPink))
-      .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color.white.opacity(0.2), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-      }
+      .overlay { iconOverlay().opacity(0.5) }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .center) {
-        Image(systemName: "app")
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .frame(width: size * 0.7)
-      }
-      .overlay(alignment: .center) {
-        Image(systemName: "arrowshape.turn.up.backward.fill")
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .frame(width: size * 0.35)
-          .offset(x: -size * 0.015, y: -size * 0.015)
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .white), location: 0.35),
+          .init(color: Color(nsColor: .systemPink.blended(withFraction: 0.2, of: .white)!), location: 1.0),
+        ], startPoint: .topLeading, endPoint: .bottom)
+        .mask {
+          ZStack {
+            Image(systemName: "app")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: size * 0.7)
+            Image(systemName: "arrowshape.turn.up.backward.fill")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: size * 0.35)
+              .offset(x: -size * 0.015, y: -size * 0.015)
+          }
+        }
       }
       .frame(width: size, height: size)
       .fixedSize()

--- a/App/Sources/UI/Views/Icons/BugFixIconView.swift
+++ b/App/Sources/UI/Views/Icons/BugFixIconView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct BugFixIconView: View {
+  let size: CGFloat
+  var body: some View {
+    Rectangle()
+      .fill(
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .systemGreen), location: 0.25),
+          .init(color: Color(nsColor: .systemGreen.blended(withFraction: 0.25, of: NSColor.black)!), location: 1.0),
+        ], startPoint: .top, endPoint: .bottom)
+      )
+      .overlay { iconOverlay().opacity(0.5) }
+      .overlay { iconBorder(size) }
+      .overlay {
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .systemGreen.blended(withFraction: 0.8, of: .white)!), location: 0.4),
+          .init(color: Color(nsColor: .systemGreen), location: 1.0),
+        ], startPoint: .topLeading, endPoint: .bottom)
+        .mask {
+          Image(systemName: "ladybug")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+        }
+        .frame(width: size * 0.6)
+        .shadow(radius: 2)
+      }
+      .iconShape(size)
+      .frame(width: size, height: size)
+  }
+}
+
+#Preview {
+  HStack(alignment: .top, spacing: 8) {
+    BugFixIconView(size: 192)
+    VStack(alignment: .leading, spacing: 8) {
+      BugFixIconView(size: 128)
+      HStack(alignment: .top, spacing: 8) {
+        BugFixIconView(size: 64)
+        BugFixIconView(size: 32)
+        BugFixIconView(size: 16)
+      }
+    }
+  }
+  .padding()
+}
+

--- a/App/Sources/UI/Views/Icons/DockIconView.swift
+++ b/App/Sources/UI/Views/Icons/DockIconView.swift
@@ -6,23 +6,8 @@ struct DockIconView: View {
   var body: some View {
     RoundedRectangle(cornerRadius: 4)
       .fill(Color(.controlAccentColor))
-      .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color.white.opacity(0.2), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-      }
+      .overlay { iconOverlay() }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .top) {
         Rectangle()
           .opacity(0.6)

--- a/App/Sources/UI/Views/Icons/IconOverview.swift
+++ b/App/Sources/UI/Views/Icons/IconOverview.swift
@@ -10,14 +10,16 @@ struct IconOverview: PreviewProvider {
         MenuIconView(size: size)
         MouseIconView(size: size)
         MissionControlIconView(size: size)
+        ScriptIconView(size: size)
       }
 
       HStack {
-        ScriptIconView(size: size)
         TypingIconView(size: size)
         UIElementIconView(size: size)
         WindowManagementIconView(size: size)
         MinimizeAllIconView(size: size)
+        BugFixIconView(size: size)
+        ImprovementIconView(size: size)
       }
 
       HStack {
@@ -26,10 +28,10 @@ struct IconOverview: PreviewProvider {
         MacroIconView(.remove, size: size)
         MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
         MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
       }
 
       HStack {
-        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
         MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
         MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
         MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)

--- a/App/Sources/UI/Views/Icons/IconOverview.swift
+++ b/App/Sources/UI/Views/Icons/IconOverview.swift
@@ -22,13 +22,15 @@ struct IconOverview: PreviewProvider {
 
       HStack {
         ActivateLastApplicationIconView(size: size)
+        MacroIconView(.record, size: size)
+        MacroIconView(.remove, size: size)
         MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
         MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
-        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
-        MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
       }
 
       HStack {
+        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
+        MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
         MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
         MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
       }

--- a/App/Sources/UI/Views/Icons/ImprovementIconView.swift
+++ b/App/Sources/UI/Views/Icons/ImprovementIconView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct ImprovementIconView: View {
+  let size: CGFloat
+
+  var body: some View {
+    Rectangle()
+      .fill(
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .textBackgroundColor), location: 0.25),
+          .init(color: Color(nsColor: .textBackgroundColor.blended(withFraction: 0.1, of: .black)!), location: 1),
+        ], startPoint: .top, endPoint: .bottom)
+      )
+      .overlay { iconOverlay() }
+      .overlay { iconBorder(size) }
+      .overlay {
+        LinearGradient(stops: [
+          .init(color: Color(.systemYellow), location: 0),
+          .init(color: Color.orange, location: 1)
+        ], startPoint: .top, endPoint: .bottom)
+        .mask {
+          VStack(alignment: .leading, spacing: 0) {
+              Text("LEVEL")
+                .font(Font.system(size: size * 0.25, weight: .heavy, design: .rounded))
+              HStack(spacing: 0) {
+                Text("UP")
+                  .font(Font.system(size: size * 0.3, weight: .heavy, design: .rounded))
+                Image(systemName: "arrowshape.turn.up.left.fill")
+                  .resizable()
+                  .aspectRatio(contentMode: .fit)
+                  .rotationEffect(.degrees(90))
+                  .frame(width: size * 0.35)
+            }
+          }
+        }
+        .padding(size * 0.05)
+        .shadow(color: Color(.systemYellow), radius: 3, y: 1)
+      }
+      .iconShape(size)
+      .frame(width: size, height: size)
+  }
+}
+
+#Preview {
+  HStack(alignment: .top, spacing: 8) {
+    ImprovementIconView(size: 192)
+    VStack(alignment: .leading, spacing: 8) {
+      ImprovementIconView(size: 128)
+      HStack(alignment: .top, spacing: 8) {
+        ImprovementIconView(size: 64)
+        ImprovementIconView(size: 32)
+        ImprovementIconView(size: 16)
+      }
+    }
+  }
+  .padding()
+}
+

--- a/App/Sources/UI/Views/Icons/KeyboardIconView.swift
+++ b/App/Sources/UI/Views/Icons/KeyboardIconView.swift
@@ -15,6 +15,7 @@ struct KeyboardIconView: View {
   var body: some View {
     Rectangle()
       .fill(Color(.textBackgroundColor))
+      .overlay { iconOverlay().opacity(0.2) }
       .overlay {
         AngularGradient(stops: [
           .init(color: Color.clear, location: 0.0),
@@ -32,6 +33,7 @@ struct KeyboardIconView: View {
           .init(color: Color(.windowBackgroundColor), location: 1.0),
         ], startPoint: .top, endPoint: .bottom)
       }
+      .overlay { iconBorder(size).opacity(0.5) }
       .overlay {
         Text(letter)
           .font(Font.system(size: size * 0.3, weight: .regular, design: .rounded))

--- a/App/Sources/UI/Views/Icons/MacroIconView.swift
+++ b/App/Sources/UI/Views/Icons/MacroIconView.swift
@@ -19,7 +19,8 @@ struct MacroIconView: View {
                       : .systemYellow)
     Rectangle()
       .fill(color)
-      .overlay { overlay() }
+      .overlay { iconOverlay().opacity(0.25) }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .center) {
         backgroundShape(color: color)
           .scaleEffect(0.8)

--- a/App/Sources/UI/Views/Icons/MacroIconView.swift
+++ b/App/Sources/UI/Views/Icons/MacroIconView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+struct MacroIconView: View {
+  enum Kind {
+    case record
+    case remove
+  }
+  let kind: Kind
+  let size: CGFloat
+
+  init(_ kind: Kind, size: CGFloat) {
+    self.kind = kind
+    self.size = size
+  }
+
+  var body: some View {
+    let color = Color(kind == .record 
+                      ? .systemCyan
+                      : .systemYellow)
+    Rectangle()
+      .fill(color)
+      .overlay { overlay() }
+      .overlay(alignment: .center) {
+        backgroundShape(color: color)
+          .scaleEffect(0.8)
+          .rotation3DEffect(.degrees(30), axis: (x: 1.0, y: 0.0, z: 0.0))
+          .offset(y: -size * 0.225)
+
+        backgroundShape(color: color)
+          .scaleEffect(0.9)
+          .rotation3DEffect(.degrees(15), axis: (x: 1.0, y: 0.0, z: 0.0))
+          .offset(y: -size * 0.125)
+
+        Text("MACRO")
+          .frame(minWidth: size * 0.9, minHeight: size * 0.4)
+          .font(Font.system(size: size * 0.225, weight: .heavy, design: .rounded))
+          .foregroundColor(color)
+          .allowsTightening(true)
+          .padding(size * 0.02)
+          .overlay {
+            RoundedRectangle(cornerRadius: size * 0.05)
+              .fill(.black)
+              .frame(width: size * 0.9, height: size * 0.025)
+              .opacity(kind == .record ? 0 : 1)
+          }
+          .background {
+            RoundedRectangle(cornerRadius: size * 0.05)
+              .fill(Color(.textBackgroundColor))
+              .overlay(overlay())
+              .shadow(radius: 2, y: 2)
+          }
+      }
+      .overlay(alignment: .bottomTrailing) {
+        RoundedRectangle(cornerRadius: size * 0.05)
+          .fill(Color(kind == .record ? .systemGreen : .systemRed))
+          .overlay {
+            Image(systemName: kind == .record ? "plus" : "minus")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .fontWeight(.heavy)
+              .frame(width: size * 0.15, height: size * 0.15)
+          }
+          .overlay(content: {
+            overlay()
+              .mask(RoundedRectangle(cornerRadius: size * 0.05))
+              .shadow(radius: 2)
+          })
+          .background {
+            RoundedRectangle(cornerRadius: size * 0.05)
+              .stroke(Color(.white).opacity(0.75), lineWidth: size * 0.0075)
+              .offset(y: size * 0.015)
+          }
+          .frame(width: size * 0.25, height: size * 0.25)
+          .offset(x: -size * 0.075, y: -size * 0.075)
+      }
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
+  }
+
+  @ViewBuilder
+  func overlay() -> some View {
+    AngularGradient(stops: [
+      .init(color: Color.clear, location: 0.0),
+      .init(color: Color.white.opacity(0.2), location: 0.2),
+      .init(color: Color.clear, location: 1.0),
+    ], center: .bottomLeading)
+
+    LinearGradient(stops: [
+      .init(color: Color.white.opacity(0.2), location: 0),
+      .init(color: Color.clear, location: 0.3),
+    ], startPoint: .top, endPoint: .bottom)
+
+    LinearGradient(stops: [
+      .init(color: Color.clear, location: 0.8),
+      .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
+    ], startPoint: .top, endPoint: .bottom)
+  }
+
+  func backgroundShape(color: Color) -> some View {
+    Rectangle()
+      .fill(color)
+      .overlay {
+        RoundedRectangle(cornerRadius: size * 0.05)
+          .stroke(Color(.textBackgroundColor), lineWidth: size * 0.0175)
+      }
+      .frame(width: size * 0.9, height: size * 0.4)
+      .shadow(radius: 2, y: 2)
+  }
+}
+
+#Preview {
+  VStack {
+    HStack(alignment: .top, spacing: 8) {
+      MacroIconView(.record, size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        MacroIconView(.record, size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          MacroIconView(.record, size: 64)
+          MacroIconView(.record, size: 32)
+          MacroIconView(.record, size: 16)
+        }
+      }
+    }
+
+    HStack(alignment: .top, spacing: 8) {
+      MacroIconView(.remove, size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        MacroIconView(.remove, size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          MacroIconView(.remove, size: 64)
+          MacroIconView(.remove, size: 32)
+          MacroIconView(.remove, size: 16)
+        }
+      }
+    }
+  }
+  .padding()
+}

--- a/App/Sources/UI/Views/Icons/MenuIconView.swift
+++ b/App/Sources/UI/Views/Icons/MenuIconView.swift
@@ -17,6 +17,8 @@ struct MenuIconView: View {
           endPoint: .bottom
         )
       )
+      .overlay { iconOverlay().opacity(0.65) }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .top) {
         Rectangle()
           .fill(Color(.white).opacity(0.4))

--- a/App/Sources/UI/Views/Icons/MinimizeAllIconView.swift
+++ b/App/Sources/UI/Views/Icons/MinimizeAllIconView.swift
@@ -6,23 +6,8 @@ struct MinimizeAllIconView: View {
   var body: some View {
     Rectangle()
       .fill(Color(nsColor: .systemBrown))
-      .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color.white.opacity(0.2), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-      }
+      .overlay { iconOverlay() }
+      .overlay { iconBorder(size) }
       .overlay {
         window(.init(width: (size * 0.85) * 0.8,
                      height: (size * 0.75) * 0.8))

--- a/App/Sources/UI/Views/Icons/MissionControlIconView.swift
+++ b/App/Sources/UI/Views/Icons/MissionControlIconView.swift
@@ -6,23 +6,8 @@ struct MissionControlIconView: View {
   var body: some View {
     RoundedRectangle(cornerRadius: 4)
       .fill(Color(nsColor: .systemIndigo))
-      .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color.white.opacity(0.2), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-      }
+      .overlay { iconOverlay().opacity(0.65) }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .center, content: {
         HStack(spacing: size * 0.03) {
           VStack(alignment: .trailing, spacing: size * 0.08) {

--- a/App/Sources/UI/Views/Icons/MouseIconView.swift
+++ b/App/Sources/UI/Views/Icons/MouseIconView.swift
@@ -5,23 +5,9 @@ struct MouseIconView: View {
   var body: some View {
     Rectangle()
       .fill(Color(.systemGreen))
+      .overlay { iconOverlay().opacity(0.65) }
+      .overlay { iconBorder(size) }
       .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color.white.opacity(0.2), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-
         Capsule()
           .fill(Color(.white))
           .frame(width: size * 0.45, height: size * 0.8)

--- a/App/Sources/UI/Views/Icons/MoveFocusToWindowIconView.swift
+++ b/App/Sources/UI/Views/Icons/MoveFocusToWindowIconView.swift
@@ -18,6 +18,7 @@ struct MoveFocusToWindowIconView: View {
     RoundedRectangle(cornerRadius: 4)
       .fill(baseColor(for: scope))
       .overlay { background() }
+      .overlay { iconBorder(size) }
       .overlay(content: {
         HStack(spacing: size * 0.0_140) {
           if scope == .allWindows {

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -124,7 +124,11 @@ struct Release3_22_0: View {
               .mask { Circle() }
           } placeholder: {
             Circle()
+              .fill(Color(.controlAccentColor))
               .frame(width: 24, height: 24)
+              .overlay {
+                ProgressView()
+              }
           }
           Link("@bforpc", destination: URL(string: "https://github.com/bforpc")!)
           Text("for supporting the project ❤️")
@@ -136,7 +140,7 @@ struct Release3_22_0: View {
       .padding(.horizontal, 16)
 
       HStack(spacing: 8) {
-        Button(action: { action(.done) }, label: { Text("About Macros") })
+        Button(action: { action(.wiki) }, label: { Text("About Macros") })
         .buttonStyle(.zen(.init(color: .systemCyan, hoverEffect: .constant(false))))
 
         Button(action: { action(.done) }, label: { Text("Got it!") })

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -101,6 +101,9 @@ struct Release3_22_0: View {
                   Text("Keyboard-, Menubar- & Window Management Commands now work better with repeating events")
                     .frame(maxWidth: .infinity, alignment: .leading)
 
+                  Text("Window-hopping within your go-to app just got a snappy upgrade—slick, reliable, and ready to roll!")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
                   Text("Icons revamped – a subtle glow-up for your visual pleasure!")
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -98,7 +98,7 @@ struct Release3_22_0: View {
               HStack(alignment: .top, spacing: 12) {
                 ImprovementIconView(size: 24)
                 VStack(spacing: 12) {
-                  Text("Keyboard-, Menubar- & Window Management Commands now work better with repeating events")
+                  Text("Smooth Operator: Your Keyboard, Menu, and Window Commands now nail those encores like a pro!")
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                   Text("Window-hopping within your go-to app just got a snappy upgrade—slick, reliable, and ready to roll!")

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -1,4 +1,126 @@
+import Bonzai
 import SwiftUI
+
+struct Release3_22_0: View {
+  let size: CGFloat = 128
+  let action: () -> Void
+  var body: some View {
+    VStack(spacing: 8) {
+      HStack(spacing: 16) {
+        ZStack {
+          MacroIconView(.record, size: size)
+            .scaleEffect(0.8)
+            .offset(y: -24)
+            .opacity(0.5)
+          MacroIconView(.record, size: size)
+            .scaleEffect(0.9)
+            .offset(y: -12)
+            .shadow(radius: 2)
+            .opacity(0.5)
+          MacroIconView(.record, size: size)
+            .shadow(radius: 2)
+        }
+        VStack(alignment: .leading) {
+          Text("Keyboard Cowboy")
+            .font(Font.system(size: 16, design: .rounded))
+          Text("3.22.0")
+            .foregroundStyle(.white)
+            .font(Font.system(size: 43, design: .rounded))
+            .allowsTightening(true)
+            .fontWeight(.heavy)
+            .shadow(color: Color(.systemCyan), radius: 10)
+        }
+        .shadow(radius: 2)
+        .frame(width: 268, height: size)
+        .fixedSize()
+        .background {
+          Rectangle()
+            .fill(.black)
+            .overlay {
+              AngularGradient(stops: [
+                .init(color: Color.clear, location: 0.0),
+                .init(color: Color.white.opacity(0.2), location: 0.2),
+                .init(color: Color.clear, location: 1.0),
+              ], center: .bottomLeading)
+
+              LinearGradient(stops: [
+                .init(color: Color.white.opacity(0.2), location: 0),
+                .init(color: Color.clear, location: 0.3),
+              ], startPoint: .top, endPoint: .bottom)
+
+              LinearGradient(stops: [
+                .init(color: Color.clear, location: 0.8),
+                .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
+              ], startPoint: .top, endPoint: .bottom)
+
+            }
+        }
+        .iconShape(size)
+      }
+      .padding(.top, 32)
+
+      ZenDivider()
+        .frame(maxWidth: 400)
+        .padding(.top, 8)
+
+      VStack(alignment: .leading, spacing: 16) {
+        HStack(spacing: 12) {
+          MacroIconView(.record, size: 32)
+          Text("Macros: Make Every Keystroke Count!")
+            .font(Font.system(.title2, design: .rounded, weight: .bold))
+        }
+        Text("Rev up your routine with Macros — where doing less isn't just more; it's epic. Say hello to keyboard wizardry that conjures up workflows in the blink of an eye.")
+          .fixedSize(horizontal: false, vertical: true)
+        Text("With Macros, you're not just efficient, you're effortlessly epic!")
+        Divider()
+        HStack(spacing: 4) {
+          Text("Special thanks to")
+          AsyncImage.init(url: URL(string: "https://avatars.githubusercontent.com/u/5180591?v=4")) { image in
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 24, height: 24)
+              .mask { Circle() }
+          } placeholder: {
+            Circle()
+              .frame(width: 24, height: 24)
+          }
+
+          Link("@bforpc", destination: URL(string: "https://github.com/bforpc")!)
+          Text("for supporting the project ❤️")
+        }
+
+      }
+      .frame(width: 380)
+      .roundedContainer(margin: 0)
+      .padding(.top, 8)
+      .padding(.horizontal, 16)
+
+      HStack(spacing: 8) {
+        Button(action: action, label: {
+          Text("About Macros")
+        })
+        .buttonStyle(.zen(.init(color: .systemCyan, hoverEffect: .constant(false))))
+
+        Button(action: action, label: {
+          Text("Got it!")
+        })
+        .buttonStyle(.zen(.init(color: .systemGreen, hoverEffect: .constant(false))))
+      }
+      .padding(.top, 8)
+      .padding(.bottom, 32)
+      .frame(width: 410)
+    }
+    .background(Color(.windowBackgroundColor))
+  }
+}
+
+struct Release3_22_0_Previews: PreviewProvider {
+  static var previews: some View {
+    Release3_22_0 {}
+    .previewDisplayName("Release 3.22.0")
+  }
+}
 
 struct Release3_21_0: PreviewProvider {
   static let size: CGFloat = 96
@@ -66,6 +188,7 @@ struct Release3_21_0: PreviewProvider {
     }
     .padding(64)
     .background(Color(.windowBackgroundColor))
+    .previewDisplayName("Release 3.21.0")
   }
 }
 

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -70,15 +70,50 @@ struct Release3_22_0: View {
         .padding(.top, 8)
 
       VStack(alignment: .leading, spacing: 16) {
-        HStack(spacing: 12) {
-          MacroIconView(.record, size: 32)
-          Text("Macros: Make Every Keystroke Count!")
-            .font(Font.system(.title2, design: .rounded, weight: .bold))
+        ScrollView(.vertical) {
+          VStack(spacing: 6) {
+            HStack(spacing: 12) {
+              MacroIconView(.record, size: 32)
+              Text("Macros: Make Every Keystroke Count!")
+                .font(Font.system(.title2, design: .rounded, weight: .bold))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Rev up your routine with Macros — where doing less isn't just more; it's epic. Say hello to keyboard wizardry that conjures up workflows in the blink of an eye.")
+              .fixedSize(horizontal: false, vertical: true)
+            Text("With Macros, you're not just efficient, you're effortlessly epic!")
+
+            Divider()
+              .padding(.vertical, 8)
+
+            Text("Other changes")
+              .font(Font.system(.headline, weight: .bold))
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 12) {
+              HStack(spacing: 12) {
+                BugFixIconView(size: 24)
+                Text("Banishes the ghosted icons — they're all back with a vengeance!")
+              }
+
+              HStack(alignment: .top, spacing: 12) {
+                ImprovementIconView(size: 24)
+                VStack(spacing: 12) {
+                  Text("Keyboard-, Menubar- & Window Management Commands now work better with repeating events")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                  Text("Icons revamped – a subtle glow-up for your visual pleasure!")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+              }
+            }
+            .font(Font.system(.caption2, design: .rounded))
+            .frame(maxWidth: .infinity, alignment: .leading)
+          }
         }
-        Text("Rev up your routine with Macros — where doing less isn't just more; it's epic. Say hello to keyboard wizardry that conjures up workflows in the blink of an eye.")
-          .fixedSize(horizontal: false, vertical: true)
-        Text("With Macros, you're not just efficient, you're effortlessly epic!")
+        .frame(minHeight: 220)
+
         Divider()
+
         HStack(spacing: 4) {
           Text("Special thanks to")
           AsyncImage.init(url: URL(string: "https://avatars.githubusercontent.com/u/5180591?v=4")) { image in

--- a/App/Sources/UI/Views/Icons/Releases.swift
+++ b/App/Sources/UI/Views/Icons/Releases.swift
@@ -2,8 +2,14 @@ import Bonzai
 import SwiftUI
 
 struct Release3_22_0: View {
+  enum ButtonAction {
+    case wiki
+    case done
+  }
+
   let size: CGFloat = 128
-  let action: () -> Void
+  let action: (ButtonAction) -> Void
+
   var body: some View {
     VStack(spacing: 8) {
       HStack(spacing: 16) {
@@ -85,11 +91,9 @@ struct Release3_22_0: View {
             Circle()
               .frame(width: 24, height: 24)
           }
-
           Link("@bforpc", destination: URL(string: "https://github.com/bforpc")!)
           Text("for supporting the project ❤️")
         }
-
       }
       .frame(width: 380)
       .roundedContainer(margin: 0)
@@ -97,14 +101,10 @@ struct Release3_22_0: View {
       .padding(.horizontal, 16)
 
       HStack(spacing: 8) {
-        Button(action: action, label: {
-          Text("About Macros")
-        })
+        Button(action: { action(.done) }, label: { Text("About Macros") })
         .buttonStyle(.zen(.init(color: .systemCyan, hoverEffect: .constant(false))))
 
-        Button(action: action, label: {
-          Text("Got it!")
-        })
+        Button(action: { action(.done) }, label: { Text("Got it!") })
         .buttonStyle(.zen(.init(color: .systemGreen, hoverEffect: .constant(false))))
       }
       .padding(.top, 8)
@@ -117,7 +117,7 @@ struct Release3_22_0: View {
 
 struct Release3_22_0_Previews: PreviewProvider {
   static var previews: some View {
-    Release3_22_0 {}
+    Release3_22_0 { _ in }
     .previewDisplayName("Release 3.22.0")
   }
 }

--- a/App/Sources/UI/Views/Icons/ScriptIconView.swift
+++ b/App/Sources/UI/Views/Icons/ScriptIconView.swift
@@ -5,27 +5,12 @@ struct ScriptIconView: View {
   var body: some View {
     Rectangle()
       .fill(Color(.black))
-      .overlay {
-        AngularGradient(stops: [
-          .init(color: Color.clear, location: 0.0),
-          .init(color: Color(.controlAccentColor).opacity(0.5), location: 0.2),
-          .init(color: Color.clear, location: 1.0),
-        ], center: .bottomLeading)
-
-        LinearGradient(stops: [
-          .init(color: Color.white.opacity(0.2), location: 0),
-          .init(color: Color.clear, location: 0.3),
-        ], startPoint: .top, endPoint: .bottom)
-
-        LinearGradient(stops: [
-          .init(color: Color.clear, location: 0.8),
-          .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
-        ], startPoint: .top, endPoint: .bottom)
-      }
+      .overlay { iconOverlay() }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .topLeading) {
         HStack(spacing: 0) {
           Text(">")
-            .font(Font.system(size: size * 0.375, design: .monospaced))
+            .font(Font.system(size: size * 0.375, weight: .regular, design: .rounded))
             .padding(.top, size * 0.05)
             .padding(.leading, size * 0.1)
             .foregroundColor(
@@ -33,32 +18,13 @@ struct ScriptIconView: View {
             )
             .shadow(color: .white, radius: 15, y: 5)
           Text("_")
-            .font(Font.system(size: size * 0.375, design: .monospaced))
+            .font(Font.system(size: size * 0.375, weight: .regular, design: .rounded))
             .padding(.top, size * 0.05)
             .foregroundColor(
               Color(nsColor: .controlAccentColor.withSystemEffect(.deepPressed))
             )
-            .shadow(color: .white, radius: 10, y: 5)
+            .shadow(color: Color(.controlAccentColor), radius: 10, y: 2)
         }
-      }
-      .overlay {
-        RoundedRectangle(cornerRadius: size * 0.175)
-          .stroke(        LinearGradient(stops: [
-            .init(color: Color(.windowBackgroundColor), location: 0.0),
-            .init(color: Color(.systemGray), location: 0.2),
-            .init(color: Color(.windowBackgroundColor), location: 1.0),
-          ], startPoint: .topLeading, endPoint: .bottomTrailing)
-                          , lineWidth: size * 0.0_5)
-
-//        RoundedRectangle(cornerRadius: size * 0.105)
-//          .stroke(        LinearGradient(stops: [
-//            .init(color: Color(.windowBackgroundColor), location: 0.0),
-//            .init(color: Color(.systemGray), location: 0.2),
-//            .init(color: Color(.windowBackgroundColor), location: 1.0),
-//          ], startPoint: .bottomTrailing, endPoint: .topLeading)
-//                          , lineWidth: size * 0.0_175)
-//          .padding(size * 0.0_24)
-
       }
       .frame(width: size, height: size)
       .fixedSize()

--- a/App/Sources/UI/Views/Icons/TypingIconView.swift
+++ b/App/Sources/UI/Views/Icons/TypingIconView.swift
@@ -11,6 +11,8 @@ Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The roun
   var body: some View {
     Rectangle()
       .fill(.white)
+      .overlay { iconOverlay().opacity(0.5) }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .leading) {
         Rectangle()
           .fill(Color(.systemRed).opacity(0.25))

--- a/App/Sources/UI/Views/Icons/UIElementIconView.swift
+++ b/App/Sources/UI/Views/Icons/UIElementIconView.swift
@@ -45,6 +45,8 @@ struct UIElementIconView: View {
           endPoint: .leading
         )
       }
+      .overlay { iconOverlay() }
+      .overlay { iconBorder(size) }
       .overlay(alignment: .center) {
         Image(systemName: "viewfinder")
           .resizable()

--- a/App/Sources/UI/Views/Icons/WindowManagementIconView.swift
+++ b/App/Sources/UI/Views/Icons/WindowManagementIconView.swift
@@ -23,6 +23,7 @@ struct WindowManagementIconView: View {
       window()
         .frame(width: size * 0.182)
     }
+    .overlay { iconBorder(size) }
     .background()
     .compositingGroup()
     .iconShape(size)

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -127,13 +127,23 @@ private extension Array where Element == Command {
       case .menuBar(let command):
         images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.menuBar(.init(id: command.id, tokens: command.tokens)))))
       case .builtIn(let command):
-        let path = Bundle.main.bundleURL.path
-        images.append(
-          ContentViewModel.ImageModel(
-            id: command.id,
-            offset: convertedOffset,
-            kind: .icon(.init(bundleIdentifier: path, path: path)))
-        )
+        switch command.kind {
+        case .macro(let action):
+          switch action.kind {
+          case .record:
+            images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.builtIn(.init(id: command.id, name: command.name, kind: .macro(.record))))))
+          case .remove:
+            images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.builtIn(.init(id: command.id, name: command.name, kind: .macro(.remove))))))
+          }
+        case .userMode:
+          let path = Bundle.main.bundleURL.path
+          images.append(
+            ContentViewModel.ImageModel(
+              id: command.id,
+              offset: convertedOffset,
+              kind: .icon(.init(bundleIdentifier: path, path: path)))
+          )
+        }
       case .mouse(let command):
         images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.mouse(.init(id: command.id, kind: command.kind)))))
       case .keyboard(let keyCommand):

--- a/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
@@ -17,6 +17,8 @@ struct NewCommandBuiltInView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
+      ZenLabel("Built-In Commands")
+        .frame(maxWidth: .infinity, alignment: .leading)
       HStack {
         switch kindSelection {
         case .macro(let macroAction):
@@ -32,8 +34,6 @@ struct NewCommandBuiltInView: View {
         }
 
         VStack {
-          ZenLabel("Built-In Commands")
-            .frame(maxWidth: .infinity, alignment: .leading)
 
           Menu {
             Button(action: { kindSelection = .userMode(.init(id: UUID().uuidString, name: "", isEnabled: true), .toggle) },

--- a/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
@@ -59,7 +59,8 @@ struct NewCommandBuiltInView: View {
   @discardableResult
   private func updateAndValidatePayload() -> NewCommandValidation {
     let newKind: BuiltInCommand.Kind = switch kindSelection {
-      case .userMode(_, let action): .userMode(userModeSelection, action)
+    case .macro(let action): .macro(action)
+    case .userMode(_, let action): .userMode(userModeSelection, action)
     }
 
     payload = .builtIn(builtIn: .init(kind: newKind, notification: false))

--- a/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
@@ -18,8 +18,18 @@ struct NewCommandBuiltInView: View {
   var body: some View {
     VStack(alignment: .leading) {
       HStack {
-        let path = Bundle.main.bundleURL.path
-        IconView(icon: .init(bundleIdentifier: path, path: path), size: CGSize(width: 24, height: 24))
+        switch kindSelection {
+        case .macro(let macroAction):
+          switch macroAction.kind {
+          case .record:
+            MacroIconView(.record, size: 24)
+          case .remove:
+            MacroIconView(.remove, size: 24)
+          }
+        case .userMode:
+          let path = Bundle.main.bundleURL.path
+          IconView(icon: .init(bundleIdentifier: path, path: path), size: CGSize(width: 24, height: 24))
+        }
 
         VStack {
           ZenLabel("Built-In Commands")
@@ -32,14 +42,10 @@ struct NewCommandBuiltInView: View {
                    label: { Text("Record Macros") })
             Button(action: { kindSelection = .macro(.remove) },
                    label: { Text("Remove Macros") })
-            Button(action: { kindSelection = .macro(.list) },
-                   label: { Text("List Macros") })
           } label: {
             switch kindSelection {
               case .macro(let action):
                 switch action.kind {
-                  case .list:
-                    Text("List Macros")
                   case .record:
                     Text("Record Macro")
                   case .remove:

--- a/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
+++ b/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
@@ -1,0 +1,31 @@
+import Cocoa
+import SwiftUI
+
+struct ReleaseNotesScene: Scene {
+  let appStorage = AppStorageContainer.shared
+  @Environment(\.dismiss) var dismiss
+
+  var body: some Scene {
+    WindowGroup(id: KeyboardCowboy.releaseNotesWindowIdentifier) {
+      Release3_22_0 { action in
+        switch action {
+        case .done:
+          break
+        case .wiki:
+          NSWorkspace.shared.open(
+            URL(string: "https://github.com/zenangst/KeyboardCowboy/wiki/Commands#macros")!,
+            configuration: NSWorkspace.OpenConfiguration()
+          )
+        }
+        NSApplication.shared.keyWindow?.close()
+      }
+      .onDisappear {
+        
+      }
+    }
+    .windowResizability(.contentSize)
+    .windowToolbarStyle(.unified(showsTitle: true))
+    .windowStyle(.hiddenTitleBar)
+    .defaultPosition(.center)
+  }
+}

--- a/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
+++ b/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
@@ -12,15 +12,12 @@ struct ReleaseNotesScene: Scene {
         case .done:
           break
         case .wiki:
-          NSWorkspace.shared.open(
-            URL(string: "https://github.com/zenangst/KeyboardCowboy/wiki/Commands#macros")!,
-            configuration: NSWorkspace.OpenConfiguration()
-          )
+          NSWorkspace.shared.open(URL(string: "https://github.com/zenangst/KeyboardCowboy/wiki/Commands#macros")!)
         }
         NSApplication.shared.keyWindow?.close()
       }
       .onDisappear {
-        
+        AppStorageContainer.shared.releaseNotes = KeyboardCowboy.marektingVersion
       }
     }
     .windowResizability(.contentSize)

--- a/App/Sources/UI/Windows/MainWindow.swift
+++ b/App/Sources/UI/Windows/MainWindow.swift
@@ -5,6 +5,7 @@ struct MainWindow: Scene {
   private let core: Core
   @FocusState var focus: AppFocus?
 
+  @Environment(\.openWindow) private var openWindow
   private let onScene: (AppScene) -> Void
 
   init(_ core: Core, onScene: @escaping (AppScene) -> Void) {
@@ -43,6 +44,7 @@ struct MainWindow: Scene {
     .commands {
       CommandGroup(after: .appSettings) {
         AppMenu()
+        Button { openWindow(id: KeyboardCowboy.releaseNotesWindowIdentifier) } label: { Text("What's new?") }
       }
       CommandGroup(replacing: .newItem) {
         FileMenu(

--- a/Project.swift
+++ b/Project.swift
@@ -165,7 +165,7 @@ public enum PackageResolver {
       packages = [
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.1.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
-        .package(url: "https://github.com/zenangst/AXEssibility.git", from: "0.1.1"),
+        .package(url: "https://github.com/zenangst/AXEssibility.git", from: "0.1.2"),
         .package(url: "https://github.com/zenangst/Bonzai.git", .revision("cd94e615fa183c82395a783881c211c26255ad40")),
         .package(url: "https://github.com/zenangst/Apps.git", from: "1.4.2"),
         .package(url: "https://github.com/zenangst/Dock.git", from: "1.0.1"),

--- a/Project.swift
+++ b/Project.swift
@@ -59,10 +59,10 @@ let project = Project(
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_IDENTITY": "Apple Development",
             "CODE_SIGN_STYLE": "Automatic",
-            "CURRENT_PROJECT_VERSION": "454",
+            "CURRENT_PROJECT_VERSION": "512",
             "DEVELOPMENT_TEAM": env["TEAM_ID"],
             "ENABLE_HARDENED_RUNTIME": true,
-            "MARKETING_VERSION": "3.21.2",
+            "MARKETING_VERSION": "3.22.0",
             "PRODUCT_NAME": "Keyboard Cowboy"
           ],
           configurations: [

--- a/UnitTests/Sources/Controllers/ApplicationTriggerControllerTests.swift
+++ b/UnitTests/Sources/Controllers/ApplicationTriggerControllerTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 import Combine
 import Cocoa
+import MachPort
 
 final class ApplicationTriggerControllerTests: XCTestCase {
   func testApplicationTriggerController_frontMost() {
@@ -114,11 +115,11 @@ private final class CommandRunner: CommandRunning {
     self.serialRunHandler = serial
   }
 
-  func concurrentRun(_ commands: [Command], checkCancellation: Bool, resolveUserEnvironment: Bool) {
+  func concurrentRun(_ commands: [Command], checkCancellation: Bool, resolveUserEnvironment: Bool, shortcut: KeyShortcut, machPortEvent: MachPortEvent, repeatingEvent: Bool) {
     concurrentRunHandler(commands)
   }
 
-  func serialRun(_ commands: [Command], checkCancellation: Bool, resolveUserEnvironment: Bool) {
+  func serialRun(_ commands: [Command], checkCancellation: Bool, resolveUserEnvironment: Bool, shortcut: KeyShortcut, machPortEvent: MachPortEvent, repeatingEvent: Bool) {
     serialRunHandler(commands)
   }
 }


### PR DESCRIPTION
- Add support for macros inside the MachPortCoordinator
- Start adding models and runners for macros
- Continue macros implementation
- Add support for removing macros
- Add support for finishing up a recording using the binding key
- Improve realiabillty of the macro implementation
- Fix key repeat regression
- Fix bug with macros recording themselves
- Remove `list` kind from Macro (will be added later Add icons for record and remove macro commands
- Minor UI fix when adding new builtin command
- Add release notes view
- Add release notes scene and trigger that when the app opens
- Update the look & feel of the icons
- Don't index dialog and system dialogs for front most application windows
- Add "What's new?" menu item to menu extras
- Add release notes for switching between windows in the front most application
- Update the release notes
