### PR TITLE
Feature snippet triggers + other improvements

### DIFF
--- a/App/Sources/Core/Controllers/ApplicationTriggerController.swift
+++ b/App/Sources/Core/Controllers/ApplicationTriggerController.swift
@@ -55,8 +55,8 @@ final class ApplicationTriggerController {
             self.activateActions[trigger.application.bundleIdentifier, default: []].append(workflow)
           }
         }
-      case .keyboardShortcuts, .none:
-        break
+      case .keyboardShortcuts, .snippet, .none:
+        return
       }
     }
   }

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -95,8 +95,8 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
       // Clean up snippet before running command
       if let key = VirtualSpecialKey.keys[kVK_Delete] {
         for _ in 0..<currentSnippet.count {
-          _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyDown, originalEvent: nil, with: nil)
-          _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyUp, originalEvent: nil, with: nil)
+            _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyDown, with: nil)
+            _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyUp, with: nil)
         }
       }
 

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -1,0 +1,118 @@
+import Combine
+import Foundation
+import MachPort
+
+final class SnippetController: @unchecked Sendable {
+  private var currentSnippet: String = ""
+  private var snippets: Set<String> = []
+  private var snippetsStorage = [String: [Workflow]]()
+  private var timeout: Timer?
+  private var machPortEventSubscription: AnyCancellable?
+  private var workflowGroupsSubscription: AnyCancellable?
+
+  private let commandRunner: CommandRunning
+  private let keyboardShortcutsController: KeyboardShortcutsController
+  private let store: KeyCodesStore
+  private let specialKeys: [Int]
+
+  init(commandRunner: CommandRunning,
+       keyboardShortcutsController: KeyboardShortcutsController,
+       store: KeyCodesStore) {
+    self.commandRunner = commandRunner
+    self.keyboardShortcutsController = keyboardShortcutsController
+    self.store = store
+    self.specialKeys = Array(store.specialKeys().keys)
+  }
+
+  func subscribe(to publisher: Published<[WorkflowGroup]>.Publisher) {
+    workflowGroupsSubscription = publisher.sink { [weak self] in
+      self?.receiveGroups($0)
+    }
+  }
+
+  func subscribe(to publisher: Published<MachPortEvent?>.Publisher) {
+    machPortEventSubscription = publisher
+      .compactMap { $0 }
+      .sink { [weak self] machPortEvent in
+      self?.receiveMachPortEvent(machPortEvent)
+    }
+  }
+
+  // MARK: Private methods
+
+  private func receiveMachPortEvent(_ machPortEvent: MachPortEvent) {
+    guard machPortEvent.type == .keyUp else { return }
+    guard let shortcut = MachPortKeyboardShortcut(machPortEvent, specialKeys: specialKeys, store: store) else {
+      return
+    }
+    let keyboardShortcut: KeyShortcut = shortcut.original
+
+    currentSnippet = currentSnippet + keyboardShortcut.key
+
+    timeout?.invalidate()
+    timeout = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false, block: { [weak self] timer in
+      guard let self else { return }
+      currentSnippet = ""
+      timer.invalidate()
+    })
+
+    if snippets.contains(currentSnippet) {
+      guard let workflows = snippetsStorage[currentSnippet] else { return }
+      for workflow in workflows {
+        runCommands(in: workflow)
+      }
+      currentSnippet = ""
+      timeout?.invalidate()
+    }
+  }
+
+  private func receiveGroups(_ groups: [WorkflowGroup]) {
+    self.snippetsStorage = [:]
+    self.snippets = []
+
+    let workflows = groups.flatMap { $0.workflows }
+
+    for workflow in workflows {
+      guard workflow.isEnabled else { continue }
+        if let trigger = workflow.trigger {
+            switch trigger {
+            case .snippet(let trigger):
+              if let existingWorkflows = snippetsStorage[trigger.text] {
+                snippetsStorage[trigger.text] = existingWorkflows + [workflow]
+              } else {
+                snippetsStorage[trigger.text] = [workflow]
+              }
+              snippets.insert(trigger.text)
+            default: break
+            }
+        } else {
+            runCommands(in: workflow)
+        }
+    }
+  }
+
+  private func runCommands(in workflow: Workflow) {
+    let commands = workflow.commands.filter(\.isEnabled)
+    guard let machPortEvent = MachPortEvent.empty() else { return }
+    switch workflow.execution {
+    case .concurrent:
+      commandRunner.concurrentRun(
+        commands,
+        checkCancellation: true,
+        resolveUserEnvironment: workflow.resolveUserEnvironment(),
+        shortcut: .empty(),
+        machPortEvent: machPortEvent,
+        repeatingEvent: false
+      )
+    case .serial:
+      commandRunner.serialRun(
+        commands,
+        checkCancellation: true,
+        resolveUserEnvironment: workflow.resolveUserEnvironment(),
+        shortcut: .empty(),
+        machPortEvent: machPortEvent,
+        repeatingEvent: false
+      )
+    }
+  }
+}

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -5,6 +5,8 @@ import KeyCodes
 import MachPort
 
 final class SnippetController: @unchecked Sendable {
+  static var isEnabled: Bool = true
+
   private var currentSnippet: String = ""
   private var machPortEventSubscription: AnyCancellable?
   private var snippets: Set<String> = []
@@ -51,7 +53,7 @@ final class SnippetController: @unchecked Sendable {
   // MARK: Private methods
 
   private func receiveMachPortEvent(_ machPortEvent: MachPortEvent) {
-    guard !snippets.isEmpty else { return }
+    guard Self.isEnabled && !snippets.isEmpty else { return }
     guard machPortEvent.type == .keyUp else { return }
 
     let modifiers = VirtualModifierKey.fromCGEvent(machPortEvent.event, specialKeys: specialKeys)
@@ -118,11 +120,14 @@ final class SnippetController: @unchecked Sendable {
         if let trigger = workflow.trigger {
             switch trigger {
             case .snippet(let trigger):
+              guard !trigger.text.isEmpty else { return }
+
               if let existingWorkflows = snippetsStorage[trigger.text] {
                 snippetsStorage[trigger.text] = existingWorkflows + [workflow]
               } else {
                 snippetsStorage[trigger.text] = [workflow]
               }
+
               snippets.insert(trigger.text)
             default: break
             }

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -95,7 +95,6 @@ final class SnippetController: @unchecked Sendable {
       if let key = VirtualSpecialKey.keys[kVK_Delete] {
         for _ in 0..<currentSnippet.count {
           try? keyboardCommandRunner.run([.init(key: key)], type: .keyDown, originalEvent: nil, with: nil)
-
         }
       }
 

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -93,7 +93,7 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
     currentSnippet = currentSnippet + displayValue
 
     timeout?.invalidate()
-    timeout = Timer.scheduledTimer(withTimeInterval: 0.75, repeats: false, block: { [weak self] timer in
+    timeout = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false, block: { [weak self] timer in
       guard let self else { return }
       Task { @MainActor in
         self.currentSnippet = ""

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -1,4 +1,5 @@
 import Carbon
+import Cocoa
 import Combine
 import Foundation
 import KeyCodes
@@ -7,9 +8,9 @@ import MachPort
 final class SnippetController: @unchecked Sendable, ObservableObject {
   var isEnabled: Bool = true
 
+  @MainActor
   private var currentSnippet: String = ""
   private var machPortEventSubscription: AnyCancellable?
-  private var snippets: Set<String> = []
   private var snippetsStorage = [String: [Workflow]]()
   private var timeout: Timer?
   private var workflowGroupsSubscription: AnyCancellable?
@@ -45,15 +46,19 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
   func subscribe(to publisher: Published<CGEvent?>.Publisher) {
     machPortEventSubscription = publisher
       .compactMap { $0 }
-      .sink { [weak self] machPortEvent in
-      self?.receiveCGEvent(machPortEvent)
+      .sink { [weak self] cgEvent in
+        guard let self else { return }
+        Task { [cgEvent] in
+          await self.receiveCGEvent(cgEvent)
+        }
     }
   }
 
   // MARK: Private methods
 
+  @MainActor
   private func receiveCGEvent(_ event: CGEvent) {
-    guard isEnabled && !snippets.isEmpty, event.type == .keyDown else { return }
+    guard isEnabled && !snippetsStorage.isEmpty, event.type == .keyDown else { return }
     let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
     let forbiddenKeys = [kVK_Escape, kVK_Space, kVK_Delete]
 
@@ -79,25 +84,42 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
       return
     }
 
+    if displayValue == "." {
+      currentSnippet = ""
+      timeout?.invalidate()
+      return
+    }
+
     currentSnippet = currentSnippet + displayValue
 
     timeout?.invalidate()
     timeout = Timer.scheduledTimer(withTimeInterval: 0.75, repeats: false, block: { [weak self] timer in
       guard let self else { return }
-      currentSnippet = ""
+      Task { @MainActor in
+        self.currentSnippet = ""
+      }
       timer.invalidate()
     })
 
-    if snippets.contains(currentSnippet) {
-      guard let workflows = snippetsStorage[currentSnippet],
-            let machPortEvent = MachPortEvent.empty() else { return }
+    guard let runningApplication = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = runningApplication.bundleIdentifier else { return }
 
+    let globalKey: String = "*." + currentSnippet
+    let localKey: String = bundleIdentifier + "." + currentSnippet
+
+    guard let workflows = snippetsStorage[localKey] ?? snippetsStorage[globalKey],
+          let machPortEvent = MachPortEvent.empty() else {
+      return
+    }
+
+    Task { @MainActor in
       // Clean up snippet before running command
       if let key = VirtualSpecialKey.keys[kVK_Delete] {
         for _ in 0..<currentSnippet.count {
-            _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyDown, with: nil)
-            _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyUp, with: nil)
+          _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyDown, with: nil)
+          _ = try? keyboardCommandRunner.run([.init(key: key)], type: .keyUp, with: nil)
         }
+        try await Task.sleep(for: .milliseconds(10))
       }
 
       for workflow in workflows {
@@ -118,30 +140,39 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
 
   private func receiveGroups(_ groups: [WorkflowGroup]) {
     self.snippetsStorage = [:]
-    self.snippets = []
 
-    let workflows = groups.flatMap { $0.workflows }
+    for group in groups {
+      let bundleIdentifiers: [String]
+      if let rule = group.rule {
+        bundleIdentifiers = rule.bundleIdentifiers
+      } else {
+        bundleIdentifiers = ["*"]
+      }
 
-    for workflow in workflows {
-      guard workflow.isEnabled else { continue }
-        if let trigger = workflow.trigger {
+      bundleIdentifiers.forEach { bundleIdentifier in
+        for workflow in group.workflows {
+          guard workflow.isEnabled else { continue }
+          if let trigger = workflow.trigger {
             switch trigger {
             case .snippet(let trigger):
               guard !trigger.text.isEmpty else { return }
 
-              if let existingWorkflows = snippetsStorage[trigger.text] {
-                snippetsStorage[trigger.text] = existingWorkflows + [workflow]
-              } else {
-                snippetsStorage[trigger.text] = [workflow]
-              }
+              let key = bundleIdentifier + "." + trigger.text
 
-              snippets.insert(trigger.text)
+              if let existingWorkflows = snippetsStorage[trigger.text] {
+                snippetsStorage[key] = existingWorkflows + [workflow]
+              } else {
+                snippetsStorage[key] = [workflow]
+              }
             default: break
             }
-        } else {
+          } else {
             runCommands(in: workflow)
+          }
         }
+      }
     }
+
   }
 
   private func runCommands(in workflow: Workflow) {
@@ -169,3 +200,5 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
     }
   }
 }
+
+extension CGEvent: @unchecked Sendable {}

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -172,7 +172,6 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
         }
       }
     }
-
   }
 
   private func runCommands(in workflow: Workflow) {

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -166,8 +166,6 @@ final class SnippetController: @unchecked Sendable, ObservableObject {
               }
             default: break
             }
-          } else {
-            runCommands(in: workflow)
           }
         }
       }

--- a/App/Sources/Core/Controllers/SnippetController.swift
+++ b/App/Sources/Core/Controllers/SnippetController.swift
@@ -42,22 +42,22 @@ final class SnippetController: @unchecked Sendable {
     }
   }
 
-  func subscribe(to publisher: Published<MachPortEvent?>.Publisher) {
+  func subscribe(to publisher: Published<CGEvent?>.Publisher) {
     machPortEventSubscription = publisher
       .compactMap { $0 }
       .sink { [weak self] machPortEvent in
-      self?.receiveMachPortEvent(machPortEvent)
+      self?.receiveCGEvent(machPortEvent)
     }
   }
 
   // MARK: Private methods
 
-  private func receiveMachPortEvent(_ machPortEvent: MachPortEvent) {
+  private func receiveCGEvent(_ event: CGEvent) {
     guard Self.isEnabled && !snippets.isEmpty else { return }
-    guard machPortEvent.type == .keyUp else { return }
+    guard event.type == .keyDown else { return }
 
-    let modifiers = VirtualModifierKey.fromCGEvent(machPortEvent.event, specialKeys: specialKeys)
-    let keyCode = Int(machPortEvent.keyCode)
+    let modifiers = VirtualModifierKey.fromCGEvent(event, specialKeys: specialKeys)
+    let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
     let forbiddenKeys = [kVK_Escape, kVK_Space, kVK_Delete]
 
     if forbiddenKeys.contains(keyCode) {

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -94,6 +94,7 @@ final class Core {
     machPortCoordinator: machPortCoordinator,
     scriptCommandRunner: scriptCommandRunner,
     shortcutStore: shortcutStore,
+    snippetController: snippetController,
     uiElementCaptureStore: uiElementCaptureStore,
     workspace: .shared)
   lazy private(set) var uiElementCaptureStore = UIElementCaptureStore()
@@ -112,6 +113,11 @@ final class Core {
   lazy private(set) var uiElementCommandRunner = UIElementCommandRunner()
   lazy private(set) var scriptCommandRunner = ScriptCommandRunner(workspace: .shared)
   lazy private(set) var macroRunner = MacroRunner(coordinator: macroCoordinator)
+  lazy private(set) var snippetController = SnippetController(
+    commandRunner: commandRunner,
+    keyboardShortcutsController: keyboardShortcutsController,
+    store: keyCodeStore
+  )
 
   // MARK: - Controllers
 

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -115,6 +115,7 @@ final class Core {
   lazy private(set) var macroRunner = MacroRunner(coordinator: macroCoordinator)
   lazy private(set) var snippetController = SnippetController(
     commandRunner: commandRunner,
+    keyboardCommandRunner: keyboardCommandRunner,
     keyboardShortcutsController: keyboardShortcutsController,
     store: keyCodeStore
   )

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -125,6 +125,8 @@ struct KeyboardCowboy: App {
       } else {
         assertionFailure("Unable to find workflow group")
       }
+    case .addCommand(let workflowId):
+      openWindow(value: NewCommandWindow.Context.newCommand(workflowId: workflowId))
     }
   }
 

--- a/App/Sources/Core/Models/Extensions/Command+Name.swift
+++ b/App/Sources/Core/Models/Extensions/Command+Name.swift
@@ -46,8 +46,9 @@ extension Command {
       case .application(var command):
         command.name = newValue
         self = .application(command)
-      case .builtIn:
-        break
+      case .builtIn(var command):
+        command.name = newValue
+        self = .builtIn(command)
       case .keyboard(var command):
         command.name = newValue
         self = .keyboard(command)

--- a/App/Sources/Core/Models/KeyShortcut.swift
+++ b/App/Sources/Core/Models/KeyShortcut.swift
@@ -39,10 +39,8 @@ struct KeyShortcut: Identifiable, Equatable, Codable, Hashable, Sendable, Transf
     return input
   }
 
-  init(id: String = UUID().uuidString,
-              key: String,
-              lhs: Bool = true,
-              modifiers: [ModifierKey] = []) {
+  init(id: String = UUID().uuidString, key: String,
+       lhs: Bool = true, modifiers: [ModifierKey] = []) {
     self.id = id
     self.key = key
     self.lhs = lhs

--- a/App/Sources/Core/Models/Triggers/SnippetTrigger.swift
+++ b/App/Sources/Core/Models/Triggers/SnippetTrigger.swift
@@ -3,4 +3,8 @@ import Foundation
 struct SnippetTrigger: Identifiable, Hashable, Codable, Equatable {
   let id: String
   let text: String
+
+  func copy() -> Self {
+    SnippetTrigger(id: UUID().uuidString, text: text)
+  }
 }

--- a/App/Sources/Core/Models/Triggers/SnippetTrigger.swift
+++ b/App/Sources/Core/Models/Triggers/SnippetTrigger.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct SnippetTrigger: Identifiable, Hashable, Codable, Equatable {
+  let id: String
+  let text: String
+}

--- a/App/Sources/Core/Models/Workflow.swift
+++ b/App/Sources/Core/Models/Workflow.swift
@@ -111,7 +111,7 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
     case .keyboardShortcuts(let keyboardShortcutTrigger):
       clone.trigger = .keyboardShortcuts(keyboardShortcutTrigger.copy())
     case .snippet(let trigger):
-      clone.trigger = .snippet(trigger)
+      clone.trigger = .snippet(trigger.copy())
     case .none:
       break
     }

--- a/App/Sources/Core/Models/Workflow.swift
+++ b/App/Sources/Core/Models/Workflow.swift
@@ -8,10 +8,12 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
   enum Trigger: Hashable, Equatable, Codable, Sendable {
     case application([ApplicationTrigger])
     case keyboardShortcuts(KeyboardShortcutTrigger)
+    case snippet(SnippetTrigger)
 
     enum CodingKeys: String, CodingKey {
       case application
       case keyboardShortcuts
+      case snippet
     }
 
     init(from decoder: Decoder) throws {
@@ -31,6 +33,9 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
           let keyboardShortcuts = try container.decode([KeyShortcut].self, forKey: .keyboardShortcuts)
           self = .keyboardShortcuts(.init(shortcuts: keyboardShortcuts))
         }
+      case .snippet:
+        let snippetTrigger = try container.decode(SnippetTrigger.self, forKey: .snippet)
+        self = .snippet(snippetTrigger)
       case .none:
         throw DecodingError.dataCorrupted(
           DecodingError.Context(
@@ -48,6 +53,8 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
         try container.encode(trigger, forKey: .application)
       case .keyboardShortcuts(let keyboardShortcuts):
         try container.encode(keyboardShortcuts, forKey: .keyboardShortcuts)
+      case .snippet(let trigger):
+        try container.encode(trigger, forKey: .snippet)
       }
     }
 
@@ -103,6 +110,8 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
       clone.trigger = .application(array.map { $0.copy() })
     case .keyboardShortcuts(let keyboardShortcutTrigger):
       clone.trigger = .keyboardShortcuts(keyboardShortcutTrigger.copy())
+    case .snippet(let trigger):
+      clone.trigger = .snippet(trigger)
     case .none:
       break
     }
@@ -165,10 +174,9 @@ struct Workflow: Identifiable, Equatable, Codable, Hashable, Sendable {
 extension Workflow.Trigger {
   var isPassthrough: Bool {
     switch self {
-    case .application:
-      return false
-    case .keyboardShortcuts(let trigger):
-      return trigger.passthrough
+    case .application: false
+    case .snippet: true
+    case .keyboardShortcuts(let trigger): trigger.passthrough
     }
   }
 }

--- a/App/Sources/Core/Runners/BuiltIn/UserModesRunner.swift
+++ b/App/Sources/Core/Runners/BuiltIn/UserModesRunner.swift
@@ -24,13 +24,13 @@ final class UserModesRunner {
     switch action {
     case .enable:
       modifiedMode.isEnabled = true
-      output = "Enable: \(model.name)"
+      output = "\(builtInCommand.name) ✅"
     case .disable:
       modifiedMode.isEnabled = false
-      output = "Disable: \(model.name)"
+      output = "\(builtInCommand.name) ⏸️"
     case .toggle:
       modifiedMode.isEnabled.toggle()
-      output = "\(modifiedMode.name): \( modifiedMode.isEnabled ? "✅" : "⏸️")"
+      output = "\(builtInCommand.name): \( modifiedMode.isEnabled ? "✅" : "⏸️")"
     }
     userModes[index] = modifiedMode
     await UserSpace.shared.setUserModes(userModes)

--- a/App/Sources/Core/Runners/CommandRunner.swift
+++ b/App/Sources/Core/Runners/CommandRunner.swift
@@ -182,11 +182,13 @@ final class CommandRunner: CommandRunning, @unchecked Sendable {
         } catch { }
       }
 
-      if let originalPasteboardContents {
-        try await Task.sleep(for: .seconds(0.1))
+      if commands.shouldRestorePasteboard {
+        try await Task.sleep(for: .seconds(0.2))
         await MainActor.run {
           NSPasteboard.general.clearContents()
-          NSPasteboard.general.setString(originalPasteboardContents, forType: .string)
+          if let originalPasteboardContents {
+            NSPasteboard.general.setString(originalPasteboardContents, forType: .string)
+          }
         }
       }
     }

--- a/App/Sources/Core/Runners/KeyboardCommandRunner.swift
+++ b/App/Sources/Core/Runners/KeyboardCommandRunner.swift
@@ -25,7 +25,8 @@ final class KeyboardCommandRunner: @unchecked Sendable {
   @discardableResult
   func run(_ keyboardShortcuts: [KeyShortcut],
            type: CGEventType,
-           originalEvent: CGEvent?,
+           originalEvent: CGEvent? = nil,
+           isRepeating: Bool = false,
            with eventSource: CGEventSource?) throws -> [CGEvent] {
     guard let machPort else {
       throw KeyboardCommandRunnerError.failedToResolveMachPortController
@@ -50,8 +51,11 @@ final class KeyboardCommandRunner: @unchecked Sendable {
           if let originalEvent {
             let originalKeyboardEventAutorepeat = originalEvent.getIntegerValueField(.keyboardEventAutorepeat)
             newEvent.setIntegerValueField(.keyboardEventAutorepeat, value: originalKeyboardEventAutorepeat)
+          } else if isRepeating {
+            newEvent.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
           }
         }
+
         events.append(newEvent)
       } catch let error {
         throw error

--- a/App/Sources/Core/Runners/KeyboardCommandRunner.swift
+++ b/App/Sources/Core/Runners/KeyboardCommandRunner.swift
@@ -22,6 +22,7 @@ final class KeyboardCommandRunner: @unchecked Sendable {
     store.virtualKey(for: string, modifiers: modifiers, matchDisplayValue: matchDisplayValue)
   }
 
+  @discardableResult
   func run(_ keyboardShortcuts: [KeyShortcut],
            type: CGEventType,
            originalEvent: CGEvent?,

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -15,6 +15,7 @@ final class KeyboardCowboyEngine {
   private let keyCodeStore: KeyCodesStore
   private let machPortCoordinator: MachPortCoordinator
   private let notificationCenterPublisher: NotificationCenterPublisher
+  private let snippetController: SnippetController
   private let shortcutStore: ShortcutStore
   private let workspace: NSWorkspace
   private let workspacePublisher: WorkspacePublisher
@@ -33,6 +34,7 @@ final class KeyboardCowboyEngine {
        notificationCenter: NotificationCenter = .default,
        scriptCommandRunner: ScriptCommandRunner,
        shortcutStore: ShortcutStore,
+       snippetController: SnippetController,
        uiElementCaptureStore: UIElementCaptureStore,
        workspace: NSWorkspace = .shared) {
     
@@ -43,6 +45,7 @@ final class KeyboardCowboyEngine {
     self.shortcutStore = shortcutStore
     self.uiElementCaptureStore = uiElementCaptureStore
     self.applicationTriggerController = ApplicationTriggerController(commandRunner)
+    self.snippetController = snippetController
     self.workspace = workspace
     self.workspacePublisher = WorkspacePublisher(workspace)
     self.notificationCenterPublisher = NotificationCenterPublisher(notificationCenter)
@@ -84,6 +87,7 @@ final class KeyboardCowboyEngine {
       machPortController = newMachPortController
       keyCodeStore.subscribe(to: notificationCenterPublisher.$keyboardSelectionDidChange)
       uiElementCaptureStore.subscribe(to: machPortCoordinator)
+      snippetController.subscribe(to: machPortCoordinator.$event)
     } catch let error {
       NSAlert(error: error).runModal()
     }
@@ -99,5 +103,7 @@ final class KeyboardCowboyEngine {
     applicationTriggerController.subscribe(to: UserSpace.shared.$frontMostApplication)
     applicationTriggerController.subscribe(to: UserSpace.shared.$runningApplications)
     applicationTriggerController.subscribe(to: contentStore.groupStore.$groups)
+
+    snippetController.subscribe(to: contentStore.groupStore.$groups)
   }
 }

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -87,7 +87,7 @@ final class KeyboardCowboyEngine {
       machPortController = newMachPortController
       keyCodeStore.subscribe(to: notificationCenterPublisher.$keyboardSelectionDidChange)
       uiElementCaptureStore.subscribe(to: machPortCoordinator)
-      snippetController.subscribe(to: machPortCoordinator.$event)
+      snippetController.subscribe(to: machPortCoordinator.$coordinatorEvent)
     } catch let error {
       NSAlert(error: error).runModal()
     }
@@ -105,6 +105,5 @@ final class KeyboardCowboyEngine {
     applicationTriggerController.subscribe(to: UserSpace.shared.$frontMostApplication)
     applicationTriggerController.subscribe(to: UserSpace.shared.$runningApplications)
     applicationTriggerController.subscribe(to: contentStore.groupStore.$groups)
-
   }
 }

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -98,12 +98,13 @@ final class KeyboardCowboyEngine {
   private func subscribe(to workspace: NSWorkspace) {
     WindowStore.shared.subscribe(to: UserSpace.shared.$frontMostApplication)
 
+    snippetController.subscribe(to: contentStore.groupStore.$groups)
+
     guard KeyboardCowboy.env() == .production else { return }
 
     applicationTriggerController.subscribe(to: UserSpace.shared.$frontMostApplication)
     applicationTriggerController.subscribe(to: UserSpace.shared.$runningApplications)
     applicationTriggerController.subscribe(to: contentStore.groupStore.$groups)
 
-    snippetController.subscribe(to: contentStore.groupStore.$groups)
   }
 }

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -254,7 +254,6 @@ final class MachPortCoordinator {
 
       if machPortEvent.type == .keyDown {
         notifications.notifyBundles(partialMatch)
-        workflowRunner.cancelWorkItem()
         previousPartialMatch = partialMatch
       }
     case .exact(let workflow):

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -329,8 +329,9 @@ final class MachPortCoordinator {
           workItem = schedule(workflow, for: shortcut.original, machPortEvent: machPortEvent, after: delay)
         } else {
           workflowRunner.run(workflow, for: shortcut.original, machPortEvent: machPortEvent, repeatingEvent: false)
+          reset()
+          previousPartialMatch = Self.defaultPartialMatch
         }
-
       } else if machPortEvent.type == .keyDown, !isRepeatingEvent {
         if macroCoordinator.state == .recording {
           macroCoordinator.record(shortcut, kind: .workflow(workflow), machPortEvent: machPortEvent)
@@ -340,6 +341,7 @@ final class MachPortCoordinator {
           workItem = schedule(workflow, for: shortcut.original, machPortEvent: machPortEvent, after: delay)
         } else {
           workflowRunner.run(workflow, for: shortcut.original, machPortEvent: machPortEvent, repeatingEvent: false)
+          reset()
         }
 
         previousPartialMatch = Self.defaultPartialMatch
@@ -423,6 +425,8 @@ final class MachPortCoordinator {
       guard self.workItem?.isCancelled != true else { return }
 
       workflowRunner.run(workflow, for: shortcut, machPortEvent: machPortEvent, repeatingEvent: false)
+      reset()
+      previousPartialMatch = Self.defaultPartialMatch
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
     return workItem

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -333,7 +333,6 @@ final class MachPortCoordinator {
           workItem = schedule(workflow, for: shortcut.original, machPortEvent: machPortEvent, after: delay)
         } else {
           workflowRunner.run(workflow, for: shortcut.original, machPortEvent: machPortEvent, repeatingEvent: false)
-          reset()
           previousPartialMatch = Self.defaultPartialMatch
         }
       } else if machPortEvent.type == .keyDown, !isRepeatingEvent {
@@ -345,7 +344,6 @@ final class MachPortCoordinator {
           workItem = schedule(workflow, for: shortcut.original, machPortEvent: machPortEvent, after: delay)
         } else {
           workflowRunner.run(workflow, for: shortcut.original, machPortEvent: machPortEvent, repeatingEvent: false)
-          reset()
         }
 
         previousPartialMatch = Self.defaultPartialMatch

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -119,14 +119,14 @@ final class MachPortCoordinator {
     let isRepeatingEvent: Bool = machPortEvent.event.getIntegerValueField(.keyboardEventAutorepeat) == 1
     switch machPortEvent.type {
       case .keyDown:
-        if previousPartialMatch.rawValue != Self.defaultPartialMatch.rawValue,
-           machPortEvent.keyCode == kVK_Escape {
-          if machPortEvent.event.flags == CGEventFlags.maskNonCoalesced {
-            machPortEvent.result = nil
-            reset()
-            return
-          }
+      if machPortEvent.keyCode == kVK_Escape {
+        notifications.reset()
+        if previousPartialMatch.rawValue != Self.defaultPartialMatch.rawValue, machPortEvent.event.flags == CGEventFlags.maskNonCoalesced {
+          machPortEvent.result = nil
+          reset()
+          return
         }
+      }
       case .keyUp:
         workItem?.cancel()
         workItem = nil
@@ -254,6 +254,7 @@ final class MachPortCoordinator {
 
       if machPortEvent.type == .keyDown {
         notifications.notifyBundles(partialMatch)
+        workflowRunner.cancelWorkItem()
         previousPartialMatch = partialMatch
       }
     case .exact(let workflow):
@@ -282,7 +283,6 @@ final class MachPortCoordinator {
             return
           }
 
-          notifications.reset()
           for newEvent in newEvents {
             self.coordinatorEvent = newEvent
           }
@@ -294,6 +294,7 @@ final class MachPortCoordinator {
         repeatingResult = execution
         repeatingKeyCode = machPortEvent.keyCode
         previousPartialMatch = Self.defaultPartialMatch
+        notifications.reset()
       } else if workflow.commands.isValidForRepeat {
         guard machPortEvent.type == .keyDown else { return }
         if macroCoordinator.state == .recording {

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -282,6 +282,7 @@ final class MachPortCoordinator {
             return
           }
 
+          notifications.reset()
           for newEvent in newEvents {
             self.coordinatorEvent = newEvent
           }

--- a/App/Sources/Core/Runners/MachPortCoordinator.swift
+++ b/App/Sources/Core/Runners/MachPortCoordinator.swift
@@ -169,16 +169,19 @@ final class MachPortCoordinator {
           for element in macro {
             switch element {
             case .event(let machPortEvent):
-              try? machPort?.post(Int(machPortEvent.keyCode), type: .keyDown, flags: machPortEvent.event.flags)
+              try machPort?.post(Int(machPortEvent.keyCode), type: .keyDown, flags: machPortEvent.event.flags)
               try machPort?.post(Int(machPortEvent.keyCode), type: .keyUp, flags: machPortEvent.event.flags)
             case .workflow(let workflow):
               if workflow.commands.allSatisfy({ $0.isKeyboardBinding }) {
                 for command in workflow.commands {
                   if case .keyboard(let command) = command {
-                    try? keyboardCommandRunner.run(command.keyboardShortcuts,
-                                                   type: machPortEvent.type,
-                                                   originalEvent: machPortEvent.event,
-                                                   with: machPortEvent.eventSource)
+                    let types: [CGEventType] = [.keyDown, .keyUp]
+                    for type in types {
+                      _ = try keyboardCommandRunner.run(command.keyboardShortcuts,
+                                                        type: type,
+                                                        originalEvent: machPortEvent.event,
+                                                        with: machPortEvent.eventSource)
+                    }
                   }
                 }
 
@@ -278,6 +281,7 @@ final class MachPortCoordinator {
                                                                with: machPortEvent.eventSource) else {
             return
           }
+
           for newEvent in newEvents {
             self.coordinatorEvent = newEvent
           }

--- a/App/Sources/Core/Runners/MachPortUINotifications.swift
+++ b/App/Sources/Core/Runners/MachPortUINotifications.swift
@@ -50,6 +50,7 @@ final class MachPortUINotifications {
        case .keyboardShortcuts(let trigger) = workflow.trigger {
       let shortcuts = Array(trigger.shortcuts.prefix(prefix))
       let matches = keyboardShortcutsController.allMatchingPrefix(match.rawValue, shortcutIndexPrefix: prefix)
+        .sorted(by: { $0.name < $1.name })
 
       Task { @MainActor in
         WorkflowNotificationController.shared.post(.init(id: workflow.id,

--- a/App/Sources/Core/Runners/MachPortUINotifications.swift
+++ b/App/Sources/Core/Runners/MachPortUINotifications.swift
@@ -18,9 +18,12 @@ final class MachPortUINotifications {
     shouldReset = true
     if case .keyboardShortcuts(let trigger) = workflow.trigger {
       Task { @MainActor in
-        WorkflowNotificationController.shared.post(.init(id: workflow.id,
-                                                         workflow: workflow,
-                                                         keyboardShortcuts: trigger.shortcuts))
+        WorkflowNotificationController.shared.post(
+          WorkflowNotificationViewModel(
+            id: workflow.id,
+            workflow: workflow,
+            keyboardShortcuts: trigger.shortcuts),
+          scheduleDismiss: true)
       }
     }
   }
@@ -35,14 +38,18 @@ final class MachPortUINotifications {
         keyboardShortcuts.append(.init(id: "spacer", key: "="))
         keyboardShortcuts.append(contentsOf: command.keyboardShortcuts)
       }
-      WorkflowNotificationController.shared.post(.init(id: workflow.id,
-                                                       workflow: nil,
-                                                       keyboardShortcuts: keyboardShortcuts))
+      WorkflowNotificationController.shared.post(
+        WorkflowNotificationViewModel(
+          id: workflow.id,
+          workflow: nil,
+          keyboardShortcuts: keyboardShortcuts),
+        scheduleDismiss: true)
     }
   }
 
   func notifyBundles(_ match: PartialMatch) {
     guard notificationBundles else { return }
+
     shouldReset = true
     let splits = match.rawValue.split(separator: "+")
     let prefix = splits.count - 1
@@ -55,10 +62,14 @@ final class MachPortUINotifications {
         .sorted(by: { $0.name < $1.name })
 
       Task { @MainActor in
-        WorkflowNotificationController.shared.post(.init(id: workflow.id,
-                                                         matches: sortedMatches,
-                                                         glow: true,
-                                                         keyboardShortcuts: shortcuts))
+        WorkflowNotificationController.shared.cancelReset()
+        WorkflowNotificationController.shared.post(
+          WorkflowNotificationViewModel(
+            id: workflow.id,
+            matches: sortedMatches,
+            glow: true,
+            keyboardShortcuts: shortcuts), 
+          scheduleDismiss: false)
       }
     }
   }
@@ -67,10 +78,15 @@ final class MachPortUINotifications {
     guard shouldReset else { return }
     shouldReset = false
     Task { @MainActor in
-      WorkflowNotificationController.shared.post(.init(id: UUID().uuidString,
-                                                       matches: [],
-                                                       glow: false,
-                                                       keyboardShortcuts: []))
+      WorkflowNotificationController.shared.post(
+        WorkflowNotificationViewModel(
+          id: UUID().uuidString,
+          matches: [],
+          glow: false,
+          keyboardShortcuts: []
+        ),
+        scheduleDismiss: false
+      )
     }
   }
 

--- a/App/Sources/Core/Runners/MachPortUINotifications.swift
+++ b/App/Sources/Core/Runners/MachPortUINotifications.swift
@@ -49,12 +49,14 @@ final class MachPortUINotifications {
     if let workflow = match.workflow,
        case .keyboardShortcuts(let trigger) = workflow.trigger {
       let shortcuts = Array(trigger.shortcuts.prefix(prefix))
-      let matches = keyboardShortcutsController.allMatchingPrefix(match.rawValue, shortcutIndexPrefix: prefix)
+      let matches = Set(keyboardShortcutsController.allMatchingPrefix(match.rawValue, shortcutIndexPrefix: prefix))
+
+      let sortedMatches = Array(matches)
         .sorted(by: { $0.name < $1.name })
 
       Task { @MainActor in
         WorkflowNotificationController.shared.post(.init(id: workflow.id,
-                                                         matches: matches,
+                                                         matches: sortedMatches,
                                                          glow: true,
                                                          keyboardShortcuts: shortcuts))
       }

--- a/App/Sources/Core/Runners/TextCommandRunner.swift
+++ b/App/Sources/Core/Runners/TextCommandRunner.swift
@@ -45,7 +45,9 @@ final class TextCommandRunner {
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(input, forType: .string)
+      try await Task.sleep(for: .milliseconds(1))
       try keyboardCommandRunner.machPort?.post(kVK_ANSI_V, type: .keyDown, flags: .maskCommand)
+      try await Task.sleep(for: .milliseconds(1))
     }
   }
 }

--- a/App/Sources/Core/Runners/TextCommandRunner.swift
+++ b/App/Sources/Core/Runners/TextCommandRunner.swift
@@ -40,14 +40,16 @@ final class TextCommandRunner {
         }
 
         try keyboardCommandRunner.machPort?.post(keyCode, type: .keyDown, flags: flags)
+        try keyboardCommandRunner.machPort?.post(keyCode, type: .keyUp, flags: flags)
       }
     case .instant:
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(input, forType: .string)
-      try await Task.sleep(for: .milliseconds(1))
+      try await Task.sleep(for: .milliseconds(10))
       try keyboardCommandRunner.machPort?.post(kVK_ANSI_V, type: .keyDown, flags: .maskCommand)
-      try await Task.sleep(for: .milliseconds(1))
+      try keyboardCommandRunner.machPort?.post(kVK_ANSI_V, type: .keyUp, flags: .maskCommand)
+      try await Task.sleep(for: .milliseconds(10))
     }
   }
 }

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -16,9 +16,14 @@ final class WorkflowRunner: @unchecked Sendable {
     self.notifications = notifications
   }
 
+  func cancelWorkItem() {
+    workItem?.cancel()
+  }
+
   func run(_ workflow: Workflow, for shortcut: KeyShortcut,
            executionOverride: Workflow.Execution? = nil,
            machPortEvent: MachPortEvent, repeatingEvent: Bool) {
+    workItem?.cancel()
     notifications.notifyRunningWorkflow(workflow)
     let commands = workflow.commands.filter(\.isEnabled)
 
@@ -51,7 +56,6 @@ final class WorkflowRunner: @unchecked Sendable {
                               repeatingEvent: repeatingEvent)
     }
 
-    workItem?.cancel()
     workItem = DispatchWorkItem { [notifications] in
       notifications.reset()
     }

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -7,6 +7,8 @@ final class WorkflowRunner: @unchecked Sendable {
   private let store: KeyCodesStore
   private let notifications: MachPortUINotifications
 
+  private var workItem: DispatchWorkItem?
+
   init(commandRunner: CommandRunner, store: KeyCodesStore, 
        notifications: MachPortUINotifications) {
     self.commandRunner = commandRunner
@@ -48,5 +50,11 @@ final class WorkflowRunner: @unchecked Sendable {
                               shortcut: shortcut, machPortEvent: machPortEvent,
                               repeatingEvent: repeatingEvent)
     }
+
+    workItem?.cancel()
+    workItem = DispatchWorkItem { [notifications] in
+      notifications.reset()
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem!)
   }
 }

--- a/App/Sources/Core/Runners/WorkflowRunner.swift
+++ b/App/Sources/Core/Runners/WorkflowRunner.swift
@@ -7,7 +7,7 @@ final class WorkflowRunner: @unchecked Sendable {
   private let store: KeyCodesStore
   private let notifications: MachPortUINotifications
 
-  private var workItem: DispatchWorkItem?
+
 
   init(commandRunner: CommandRunner, store: KeyCodesStore, 
        notifications: MachPortUINotifications) {
@@ -16,14 +16,9 @@ final class WorkflowRunner: @unchecked Sendable {
     self.notifications = notifications
   }
 
-  func cancelWorkItem() {
-    workItem?.cancel()
-  }
-
   func run(_ workflow: Workflow, for shortcut: KeyShortcut,
            executionOverride: Workflow.Execution? = nil,
            machPortEvent: MachPortEvent, repeatingEvent: Bool) {
-    workItem?.cancel()
     notifications.notifyRunningWorkflow(workflow)
     let commands = workflow.commands.filter(\.isEnabled)
 
@@ -55,10 +50,5 @@ final class WorkflowRunner: @unchecked Sendable {
                               shortcut: shortcut, machPortEvent: machPortEvent,
                               repeatingEvent: repeatingEvent)
     }
-
-    workItem = DispatchWorkItem { [notifications] in
-      notifications.reset()
-    }
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem!)
   }
 }

--- a/App/Sources/Core/Stores/KeyCodesStore.swift
+++ b/App/Sources/Core/Stores/KeyCodesStore.swift
@@ -50,8 +50,8 @@ final class KeyCodesStore {
                                         matchDisplayValue: matchDisplayValue)?.keyCode
   }
 
-  func displayValue(for keyCode: Int) -> String? {
-    virtualKeyContainer?.valueForKeyCode(keyCode, modifier: nil)?.displayValue
+  func displayValue(for keyCode: Int, modifier: VirtualModifierKey? = nil) -> String? {
+    virtualKeyContainer?.valueForKeyCode(keyCode, modifier: modifier)?.displayValue
   }
 
   // MARK: Private methods

--- a/App/Sources/Core/UserSpace.swift
+++ b/App/Sources/Core/UserSpace.swift
@@ -22,6 +22,7 @@ final class UserSpace: Sendable {
     case filename = "FILENAME"
     case `extension` = "EXTENSION"
     case selectedText = "SELECTED_TEXT"
+    case pasteboard = "PASTEBOARD"
 
     var asTextVariable: String { "$\(rawValue)" }
   }
@@ -87,8 +88,14 @@ final class UserSpace: Sendable {
             .replacingOccurrences(of: .file, with: lastPathComponent as String)
             .replacingOccurrences(of: .filepath, with: (url.lastPathComponent as NSString).pathExtension)
             .replacingOccurrences(of: .extension, with: (url.lastPathComponent as NSString).pathExtension)
+
         }
       }
+
+      if let pasteboard = NSPasteboard.general.string(forType: .string) {
+        interpolatedString = interpolatedString.replacingOccurrences(of: .pasteboard, with: pasteboard)
+      }
+
       return interpolatedString
     }
 
@@ -113,9 +120,14 @@ final class UserSpace: Sendable {
           environment[.filepath] = components.path.replacingOccurrences(of: "%20", with: " ")
           environment[.filename] = (url.lastPathComponent as NSString).deletingPathExtension
           environment[.extension] = (url.lastPathComponent as NSString).pathExtension
+
         }
       }
 
+      if let pasteboard = NSPasteboard.general.string(forType: .string) {
+        environment[.pasteboard] = pasteboard
+      }
+      
       return environment
     }
   }
@@ -280,8 +292,8 @@ final class UserSpace: Sendable {
       NSPasteboard.general.string(forType: .string)
     }
 
-    try? machPort?.post(kVK_ANSI_C, type: .keyDown, flags: .maskCommand)
-    try? machPort?.post(kVK_ANSI_C, type: .keyUp, flags: .maskCommand)
+    _ = try? machPort?.post(kVK_ANSI_C, type: .keyDown, flags: .maskCommand)
+    _ = try? machPort?.post(kVK_ANSI_C, type: .keyUp, flags: .maskCommand)
 
     try await Task.sleep(for: .seconds(0.1))
 

--- a/App/Sources/UI/AppScene.swift
+++ b/App/Sources/UI/AppScene.swift
@@ -2,5 +2,6 @@ enum AppScene {
   case permissions
   case mainWindow
   case addGroup
+  case addCommand(DetailViewModel.ID)
   case editGroup(GroupViewModel.ID)
 }

--- a/App/Sources/UI/Controllers/MouseWindowController.swift
+++ b/App/Sources/UI/Controllers/MouseWindowController.swift
@@ -9,15 +9,18 @@ final class MouseModel: ObservableObject {
 final class MouseWindowController {
   static let shared = MouseWindowController()
 
-  lazy var model: MouseModel = MouseModel()
-  lazy var windowController: NSWindowController = {
+  private var model: MouseModel
+  private var windowController: NSWindowController
+
+  init() {
+    let model = MouseModel()
     let window = NotificationWindow(
       animationBehavior: .none,
-      content: MouseView(model: self.model)
+      content: MouseView(model: model)
     )
-    let windowController = NSWindowController(window: window)
-    return windowController
-  }()
+    self.model = model
+    self.windowController = NSWindowController(window: window)
+  }
 
   func post(_ rect: CGRect) {
     model.rect = rect

--- a/App/Sources/UI/Controllers/UserModesBezelController.swift
+++ b/App/Sources/UI/Controllers/UserModesBezelController.swift
@@ -7,10 +7,14 @@ final class UserModesBezelController {
   @MainActor
   static let shared = UserModesBezelController()
 
-  lazy var windowController: NSWindowController = NSWindowController(window: window)
-  lazy var window: NotificationPanel = {
+  private var windowController: NSWindowController
+  private var window: NotificationPanel<CurrentUserModesView>
+  private var debouncer: DebounceManager<[UserMode]>?
+  private var subscription: AnyCancellable?
+
+  private init() { 
     let content = CurrentUserModesView(publisher: UserSpace.shared.userModesPublisher)
-    return NotificationPanel(
+    let window =  NotificationPanel(
       animationBehavior: .utilityWindow,
       styleMask: [
         .borderless,
@@ -18,12 +22,10 @@ final class UserModesBezelController {
       ],
       content: content
     )
-  }()
 
-  private var debouncer: DebounceManager<[UserMode]>?
-  private var subscription: AnyCancellable?
+    self.window = window
+    self.windowController = NSWindowController(window: window)
 
-  private init() { 
     debouncer = DebounceManager(for: .milliseconds(250)) { [weak self] userModes in
       self?.publish(userModes)
     }

--- a/App/Sources/UI/Controllers/WorkflowNotificationController.swift
+++ b/App/Sources/UI/Controllers/WorkflowNotificationController.swift
@@ -31,6 +31,8 @@ final class WorkflowNotificationController: ObservableObject {
   }
 
   func post(_ notification: WorkflowNotificationViewModel) {
+    guard notification != publisher.data else { return }
+
     Task { @MainActor [publisher, windowController] in
       withAnimation(WorkflowNotificationView.animation) {
         publisher.publish(notification)

--- a/App/Sources/UI/Coordinators/DetailCoordinator.swift
+++ b/App/Sources/UI/Coordinators/DetailCoordinator.swift
@@ -363,7 +363,8 @@ extension SingleDetailView.Action {
          .updateExecution(let workflowId, _),
          .runWorkflow(let workflowId),
          .togglePassthrough(let workflowId, _),
-         .updateHoldDuration(let workflowId, _):
+         .updateHoldDuration(let workflowId, _),
+         .updateSnippet(let workflowId, _):
       return workflowId
     }
   }

--- a/App/Sources/UI/Menubar/FileMenu.swift
+++ b/App/Sources/UI/Menubar/FileMenu.swift
@@ -2,10 +2,13 @@ import SwiftUI
 
 struct FileMenu: View {
   @EnvironmentObject private var store: GroupStore
+  @EnvironmentObject private var detail: ViewModelPublisher<DetailViewState>
+  @EnvironmentObject private var info: ViewModelPublisher<DetailViewModel.Info>
 
   var onNewConfiguration: () -> Void
   var onNewGroup: () -> Void
   var onNewWorkflow: () -> Void
+  var onNewCommand: (DetailViewModel.Info.ID) -> Void
 
   var body: some View {
     Button(action: onNewConfiguration, label: { Text("New Configuration") })
@@ -14,5 +17,17 @@ struct FileMenu: View {
     Button(action: onNewWorkflow, label: { Text("New Workflow") })
       .keyboardShortcut("n", modifiers: [.option, .command])
       .disabled(store.groups.isEmpty)
+    Button(action: {
+      onNewCommand(info.data.id)
+    }, label: { Text("New Command") })
+      .keyboardShortcut("n", modifiers: [.command])
+      .disabled(!newCommandIsEnabled())
+  }
+
+  private func newCommandIsEnabled() -> Bool {
+    switch detail.data {
+    case .single: true
+    default: false
+    }
   }
 }

--- a/App/Sources/UI/Reducers/DetailViewActionReducer.swift
+++ b/App/Sources/UI/Reducers/DetailViewActionReducer.swift
@@ -56,6 +56,8 @@ final class DetailViewActionReducer {
             shortcuts: keyboardShortcuts
           )
         )
+      case .updateSnippet(_, let trigger):
+        workflow.trigger = .snippet(.init(id: trigger.id, text: trigger.text))
       case .updateHoldDuration(_, let holdDuration):
         guard case .keyboardShortcuts(var trigger) = workflow.trigger else {
           return .none
@@ -80,6 +82,8 @@ final class DetailViewActionReducer {
         switch action {
         case .addKeyboardShortcut:
           workflow.trigger = .keyboardShortcuts(.init(shortcuts: []))
+        case .addSnippet:
+          workflow.trigger = .snippet(.init(id: UUID().uuidString, text: ""))
         case .removeKeyboardShortcut:
           workflow.trigger = nil
         case .addApplication:

--- a/App/Sources/UI/Releases/Release3_23_0.swift
+++ b/App/Sources/UI/Releases/Release3_23_0.swift
@@ -1,0 +1,136 @@
+import Bonzai
+import SwiftUI
+
+struct Release3_23_0: View {
+  enum ButtonAction {
+    case done
+  }
+
+  let size: CGFloat = 96
+  let action: (ButtonAction) -> Void
+
+  var body: some View {
+    VStack(spacing: 8) {
+      HStack(spacing: 16) {
+        ZStack {
+          SnippetIconView(size: size)
+            .scaleEffect(0.8)
+            .offset(y: -24)
+            .opacity(0.5)
+          SnippetIconView(size: size)
+            .scaleEffect(0.9)
+            .offset(y: -12)
+            .shadow(radius: 2)
+            .opacity(0.5)
+          SnippetIconView(size: size)
+            .shadow(radius: 2)
+        }
+        VStack(alignment: .leading) {
+          Text("Keyboard Cowboy")
+            .font(Font.system(size: 16, design: .rounded))
+          Text("3.23.0")
+            .foregroundStyle(.white)
+            .font(Font.system(size: 43, design: .rounded))
+            .allowsTightening(true)
+            .fontWeight(.heavy)
+            .shadow(color: Color(.systemPink), radius: 10)
+        }
+        .shadow(radius: 2)
+        .frame(width: 300, height: size)
+        .fixedSize()
+        .background {
+          Rectangle()
+            .fill(.black)
+            .overlay {
+              AngularGradient(stops: [
+                .init(color: Color.clear, location: 0.0),
+                .init(color: Color.white.opacity(0.2), location: 0.2),
+                .init(color: Color.clear, location: 1.0),
+              ], center: .bottomLeading)
+
+              LinearGradient(stops: [
+                .init(color: Color.white.opacity(0.2), location: 0),
+                .init(color: Color.clear, location: 0.3),
+              ], startPoint: .top, endPoint: .bottom)
+
+              LinearGradient(stops: [
+                .init(color: Color.clear, location: 0.8),
+                .init(color: Color(.windowBackgroundColor).opacity(0.3), location: 1.0),
+              ], startPoint: .top, endPoint: .bottom)
+
+            }
+        }
+        .iconShape(size)
+      }
+      .padding(.top, 32)
+
+      ZenDivider()
+        .frame(maxWidth: 400)
+        .padding(.top, 8)
+
+      VStack(alignment: .leading, spacing: 16) {
+        ScrollView(.vertical) {
+          VStack(spacing: 6) {
+            HStack(spacing: 12) {
+              SnippetIconView(size: 32)
+              Text("Snippet: write more with less")
+                .font(Font.system(.title2, design: .rounded, weight: .bold))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Introducing Snippet triggers, small trigger words that expand into a collection of workflows running, at your command.")
+              .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+              .padding(.vertical, 8)
+
+            Text("Other Changes")
+              .font(Font.system(.headline, weight: .bold))
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.bottom, 6)
+
+            VStack(alignment: .leading, spacing: 12) {
+              HStack(alignment: .top, spacing: 12) {
+                UIElementIconView(size: 24)
+                VStack(spacing: 12) {
+                  Text("UI element capturing now work for Electron-based applications, such as Spotify, Slack and Discord.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+              }
+
+              HStack(alignment: .top, spacing: 12) {
+                ImprovementIconView(size: 24)
+                VStack(spacing: 12) {
+                  Text("Commands that rely on the pasteboard is now a whole lot more realiable across the board.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+              }
+            }
+            .font(Font.system(.caption2, design: .rounded))
+            .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        }
+        .frame(minHeight: 200)
+      }
+      .frame(width: 380)
+      .roundedContainer(margin: 0)
+      .padding(.top, 8)
+      .padding(.horizontal, 16)
+
+      HStack(spacing: 8) {
+        Button(action: { action(.done) }, label: { Text("Snipp Snapp Snute!") })
+          .buttonStyle(.zen(.init(color: .systemGreen, hoverEffect: .constant(false))))
+      }
+      .padding(.top, 8)
+      .padding(.bottom, 32)
+      .frame(width: 410)
+    }
+    .background(Color(.windowBackgroundColor))
+  }
+}
+
+struct Release3_23_0_Previews: PreviewProvider {
+  static var previews: some View {
+    Release3_23_0 { _ in }
+      .previewDisplayName("Release 3.23.0")
+  }
+}

--- a/App/Sources/UI/Stores/UIElementCaptureStore.swift
+++ b/App/Sources/UI/Stores/UIElementCaptureStore.swift
@@ -116,6 +116,10 @@ final class UIElementCaptureStore: ObservableObject {
 
         var enhancedUserInterface = false
         if let pid = app.pid, let appValue = app.enhancedUserInterface {
+          let runningApplication = NSRunningApplication(processIdentifier: pid)
+          runningApplication?.activate()
+          try await Task.sleep(for: .milliseconds(100))
+
           app.enhancedUserInterface = true
           enhancedUserInterface = appValue
           AXUIElementSetAttributeValue(app.reference, "AXManualAccessibility" as CFString, true as CFTypeRef)

--- a/App/Sources/UI/Views/AddUserModeView.swift
+++ b/App/Sources/UI/Views/AddUserModeView.swift
@@ -9,7 +9,9 @@ struct AddUserModeView: View {
   var body: some View {
     Group {
       HStack {
+        UserModeIconView(size: 24)
         TextField("User Mode Name", text: $name)
+          .textFieldStyle(.regular(nil))
           .onSubmit {
             action(name)
           }

--- a/App/Sources/UI/Views/AppFocus.swift
+++ b/App/Sources/UI/Views/AppFocus.swift
@@ -10,6 +10,7 @@ enum AppFocus: Hashable {
     case name
     case addAppTrigger
     case addKeyboardTrigger
+    case addSnippetTrigger
     case applicationTriggers
     case applicationTrigger(ApplicationTrigger.ID)
     case keyboardShortcuts

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -96,9 +96,9 @@ struct BuiltInCommandView: View {
           .fixedSize()
 
           switch model.kind {
-            case .macro(let macroAction):
+            case .macro:
               EmptyView()
-            case .userMode(let userMode, let action):
+            case .userMode:
               Menu(content: {
                 ForEach(configurationPublisher.data.userModes) { userMode in
                   Button(action: {

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -36,10 +36,7 @@ struct BuiltInCommandView: View {
           case .remove: MacroIconView(.remove, size: iconSize.width)
           }
         case .userMode:
-          switch command.icon.wrappedValue {
-          case .some(let icon): IconView(icon: icon, size: iconSize)
-          case .none: EmptyView()
-          }
+          UserModeIconView(size: iconSize.width)
         }
 
       } content: { _ in
@@ -90,7 +87,7 @@ struct BuiltInCommandView: View {
               },
               label: { Text("Disable User Mode").font(.subheadline) })
           }, label: {
-            Text(model.name)
+            Text(model.kind.displayValue)
               .font(.subheadline)
           })
           .fixedSize()

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -118,9 +118,7 @@ struct BuiltInCommandView: View {
 
         }
           .menuStyle(.regular)
-      } subContent: { _ in
-
-      } onAction: {
+      } subContent: { _ in } onAction: {
         onAction(.commandAction($0))
       }
 

--- a/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
+++ b/App/Sources/UI/Views/Commands/BuiltInCommandView.swift
@@ -48,6 +48,7 @@ struct BuiltInCommandView: View {
               model.name = newKind.displayValue
               model.kind = newKind
             }, label: {
+              Image(systemName: "record.circle")
               Text("Record Macro").font(.subheadline)
             })
 
@@ -57,6 +58,7 @@ struct BuiltInCommandView: View {
               model.name = newKind.displayValue
               model.kind = newKind
             }, label: {
+              Image(systemName: "minus.circle.fill")
               Text("Remove Macro").font(.subheadline)
             })
 
@@ -68,6 +70,7 @@ struct BuiltInCommandView: View {
                 model.kind = newKind
               },
               label: {
+                Image(systemName: "togglepower")
                 Text("Toggle User Mode").font(.subheadline)
               })
             Button(
@@ -77,7 +80,10 @@ struct BuiltInCommandView: View {
                 model.name = newKind.displayValue
                 model.kind = newKind
               },
-              label: { Text("Enable User Mode").font(.subheadline) })
+              label: {
+                Image(systemName: "lightswitch.on")
+                Text("Enable User Mode").font(.subheadline)
+              })
             Button(
               action: {
                 let newKind: BuiltInCommand.Kind = .userMode(.init(id: model.kind.userModeId, name: model.name, isEnabled: true), .disable)
@@ -85,7 +91,10 @@ struct BuiltInCommandView: View {
                 model.name = newKind.displayValue
                 model.kind = newKind
               },
-              label: { Text("Disable User Mode").font(.subheadline) })
+              label: {
+                Image(systemName: "lightswitch.off")
+                Text("Disable User Mode").font(.subheadline)
+              })
           }, label: {
             Text(model.kind.displayValue)
               .font(.subheadline)

--- a/App/Sources/UI/Views/ContentImageView.swift
+++ b/App/Sources/UI/Views/ContentImageView.swift
@@ -24,7 +24,7 @@ struct ContentImageView: View {
             MacroIconView(.remove, size: size - 6)
           }
         case .userMode:
-          EmptyView()
+          UserModeIconView(size: size - 6)
         }
       case .keyboard(let model):
         if let firstKey = model.keys.first {

--- a/App/Sources/UI/Views/ContentItemView.swift
+++ b/App/Sources/UI/Views/ContentItemView.swift
@@ -54,10 +54,24 @@ struct ContentItemView: View {
       if let binding = workflow.binding {
         KeyboardShortcutView(shortcut: .init(key: binding, lhs: true, modifiers: []))
           .fixedSize()
-          .font(.caption)
+          .font(.footnote)
           .lineLimit(1)
           .allowsTightening(true)
           .frame(minWidth: 32, alignment: .trailing)
+      } else if let snippet = workflow.snippet {
+        HStack(spacing: 1) {
+          Text(snippet)
+            .font(.footnote)
+          SnippetIconView(size: 12)
+        }
+        .lineLimit(1)
+        .allowsTightening(true)
+        .truncationMode(.tail)
+        .padding(1)
+        .overlay(
+          RoundedRectangle(cornerRadius: 4)
+            .stroke(Color(.separatorColor), lineWidth: 1)
+        )
       }
     }
     .padding(4)

--- a/App/Sources/UI/Views/EditableKeyboardShortcutsView.swift
+++ b/App/Sources/UI/Views/EditableKeyboardShortcutsView.swift
@@ -32,6 +32,7 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
   @State private var replacing: KeyShortcut.ID?
   @State private var selectedColor: Color = .accentColor
   private let animation: Animation = .easeOut(duration: 0.2)
+  private let recordOnAppearIfEmpty: Bool
   private let draggableEnabled: Bool
   private let focusBinding: (KeyShortcut.ID) -> T
   private let onTab: (Bool) -> Void
@@ -44,6 +45,7 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
        draggableEnabled: Bool,
        state: CurrentState? = nil,
        selectionManager: SelectionManager<KeyShortcut>,
+       recordOnAppearIfEmpty: Bool = false,
        onTab: @escaping (Bool) -> Void) {
     self.focus = focus
     self.draggableEnabled = draggableEnabled
@@ -52,6 +54,7 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
     self.focusBinding = focusBinding
     self.onTab = onTab
     self.selectionManager = selectionManager
+    self.recordOnAppearIfEmpty = recordOnAppearIfEmpty
   }
 
   var body: some View {
@@ -164,7 +167,11 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
         .padding(.trailing, 4)
       }
       .overlay(overlay(proxy))
-      .enableInjection()
+      .onAppear {
+        guard recordOnAppearIfEmpty, keyboardShortcuts.isEmpty else { return }
+
+        addButtonAction(proxy)
+      }
     }
     .onChange(of: controlActiveState, perform: { value in
       if value != .key {
@@ -189,6 +196,7 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
         break
       }
     })
+    .enableInjection()
   }
 
   private func rerecord(_ id: KeyShortcut.ID) {
@@ -246,6 +254,7 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
       isGlowing = true
       selectedColor = Color(.systemRed)
     }
+
     DispatchQueue.main.async {
       withAnimation(animation) {
         proxy.scrollTo(keyShortcut.id)

--- a/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
+++ b/App/Sources/UI/Views/Groups/EditWorfklowGroupView.swift
@@ -47,10 +47,13 @@ struct EditWorfklowGroupView: View {
 
       HStack(spacing: 16) {
         VStack(alignment: .leading, spacing: 0) {
-          ZenLabel("User Modes")
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
-            .background(Color(.windowBackgroundColor))
+          HStack {
+            UserModeIconView(size: 24)
+            ZenLabel("User Modes")
+          }
+          .padding(8)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(Color(.windowBackgroundColor))
 
           Menu("Add User Mode") {
             ForEach(publisher.data.userModes) { userMode in
@@ -62,8 +65,7 @@ struct EditWorfklowGroupView: View {
               })
             }
           }
-          .padding(.horizontal)
-          .padding(.bottom)
+          .padding([.leading, .trailing, .bottom], 8)
           .menuStyle(.regular)
           
           ScrollView {
@@ -90,7 +92,7 @@ struct EditWorfklowGroupView: View {
 
         VStack(alignment: .leading, spacing: 0) {
           RuleHeaderView(applicationStore: applicationStore, group: $group)
-            .padding()
+            .padding(8)
             .background(Color(.windowBackgroundColor))
           ScrollView {
             RuleListView(applicationStore: applicationStore,

--- a/App/Sources/UI/Views/Groups/RuleHeaderView.swift
+++ b/App/Sources/UI/Views/Groups/RuleHeaderView.swift
@@ -7,28 +7,33 @@ struct RuleHeaderView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      ZenLabel("Rules")
       HStack {
-        Menu("Application") {
-          ForEach(applicationStore.applications.lazy.filter({
-            if let rule = group.rule {
-              return !rule.bundleIdentifiers.contains($0.bundleIdentifier)
-            } else {
-              return true
+        GenericAppIconView(size: 24)
+        ZenLabel("Rules")
+      }
+      Menu("Application") {
+        ForEach(applicationStore.applications.lazy.filter({
+          if let rule = group.rule {
+            return !rule.bundleIdentifiers.contains($0.bundleIdentifier)
+          } else {
+            return true
+          }
+        }), id: \.path) { application in
+          Button {
+            if group.rule == .none {
+              group.rule = .init()
             }
-          }), id: \.path) { application in
-            Button {
-              if group.rule == .none {
-                group.rule = .init()
-              }
-              group.rule?.bundleIdentifiers.append(application.bundleIdentifier)
-            } label: {
+            group.rule?.bundleIdentifiers.append(application.bundleIdentifier)
+          } label: {
+            if application.metadata.isSafariWebApp {
+              Text("\(application.displayName) (Safari Web App)")
+            } else {
               Text(application.displayName)
             }
           }
         }
-        .menuStyle(.regular)
       }
+      .menuStyle(.regular)
     }
   }
 }

--- a/App/Sources/UI/Views/Icons/ActivateLastApplicationIconView.swift
+++ b/App/Sources/UI/Views/Icons/ActivateLastApplicationIconView.swift
@@ -25,6 +25,7 @@ struct ActivateLastApplicationIconView: View {
               .offset(x: -size * 0.015, y: -size * 0.015)
           }
         }
+        .shadow(color: Color(nsColor: .systemPink.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)
       }
       .frame(width: size, height: size)
       .fixedSize()

--- a/App/Sources/UI/Views/Icons/DockIconView.swift
+++ b/App/Sources/UI/Views/Icons/DockIconView.swift
@@ -26,21 +26,29 @@ struct DockIconView: View {
           let iconSize = size * 0.125
           Rectangle()
             .iconShape(size * 0.1)
+            .overlay { iconOverlay().opacity(0.5) }
+            .overlay { iconBorder(size * 0.1) }
             .frame(width: iconSize, height: iconSize)
             .offset(y: -size * 0.075)
 
           Rectangle()
             .iconShape(size * 0.1)
+            .overlay { iconOverlay().opacity(0.5) }
+            .overlay { iconBorder(size * 0.1) }
             .frame(width: iconSize, height: iconSize)
             .offset(y: -size * 0.075)
 
           Rectangle()
             .iconShape(size * 0.1)
+            .overlay { iconOverlay().opacity(0.5) }
+            .overlay { iconBorder(size * 0.1) }
             .frame(width: iconSize, height: iconSize)
             .offset(y: -size * 0.075)
 
           Rectangle()
             .iconShape(size * 0.1)
+            .overlay { iconOverlay().opacity(0.5) }
+            .overlay { iconBorder(size * 0.1) }
             .frame(width: iconSize, height: iconSize)
             .offset(y: -size * 0.075)
         }

--- a/App/Sources/UI/Views/Icons/GenericAppIconView.swift
+++ b/App/Sources/UI/Views/Icons/GenericAppIconView.swift
@@ -1,0 +1,83 @@
+import Bonzai
+import SwiftUI
+
+struct GenericAppIconView: View {
+  let size: CGFloat
+  var body: some View {
+    Rectangle()
+      .fill(
+        LinearGradient(
+          stops: [
+            .init(color: Color(nsColor: .systemBlue), location: 0.1),
+            .init(color: Color(nsColor: .systemBlue.blended(withFraction: 0.6, of: .black)!), location: 1.0)
+          ],
+          startPoint: .top,
+          endPoint: .bottom)
+      )
+      .overlay { iconOverlay().opacity(0.25) }
+      .overlay { iconBorder(size) }
+      .overlay {
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .white), location: 0.2),
+          .init(color: Color(nsColor: .systemBlue.blended(withFraction: 0.1, of: .white)!), location: 1.0),
+        ], startPoint: .topLeading, endPoint: .bottom)
+        .mask {
+          Image(systemName: "app.dashed")
+            .font(Font.system(size: size * 1.1, weight: .thin, design: .rounded))
+
+
+          Image(systemName: "applepencil.gen1")
+            .font(Font.system(size: size * 0.65, weight: .bold, design: .rounded))
+            .rotationEffect(.degrees(-22))
+            .offset(x: -size * 0.17)
+            .opacity(0.75)
+
+          Image(systemName: "paintbrush.pointed.fill")
+            .font(Font.system(size: size * 0.6, weight: .ultraLight, design: .rounded))
+            .rotationEffect(.degrees(-70))
+            .offset(x: size * 0.18, y: size * 0.025)
+            .opacity(0.75)
+
+          Image(systemName: "ruler.fill")
+            .resizable()
+            .font(Font.system(size: size * 0.4, weight: .ultraLight, design: .rounded))
+            .frame(width: size * 0.65, height: size * 0.175)
+            .offset(y: size * 0.05)
+            .opacity(0.92)
+        }
+        .shadow(color: Color(nsColor: .systemBlue.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)
+      }
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
+  }
+}
+
+#Preview {
+  VStack {
+    HStack(alignment: .top, spacing: 8) {
+      GenericAppIconView(size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        GenericAppIconView(size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          GenericAppIconView(size: 64)
+          GenericAppIconView(size: 32)
+          GenericAppIconView(size: 16)
+        }
+      }
+    }
+
+    HStack(alignment: .top, spacing: 8) {
+      GenericAppIconView(size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        GenericAppIconView(size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          GenericAppIconView(size: 64)
+          GenericAppIconView(size: 32)
+          GenericAppIconView(size: 16)
+        }
+      }
+    }
+  }
+  .padding()
+}

--- a/App/Sources/UI/Views/Icons/GenericAppIconView.swift
+++ b/App/Sources/UI/Views/Icons/GenericAppIconView.swift
@@ -1,7 +1,9 @@
 import Bonzai
+import Inject
 import SwiftUI
 
 struct GenericAppIconView: View {
+  @ObserveInjection var inject
   let size: CGFloat
   var body: some View {
     Rectangle()
@@ -18,38 +20,38 @@ struct GenericAppIconView: View {
       .overlay { iconBorder(size) }
       .overlay {
         LinearGradient(stops: [
-          .init(color: Color(nsColor: .white), location: 0.2),
-          .init(color: Color(nsColor: .systemBlue.blended(withFraction: 0.1, of: .white)!), location: 1.0),
+          .init(color: Color(nsColor: .systemCyan.blended(withFraction: 0.2, of: .white)!), location: 0.2),
+          .init(color: Color(nsColor: .systemBlue), location: 1.0),
         ], startPoint: .topLeading, endPoint: .bottom)
         .mask {
-          Image(systemName: "app.dashed")
-            .font(Font.system(size: size * 1.1, weight: .thin, design: .rounded))
+          Image(systemName: "app.fill")
+            .font(Font.system(size: size * 0.9, weight: .thin, design: .rounded))
+            .mask {
+              Image(systemName: "app.dashed")
+                .font(Font.system(size: size * 0.9, weight: .thin, design: .rounded))
 
+              Image(systemName: "pencil.and.scribble")
+                .font(Font.system(size: size * 0.52, weight: .regular, design: .rounded))
+                .rotationEffect(.degrees(-19))
+                .offset(x: -size * 0.230, y: size * 0.0_86)
 
-          Image(systemName: "applepencil.gen1")
-            .font(Font.system(size: size * 0.65, weight: .bold, design: .rounded))
-            .rotationEffect(.degrees(-22))
-            .offset(x: -size * 0.17)
-            .opacity(0.75)
+              Image(systemName: "pencil")
+                .font(Font.system(size: size * 0.50, weight: .regular, design: .rounded))
+                .rotationEffect(.degrees(45))
+                .offset(y: size * 0.07)
 
-          Image(systemName: "paintbrush.pointed.fill")
-            .font(Font.system(size: size * 0.6, weight: .ultraLight, design: .rounded))
-            .rotationEffect(.degrees(-70))
-            .offset(x: size * 0.18, y: size * 0.025)
-            .opacity(0.75)
-
-          Image(systemName: "ruler.fill")
-            .resizable()
-            .font(Font.system(size: size * 0.4, weight: .ultraLight, design: .rounded))
-            .frame(width: size * 0.65, height: size * 0.175)
-            .offset(y: size * 0.05)
-            .opacity(0.92)
+              Image(systemName: "applepencil.gen1")
+                .font(Font.system(size: size * 0.50, weight: .regular, design: .rounded))
+                .rotationEffect(.degrees(-68))
+                .offset(x: size * 0.10)
+            }
         }
         .shadow(color: Color(nsColor: .systemBlue.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)
       }
       .frame(width: size, height: size)
       .fixedSize()
       .iconShape(size)
+      .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/Icons/IconOverview.swift
+++ b/App/Sources/UI/Views/Icons/IconOverview.swift
@@ -1,43 +1,35 @@
+import Bonzai
 import SwiftUI
 
 struct IconOverview: PreviewProvider {
   static let size: CGFloat = 96
   static var previews: some View {
-    VStack {
-      HStack {
-        DockIconView(size: size)
-        KeyboardIconView("M", size: size)
-        MenuIconView(size: size)
-        MouseIconView(size: size)
-        MissionControlIconView(size: size)
-        ScriptIconView(size: size)
-      }
-
-      HStack {
-        TypingIconView(size: size)
-        UIElementIconView(size: size)
-        WindowManagementIconView(size: size)
-        MinimizeAllIconView(size: size)
-        BugFixIconView(size: size)
-        ImprovementIconView(size: size)
-      }
-
-      HStack {
-        ActivateLastApplicationIconView(size: size)
-        MacroIconView(.record, size: size)
-        MacroIconView(.remove, size: size)
-        MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
-        MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
-        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
-      }
-
-      HStack {
-        MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
-        MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
-        MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
-      }
+    FlowLayout(itemSpacing: 8, lineSpacing: 8) {
+      WindowManagementIconView(size: size)
+      MenuIconView(size: size)
+      MinimizeAllIconView(size: size)
+      ActivateLastApplicationIconView(size: size)
+      SnippetIconView(size: size)
+      MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
+      MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
+      MacroIconView(.remove, size: size)
+      UIElementIconView(size: size)
+      MouseIconView(size: size)
+      BugFixIconView(size: size)
+      MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
+      MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
+      DockIconView(size: size)
+      MissionControlIconView(size: size)
+      MacroIconView(.record, size: size)
+      MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
+      MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+      ScriptIconView(size: size)
+      KeyboardIconView("M", size: size)
+      ImprovementIconView(size: size)
     }
-    .padding()
+    .frame(maxWidth: 96 * 4 + 8 * 4)
+    .padding(16)
     .background(Color(.windowBackgroundColor))
+    .previewLayout(.sizeThatFits)
   }
 }

--- a/App/Sources/UI/Views/Icons/IconOverview.swift
+++ b/App/Sources/UI/Views/Icons/IconOverview.swift
@@ -7,11 +7,8 @@ struct IconOverview: PreviewProvider {
   static var previews: some View {
     FlowLayout(itemSpacing: spacing, lineSpacing: spacing) {
       WindowManagementIconView(size: size)
-      MenuIconView(size: size)
-      MinimizeAllIconView(size: size)
       ActivateLastApplicationIconView(size: size)
       SnippetIconView(size: size)
-      MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
       MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
       MacroIconView(.remove, size: size)
       UIElementIconView(size: size)
@@ -24,7 +21,11 @@ struct IconOverview: PreviewProvider {
       MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
       MissionControlIconView(size: size)
       MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+      GenericAppIconView(size: size)
+      MenuIconView(size: size)
+      MinimizeAllIconView(size: size)
       UserModeIconView(size: size)
+      MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
       ScriptIconView(size: size)
       KeyboardIconView("M", size: size)
       ImprovementIconView(size: size)

--- a/App/Sources/UI/Views/Icons/IconOverview.swift
+++ b/App/Sources/UI/Views/Icons/IconOverview.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 struct IconOverview: PreviewProvider {
   static let size: CGFloat = 96
+  static let spacing: CGFloat = 16
   static var previews: some View {
-    FlowLayout(itemSpacing: 8, lineSpacing: 8) {
+    FlowLayout(itemSpacing: spacing, lineSpacing: spacing) {
       WindowManagementIconView(size: size)
       MenuIconView(size: size)
       MinimizeAllIconView(size: size)
@@ -19,16 +20,17 @@ struct IconOverview: PreviewProvider {
       MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
       MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
       DockIconView(size: size)
-      MissionControlIconView(size: size)
       MacroIconView(.record, size: size)
       MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
+      MissionControlIconView(size: size)
       MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+      UserModeIconView(size: size)
       ScriptIconView(size: size)
       KeyboardIconView("M", size: size)
       ImprovementIconView(size: size)
     }
-    .frame(maxWidth: 96 * 4 + 8 * 4)
-    .padding(16)
+    .frame(maxWidth: size * 5 + spacing * 5)
+    .padding(spacing)
     .background(Color(.windowBackgroundColor))
     .previewLayout(.sizeThatFits)
   }

--- a/App/Sources/UI/Views/Icons/MacroIconView.swift
+++ b/App/Sources/UI/Views/Icons/MacroIconView.swift
@@ -14,20 +14,25 @@ struct MacroIconView: View {
   }
 
   var body: some View {
-    let color = Color(kind == .record 
+    let color: NSColor = kind == .record
                       ? .systemCyan
-                      : .systemYellow)
+                      : .systemYellow
     Rectangle()
-      .fill(color)
-      .overlay { iconOverlay().opacity(0.25) }
+      .fill(LinearGradient(
+        stops: [
+          .init(color: Color(nsColor: color), location: 0.1),
+          .init(color: Color(nsColor: color.withSystemEffect(.disabled)), location: 1.0)
+        ],
+        startPoint: .top,
+        endPoint: .bottom))
       .overlay { iconBorder(size) }
       .overlay(alignment: .center) {
-        backgroundShape(color: color)
+        backgroundShape(color: Color(nsColor: color))
           .scaleEffect(0.8)
           .rotation3DEffect(.degrees(30), axis: (x: 1.0, y: 0.0, z: 0.0))
           .offset(y: -size * 0.225)
 
-        backgroundShape(color: color)
+        backgroundShape(color: Color(nsColor: color))
           .scaleEffect(0.9)
           .rotation3DEffect(.degrees(15), axis: (x: 1.0, y: 0.0, z: 0.0))
           .offset(y: -size * 0.125)
@@ -35,7 +40,7 @@ struct MacroIconView: View {
         Text("MACRO")
           .frame(minWidth: size * 0.9, minHeight: size * 0.4)
           .font(Font.system(size: size * 0.225, weight: .heavy, design: .rounded))
-          .foregroundColor(color)
+          .foregroundColor(Color(nsColor: color))
           .allowsTightening(true)
           .padding(size * 0.02)
           .overlay {

--- a/App/Sources/UI/Views/Icons/MinimizeAllIconView.swift
+++ b/App/Sources/UI/Views/Icons/MinimizeAllIconView.swift
@@ -37,6 +37,7 @@ struct MinimizeAllIconView: View {
           .init(color: Color(nsColor: .white.withSystemEffect(.disabled)), location: 1.0),
         ], startPoint: .topLeading, endPoint: .bottom)
       )
+      .overlay { iconOverlay().opacity(0.5) }
       .overlay(alignment: .topLeading) {
         HStack(alignment: .top, spacing: 0) {
           HStack(alignment: .top, spacing: size.width * 0.0_240) {
@@ -75,10 +76,12 @@ struct MinimizeAllIconView: View {
                 .opacity(0.4)
                 .frame(width: size.width * 0.3)
             }
+            .overlay { iconOverlay().opacity(0.5) }
         }
       }
       .iconShape(size.width * 0.7)
       .frame(width: size.width, height: size.height)
+      .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
   }
 }
 

--- a/App/Sources/UI/Views/Icons/MissionControlIconView.swift
+++ b/App/Sources/UI/Views/Icons/MissionControlIconView.swift
@@ -58,9 +58,12 @@ struct MissionControlIconView: View {
           .padding([.leading, .top], size.width * 0.0675)
           Rectangle()
             .fill(.white.opacity(0.7))
+            .overlay { iconOverlay().opacity(0.5) }
             .frame(maxWidth: .infinity)
         }
       }
+      .overlay { iconOverlay().opacity(0.5) }
+      .overlay { iconBorder(size.width * 0.7) }
       .iconShape(size.width * 0.7)
       .frame(width: size.width, height: size.height)
   }

--- a/App/Sources/UI/Views/Icons/MoveFocusToWindowIconView.swift
+++ b/App/Sources/UI/Views/Icons/MoveFocusToWindowIconView.swift
@@ -119,12 +119,15 @@ struct MoveFocusToWindowIconView: View {
                   height: direction == .next ? focusedSize.height : unfocusedSize.height)
       .opacity(direction == .next ? focusedOpacity : unfocusedOpacity)
       .grayscale(direction == .next ? 0 : 1)
+      .shadow(radius: 4, y: 2)
     }
   }
 
   private func windowShape(width: CGFloat, height: CGFloat) -> some View {
     Rectangle()
       .frame(width: width, height: height)
+      .overlay { iconOverlay().opacity(0.5) }
+      .overlay { iconBorder(width * 0.7) }
       .overlay(alignment: .topLeading) {
         HStack(alignment: .top, spacing: 0) {
           HStack(alignment: .top, spacing: width * 0.0_240) {
@@ -142,6 +145,7 @@ struct MoveFocusToWindowIconView: View {
           Rectangle()
             .fill(.white)
             .frame(maxWidth: .infinity)
+            .overlay { iconOverlay().opacity(0.5) }
         }
       }
       .iconShape(width * 0.7)

--- a/App/Sources/UI/Views/Icons/SnippetIconView.swift
+++ b/App/Sources/UI/Views/Icons/SnippetIconView.swift
@@ -22,7 +22,7 @@ struct SnippetIconView: View {
           .init(color: Color(nsColor: .systemPink.blended(withFraction: 0.2, of: .white)!), location: 1.0),
         ], startPoint: .topLeading, endPoint: .bottom)
         .mask {
-          Text("{}")
+          Image(systemName: "ellipsis.curlybraces")
             .font(Font.system(size: size * 0.6, weight: .bold, design: .monospaced))
         }
         .shadow(color: Color(nsColor: .systemPink.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)

--- a/App/Sources/UI/Views/Icons/SnippetIconView.swift
+++ b/App/Sources/UI/Views/Icons/SnippetIconView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct SnippetIconView: View {
+  let size: CGFloat
+
+  var body: some View {
+    Rectangle()
+      .fill(
+        LinearGradient(
+          stops: [
+            .init(color: Color(nsColor: .systemPink), location: 0.1),
+            .init(color: Color(nsColor: .systemPink.withSystemEffect(.disabled)), location: 1.0)
+          ],
+          startPoint: .top,
+          endPoint: .bottom)
+      )
+      .overlay { iconOverlay().opacity(0.25) }
+      .overlay { iconBorder(size) }
+      .overlay {
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .white), location: 0.2),
+          .init(color: Color(nsColor: .systemPink.blended(withFraction: 0.2, of: .white)!), location: 1.0),
+        ], startPoint: .topLeading, endPoint: .bottom)
+        .mask {
+          Text("{}")
+            .font(Font.system(size: size * 0.6, weight: .bold, design: .monospaced))
+        }
+        .shadow(color: Color(nsColor: .systemPink.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)
+      }
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
+  }
+}
+
+#Preview {
+  VStack {
+    HStack(alignment: .top, spacing: 8) {
+      SnippetIconView(size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        SnippetIconView(size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          SnippetIconView(size: 64)
+          SnippetIconView(size: 32)
+          SnippetIconView(size: 16)
+        }
+      }
+    }
+
+    HStack(alignment: .top, spacing: 8) {
+      SnippetIconView(size: 192)
+      VStack(alignment: .leading, spacing: 8) {
+        SnippetIconView(size: 128)
+        HStack(alignment: .top, spacing: 8) {
+          SnippetIconView(size: 64)
+          SnippetIconView(size: 32)
+          SnippetIconView(size: 16)
+        }
+      }
+    }
+  }
+  .padding()
+}

--- a/App/Sources/UI/Views/Icons/TypingIconView.swift
+++ b/App/Sources/UI/Views/Icons/TypingIconView.swift
@@ -54,7 +54,7 @@ Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The roun
       .overlay(alignment: .center) {
         FlowLayout(
           itemSpacing: size * 0.0_16,
-          padding: size * 0.0_2,
+          lineSpacing: size * 0.0_2,
           minSize: .init(width: size, height: size)
         ) {
           ForEach(Array(zip(text.indices, text)), id: \.0) { index, element in

--- a/App/Sources/UI/Views/Icons/UserModeIconView.swift
+++ b/App/Sources/UI/Views/Icons/UserModeIconView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct UserModeIconView: View {
+  let size: CGFloat
+  var body: some View {
+    Rectangle()
+      .fill(
+        LinearGradient(
+          stops: [
+            .init(color: Color(nsColor: .systemBrown.blended(withFraction: 0.3, of: .systemOrange)!), location: 0.1),
+            .init(color: Color(nsColor: .systemBrown.blended(withFraction: 0.6, of: .black)!), location: 1.0)
+          ],
+          startPoint: .top,
+          endPoint: .bottom)
+      )
+      .overlay { iconOverlay().opacity(0.25) }
+      .overlay { iconBorder(size) }
+      .overlay {
+        LinearGradient(stops: [
+          .init(color: Color(nsColor: .white), location: 0.2),
+          .init(color: Color(nsColor: .systemBrown.blended(withFraction: 0.1, of: .white)!), location: 1.0),
+        ], startPoint: .topLeading, endPoint: .bottom)
+        .mask {
+          Image(systemName: "square.stack.3d.down.forward")
+            .font(Font.system(size: size * 0.6, weight: .heavy, design: .rounded))
+        }
+        .shadow(color: Color(nsColor: .systemBrown.blended(withFraction: 0.4, of: .black)!), radius: 2, y: 1)
+      }
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
+  }
+}
+
+#Preview {
+  HStack(alignment: .top, spacing: 8) {
+    UserModeIconView(size: 192)
+    VStack(alignment: .leading, spacing: 8) {
+      UserModeIconView(size: 128)
+      HStack(alignment: .top, spacing: 8) {
+        UserModeIconView(size: 64)
+        UserModeIconView(size: 32)
+        UserModeIconView(size: 16)
+      }
+    }
+  }
+  .padding()
+}
+

--- a/App/Sources/UI/Views/Icons/WindowManagementIconView.swift
+++ b/App/Sources/UI/Views/Icons/WindowManagementIconView.swift
@@ -15,10 +15,12 @@ struct WindowManagementIconView: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .background(sidebarBackground())
 
-      Divider()
-        .background(Color(.systemGray))
-      Divider()
-        .background(Color.white)
+      Rectangle()
+        .fill(Color(.systemGray))
+        .frame(width: size * 0.0125)
+      Rectangle()
+        .fill(Color.white)
+        .frame(width: size * 0.0125)
 
       window()
         .frame(width: size * 0.182)
@@ -136,10 +138,12 @@ struct WindowManagementIconView: View {
     VStack(spacing: 0) {
       Rectangle()
         .frame(height: size * 0.30)
-      Divider()
-        .background(Color.white)
-      Divider()
-        .background(Color(.systemGray))
+      Rectangle()
+        .fill(Color(.white))
+        .frame(height: size * 0.0125)
+      Rectangle()
+        .fill(Color(.systemGray))
+        .frame(height: size * 0.0125)
       Rectangle()
         .fill(Color(.systemGray).opacity(0.4))
     }

--- a/App/Sources/UI/Views/Keyboard/KeyBackgroundView.swift
+++ b/App/Sources/UI/Views/Keyboard/KeyBackgroundView.swift
@@ -7,28 +7,27 @@ struct KeyBackgroundView: View {
 
   var body: some View {
     Rectangle()
-      .fill(Color(.windowBackgroundColor))
-      .clipShape(RoundedRectangle(cornerRadius: height * 0.1))
-      .padding(0.1)
-      .offset(y: isPressed ? 1 : 0)
-      .scaleEffect(isPressed ? 0.95 : 1)
-      .animation(.linear(duration: 0.1), value: isPressed)
-      .background(
-        Rectangle()
-          .fill(Color.black.opacity( colorScheme == .light ? 0.33 : 0.9 ))
-          .clipShape(RoundedRectangle(cornerRadius: height * 0.1))
-          .offset(x: 0, y: height * 0.025)
-          .scaleEffect(CGSize(width: 0.95, height: 1.0))
-      )
-      .background(
-        Rectangle()
-          .fill(Color.black.opacity( colorScheme == .light ? 0.3 : 0.9 ))
-          .clipShape(RoundedRectangle(cornerRadius: height * 0.1))
-          .offset(x: 0, y: 1)
-          .scaleEffect(CGSize(width: 0.99, height: 1.0))
-          .opacity(isPressed ? 0 : 1)
-          .animation(.linear(duration: 0.1), value: isPressed)
-      )
+      .fill(Color(.textBackgroundColor))
+      .overlay { iconOverlay().opacity(0.2) }
+      .overlay { iconBorder(height) }
+      .overlay {
+        AngularGradient(stops: [
+          .init(color: Color.clear, location: 0.0),
+          .init(color: Color.white.opacity(0.2), location: 0.2),
+          .init(color: Color.clear, location: 1.0),
+        ], center: .bottomLeading)
+
+        LinearGradient(stops: [
+          .init(color: Color.white.opacity(0.1), location: 0),
+          .init(color: Color.clear, location: 0.02),
+        ], startPoint: .top, endPoint: .bottom)
+
+        LinearGradient(stops: [
+          .init(color: Color.clear, location: 0.99),
+          .init(color: Color(.windowBackgroundColor), location: 1.0),
+        ], startPoint: .top, endPoint: .bottom)
+      }
+      .iconShape(height * 0.8)
   }
 }
 

--- a/App/Sources/UI/Views/Keyboard/KeyboardShortcutView.swift
+++ b/App/Sources/UI/Views/Keyboard/KeyboardShortcutView.swift
@@ -4,7 +4,7 @@ struct KeyboardShortcutView: View {
   let shortcut: KeyShortcut
 
   var body: some View {
-    Group {
+    HStack(spacing: 1) {
       Text("\(shortcut.modifersDisplayValue)")
         .foregroundColor(.secondary) +
       Text("\(shortcut.key)")
@@ -14,6 +14,9 @@ struct KeyboardShortcutView: View {
     .truncationMode(.tail)
     .padding(1)
     .padding(.horizontal, 4)
+    .background(
+      KeyBackgroundView(isPressed: .readonly(false), height: 12)
+    )
     .overlay(
       RoundedRectangle(cornerRadius: 4)
         .stroke(Color(.separatorColor), lineWidth: 1)

--- a/App/Sources/UI/Views/Keyboard/ModifierKeyIcon.swift
+++ b/App/Sources/UI/Views/Keyboard/ModifierKeyIcon.swift
@@ -63,7 +63,7 @@ struct ModifierKeyIcon: View {
         }
 
         Text(key.writtenValue)
-          .font(Font.system(size: proxy.size.height * 0.23, weight: .regular, design: .rounded))
+          .font(Font.system(size: proxy.size.height * 0.23, weight: .bold, design: .rounded))
           .frame(height: proxy.size.height, alignment: .bottom)
           .offset(y: -proxy.size.width * 0.065)
       }

--- a/App/Sources/UI/Views/Keyboard/RegularKeyIcon.swift
+++ b/App/Sources/UI/Views/Keyboard/RegularKeyIcon.swift
@@ -64,7 +64,7 @@ public struct RegularKeyIcon: View {
     VStack {
       ForEach(letters) { letter in
         Text(letter.string)
-          .font(Font.system(size: height * 0.3, weight: .regular, design: .rounded))
+          .font(Font.system(size: height * 0.3, weight: .bold, design: .rounded))
           .foregroundColor(.clear)
           .padding([.leading, .trailing], height * 0.3)
           .overlay(
@@ -74,7 +74,7 @@ public struct RegularKeyIcon: View {
                                 : Color(.textColor).opacity(0.66))
               .mask(
                 Text(letter.string)
-                  .font(Font.system(size: height * 0.3, weight: .regular, design: .rounded))
+                  .font(Font.system(size: height * 0.3, weight: .bold, design: .rounded))
               )
           )
           .compositingGroup()

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -74,7 +74,7 @@ private extension Workflow.Trigger {
     switch self {
     case .keyboardShortcuts(let trigger):
       return trigger.shortcuts.binding
-    case .application:
+    case .application, .snippet:
       return nil
     }
   }

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -146,18 +146,19 @@ private extension Array where Element == Command {
         case .macro(let action):
           switch action.kind {
           case .record:
-            images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.builtIn(.init(id: command.id, name: command.name, kind: .macro(.record))))))
+            images.append(.init(id: command.id, offset: convertedOffset, 
+                                kind: .command(.builtIn(.init(id: command.id, name: command.name, 
+                                                              kind: .macro(.record))))))
           case .remove:
-            images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.builtIn(.init(id: command.id, name: command.name, kind: .macro(.remove))))))
+            images.append(.init(id: command.id, offset: convertedOffset,
+                                kind: .command(.builtIn(.init(id: command.id, name: command.name, 
+                                                              kind: .macro(.remove))))))
           }
         case .userMode:
-          let path = Bundle.main.bundleURL.path
-          images.append(
-            ContentViewModel.ImageModel(
-              id: command.id,
-              offset: convertedOffset,
-              kind: .icon(.init(bundleIdentifier: path, path: path)))
-          )
+          images.append(.init(id: command.id, offset: convertedOffset, 
+                              kind: .command(.builtIn(.init(id: command.id, name: command.name, 
+                                                            kind: .userMode(UserMode(id: command.id, name: command.name, 
+                                                                                     isEnabled: command.isEnabled), .toggle))))))
         }
       case .mouse(let command):
         images.append(.init(id: command.id, offset: convertedOffset, kind: .command(.mouse(.init(id: command.id, kind: command.kind)))))

--- a/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/ContentModelMapper.swift
@@ -50,10 +50,24 @@ private extension Workflow {
   func asViewModel(_ groupName: String?) -> ContentViewModel {
     let commandCount = commands.count
     let binding: String?
-    if let trigger, let triggerBinding = trigger.binding {
-      binding = triggerBinding
+    let snippet: String?
+
+    if let trigger  {
+      switch trigger {
+      case .application(let array):
+        binding = nil
+        snippet = nil
+      case .keyboardShortcuts(let keyboardShortcutTrigger):
+        binding = trigger.binding
+        snippet = nil
+      case .snippet(let snippetTrigger):
+        binding = nil
+        snippet = snippetTrigger.text
+      }
+
     } else {
       binding = nil
+      snippet = nil
     }
 
     return ContentViewModel(
@@ -63,6 +77,7 @@ private extension Workflow {
       images: commands.images(limit: 1),
       overlayImages: commands.overlayImages(limit: 3),
       binding: binding,
+      snippet: snippet,
       badge: commandCount > 1 ? commandCount : 0,
       badgeOpacity: commandCount > 1 ? 1.0 : 0.0,
       isEnabled: isEnabled)

--- a/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
+++ b/App/Sources/UI/Views/Mappers/DetailModelMapper.swift
@@ -149,27 +149,29 @@ extension Workflow.Trigger {
   func asViewModel() -> DetailViewModel.Trigger {
     switch self {
     case .application(let triggers):
-      return .applications(
-        triggers.map { trigger in
-          DetailViewModel.ApplicationTrigger(id: trigger.id,
-                                             name: trigger.application.displayName,
-                                             application: trigger.application,
-                                             contexts: trigger.contexts.map {
-            switch $0 {
-            case .closed:
-              return .closed
-            case .frontMost:
-              return .frontMost
-            case .launched:
-              return .launched
-            }
-          })
-        }
-      )
+        .applications(
+          triggers.map { trigger in
+            DetailViewModel.ApplicationTrigger(id: trigger.id,
+                                               name: trigger.application.displayName,
+                                               application: trigger.application,
+                                               contexts: trigger.contexts.map {
+              switch $0 {
+              case .closed:
+                return .closed
+              case .frontMost:
+                return .frontMost
+              case .launched:
+                return .launched
+              }
+            })
+          }
+        )
     case .keyboardShortcuts(let trigger):
-      return .keyboardShortcuts(.init(passthrough: trigger.passthrough, 
-                                      holdDuration: trigger.holdDuration,
-                                      shortcuts: trigger.shortcuts))
+        .keyboardShortcuts(.init(passthrough: trigger.passthrough,
+                                 holdDuration: trigger.holdDuration,
+                                 shortcuts: trigger.shortcuts))
+    case .snippet(let trigger):
+        .snippet(.init(id: trigger.id, text: trigger.text))
     }
   }
 }

--- a/App/Sources/UI/Views/Models/ContentViewModel.swift
+++ b/App/Sources/UI/Views/Models/ContentViewModel.swift
@@ -13,6 +13,7 @@ struct ContentViewModel: Identifiable, Hashable, Codable,
   let images: [ImageModel]
   let overlayImages: [ImageModel]
   let binding: String?
+  let snippet: String?
   let badge: Int
   let badgeOpacity: Double
   let isEnabled: Bool
@@ -20,7 +21,9 @@ struct ContentViewModel: Identifiable, Hashable, Codable,
   internal init(id: String, groupName: String? = nil, name: String,
                 images: [ContentViewModel.ImageModel],
                 overlayImages: [ContentViewModel.ImageModel],
-                binding: String? = nil, badge: Int,
+                binding: String? = nil, 
+                snippet: String? = nil,
+                badge: Int,
                 badgeOpacity: Double, isEnabled: Bool) {
     self.id = id
     self.groupName = groupName
@@ -30,6 +33,7 @@ struct ContentViewModel: Identifiable, Hashable, Codable,
     self.binding = binding
     self.badge = badge
     self.badgeOpacity = badgeOpacity
+    self.snippet = snippet
     self.isEnabled = isEnabled
   }
 

--- a/App/Sources/UI/Views/Models/DetailViewModel.swift
+++ b/App/Sources/UI/Views/Models/DetailViewModel.swift
@@ -50,12 +50,14 @@ struct DetailViewModel: Hashable, Identifiable, Equatable {
       switch self {
       case .applications(let array): array.map(\.id).joined()
       case .keyboardShortcuts(let keyboardTrigger): keyboardTrigger.shortcuts.map(\.id).joined()
+      case .snippet(let trigger): trigger.id
       case .empty: "empty"
       }
     }
 
     case applications([DetailViewModel.ApplicationTrigger])
     case keyboardShortcuts(DetailViewModel.KeyboardTrigger)
+    case snippet(DetailViewModel.SnippetTrigger)
     case empty
   }
 
@@ -95,5 +97,10 @@ struct DetailViewModel: Hashable, Identifiable, Equatable {
     var passthrough: Bool
     var holdDuration: Double?
     var shortcuts: [KeyShortcut]
+  }
+
+  struct SnippetTrigger: Codable, Hashable, Equatable {
+    var id: String
+    var text: String
   }
 }

--- a/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandBuiltInView.swift
@@ -84,10 +84,21 @@ struct NewCommandBuiltInView: View {
 
   func userMode() -> some View {
     HStack {
+      UserModeIconView(size: 24)
+
       Menu(content: {
-        Button(action: { kindSelection = .userMode(userModeSelection, .toggle) }, label: { Text("Toggle") })
-        Button(action: { kindSelection = .userMode(userModeSelection, .enable) }, label: { Text("Enable") })
-        Button(action: { kindSelection = .userMode(userModeSelection, .disable) }, label: { Text("Disable") })
+        Button(action: { kindSelection = .userMode(userModeSelection, .toggle) }, label: {
+          Image(systemName: "togglepower")
+          Text("Toggle")
+        })
+        Button(action: { kindSelection = .userMode(userModeSelection, .enable) }, label: {
+          Image(systemName: "lightswitch.on")
+          Text("Enable")
+        })
+        Button(action: { kindSelection = .userMode(userModeSelection, .disable) }, label: {
+          Image(systemName: "lightswitch.off")
+          Text("Disable")
+        })
       }, label: {
         Text(kindSelection.displayValue)
       })

--- a/App/Sources/UI/Views/NewCommand/NewCommandURLView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandURLView.swift
@@ -51,7 +51,6 @@ struct NewCommandURLView: View {
         Text("://")
           .font(.largeTitle)
           .opacity(0.5)
-          .frame(height: .infinity)
         TextField("address", text: $address)
           .onSubmit {
             if case .valid = updateAndValidatePayload() {

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
@@ -24,6 +24,7 @@ struct WorkflowNotificationMatchesView: View {
         LazyVStack(alignment: .trailing) {
           ForEach(publisher.data.matches, id: \.id) { workflow in
             HStack {
+              workflow.iconView(24)
               Text(workflow.name)
                 .font(.caption)
               Spacer()

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
@@ -31,7 +31,7 @@ struct WorkflowNotificationMatchesView: View {
                 ForEach(trigger.shortcuts) { shortcut in
                   WorkflowNotificationKeyView(keyShortcut: shortcut, glow: .constant(false))
                 }
-              case .application, .none:
+              case .application, .none, .snippet:
                 EmptyView()
               }
             }

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationMatchesView.swift
@@ -1,3 +1,4 @@
+import Bonzai
 import SwiftUI
 
 extension AnyTransition {
@@ -39,13 +40,26 @@ struct WorkflowNotificationMatchesView: View {
             .transition(AnyTransition.moveAndFade.animation(Self.animation))
           }
         }
-        .padding()
       }
       .frame(maxHeight: .infinity)
-      .background(
-        Color(nsColor: .windowBackgroundColor).opacity(0.8).cornerRadius(8)
-      )
+      .roundedContainer(padding: 8, margin: 0)
       .scrollIndicators(.hidden)
     }
+  }
+}
+
+struct WorkflowNotificationMatchesView_Previews: PreviewProvider {
+  static let publisher: WorkflowNotificationPublisher = .init(
+    .init(
+      id: UUID().uuidString,
+      matches: [
+        .empty()
+      ],
+      glow: false,
+      keyboardShortcuts: []
+    )
+  )
+  static var previews: some View {
+    WorkflowNotificationMatchesView(publisher: publisher)
   }
 }

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
@@ -150,77 +150,83 @@ struct WorkflowNotificationView_Previews: PreviewProvider {
   }
 }
 
-private extension Workflow {
+extension Workflow {
   @ViewBuilder
   func iconView(_ size: CGFloat) -> some View {
     let enabledCommands = commands.filter(\.isEnabled)
     if enabledCommands.count == 1, let command = enabledCommands.first {
       command.iconView(size)
     } else {
-      EmptyView()
+      PlaceholderIconView(size: size)
     }
   }
 }
 
-private extension Command {
+struct PlaceholderIconView: View {
+  let size: CGFloat
+
+  var body: some View {
+    Rectangle()
+      .fill(Color(.controlAccentColor).opacity(0.25))
+      .overlay { iconBorder(size) }
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
+  }
+}
+
+extension Command {
+  func placeholderView(_ size: CGFloat) -> some View {
+    PlaceholderIconView(size: size)
+  }
+
   @ViewBuilder
   func iconView(_ size: CGFloat) -> some View {
     switch self {
+    case .builtIn(let builtInCommand):
+      switch builtInCommand.kind {
+      case .macro(let action):
+        switch action.kind {
+        case .record: MacroIconView(.record, size: size)
+        case .remove: MacroIconView(.remove, size: size)
+        }
+      case .userMode: UserModeIconView(size: size)
+      }
     case .mouse:
       MouseIconView(size: size)
     case .systemCommand(let systemCommand):
       switch systemCommand.kind {
       case .activateLastApplication:
         ActivateLastApplicationIconView(size: size)
-      case .applicationWindows:
-        MissionControlIconView(size: size)
-      case .minimizeAllOpenWindows:
-        MinimizeAllIconView(size: size)
-      case .moveFocusToNextWindow:
-        MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
-      case .moveFocusToNextWindowFront:
-        MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
-      case .moveFocusToNextWindowGlobal:
-        MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
-      case .moveFocusToPreviousWindow:
-        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
-      case .moveFocusToPreviousWindowFront:
-        MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
-      case .moveFocusToPreviousWindowGlobal:
-        MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
-      case .showDesktop:
-        DockIconView(size: size)
-      case .missionControl:
-        MissionControlIconView(size: size)
+      case .applicationWindows:              MissionControlIconView(size: size)
+      case .minimizeAllOpenWindows:          MinimizeAllIconView(size: size)
+      case .moveFocusToNextWindow:           MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
+      case .moveFocusToNextWindowFront:      MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+      case .moveFocusToNextWindowGlobal:     MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
+      case .moveFocusToPreviousWindow:       MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
+      case .moveFocusToPreviousWindowFront:  MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
+      case .moveFocusToPreviousWindowGlobal: MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
+      case .showDesktop:                     DockIconView(size: size)
+      case .missionControl:                  MissionControlIconView(size: size)
       }
-    case .menuBar:
-      MenuIconView(size: size)
-    case .windowManagement:
-      WindowManagementIconView(size: size)
-    case .uiElement:
-      UIElementIconView(size: size)
+    case .menuBar: MenuIconView(size: size)
+    case .windowManagement: WindowManagementIconView(size: size)
+    case .uiElement: UIElementIconView(size: size)
     case .application(let command):
       IconView(
         icon: .init(command.application),
         size: .init(width: 32, height: 32)
       )
+      .frame(width: size, height: size)
+      .fixedSize()
+      .iconShape(size)
       .id(command.id)
-    case .builtIn(let command):
+    case .text(let command):
       switch command.kind {
-      case .macro(let action):
-        switch action {
-        case .record:
-          MacroIconView(.record, size: size)
-        case .remove:
-          MacroIconView(.remove, size: size)
-        default:
-          EmptyView()
-        }
-      default:
-        EmptyView()
+      case .insertText: TypingIconView(size: size)
       }
     default:
-      EmptyView()
+      placeholderView(size)
     }
   }
 }

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
@@ -48,6 +48,10 @@ struct WorkflowNotificationView: View {
         .frame(maxWidth: 250, maxHeight: 500, alignment: notificationPlacement.alignment)
         .fixedSize(horizontal: false, vertical: true)
       HStack {
+        if let workflow = publisher.data.workflow {
+          workflow.iconView(24)
+        }
+
         ForEach(publisher.data.keyboardShortcuts, id: \.id) { keyShortcut in
           WorkflowNotificationKeyView(keyShortcut: keyShortcut, glow: .readonly(false))
           .transition(AnyTransition.moveAndFade.animation(Self.animation))
@@ -143,5 +147,80 @@ struct WorkflowNotificationView_Previews: PreviewProvider {
     WorkflowNotificationView(publisher: publisher)
       .environmentObject(WindowManager())
       .padding(64)
+  }
+}
+
+private extension Workflow {
+  @ViewBuilder
+  func iconView(_ size: CGFloat) -> some View {
+    let enabledCommands = commands.filter(\.isEnabled)
+    if enabledCommands.count == 1, let command = enabledCommands.first {
+      command.iconView(size)
+    } else {
+      EmptyView()
+    }
+  }
+}
+
+private extension Command {
+  @ViewBuilder
+  func iconView(_ size: CGFloat) -> some View {
+    switch self {
+    case .mouse:
+      MouseIconView(size: size)
+    case .systemCommand(let systemCommand):
+      switch systemCommand.kind {
+      case .activateLastApplication:
+        ActivateLastApplicationIconView(size: size)
+      case .applicationWindows:
+        MissionControlIconView(size: size)
+      case .minimizeAllOpenWindows:
+        MinimizeAllIconView(size: size)
+      case .moveFocusToNextWindow:
+        MoveFocusToWindowIconView(direction: .next, scope: .visibleWindows, size: size)
+      case .moveFocusToNextWindowFront:
+        MoveFocusToWindowIconView(direction: .next, scope: .activeApplication, size: size)
+      case .moveFocusToNextWindowGlobal:
+        MoveFocusToWindowIconView(direction: .next, scope: .allWindows, size: size)
+      case .moveFocusToPreviousWindow:
+        MoveFocusToWindowIconView(direction: .previous, scope: .visibleWindows, size: size)
+      case .moveFocusToPreviousWindowFront:
+        MoveFocusToWindowIconView(direction: .previous, scope: .activeApplication, size: size)
+      case .moveFocusToPreviousWindowGlobal:
+        MoveFocusToWindowIconView(direction: .previous, scope: .allWindows, size: size)
+      case .showDesktop:
+        DockIconView(size: size)
+      case .missionControl:
+        MissionControlIconView(size: size)
+      }
+    case .menuBar:
+      MenuIconView(size: size)
+    case .windowManagement:
+      WindowManagementIconView(size: size)
+    case .uiElement:
+      UIElementIconView(size: size)
+    case .application(let command):
+      IconView(
+        icon: .init(command.application),
+        size: .init(width: 32, height: 32)
+      )
+      .id(command.id)
+    case .builtIn(let command):
+      switch command.kind {
+      case .macro(let action):
+        switch action {
+        case .record:
+          MacroIconView(.record, size: size)
+        case .remove:
+          MacroIconView(.remove, size: size)
+        default:
+          EmptyView()
+        }
+      default:
+        EmptyView()
+      }
+    default:
+      EmptyView()
+    }
   }
 }

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
@@ -45,37 +45,39 @@ struct WorkflowNotificationView: View {
   var body: some View {
     NotificationView(notificationPlacement.alignment) {
       let maxHeight = NSScreen.main?.visibleFrame.height ?? 700
-      WorkflowNotificationMatchesView(publisher: publisher)
-        .frame(
-          maxWidth: 250,
-          maxHeight: maxHeight - 64,
-          alignment: notificationPlacement.alignment
-        )
-        .fixedSize(horizontal: false, vertical: true)
-      HStack {
-        if let workflow = publisher.data.workflow {
-          workflow.iconView(24)
-        }
+      VStack(alignment: .trailing) {
+        WorkflowNotificationMatchesView(publisher: publisher)
+          .frame(
+            maxWidth: 250,
+            maxHeight: maxHeight - 64,
+            alignment: notificationPlacement.alignment
+          )
+          .fixedSize(horizontal: false, vertical: true)
+        HStack {
+          if let workflow = publisher.data.workflow {
+            workflow.iconView(24)
+          }
 
-        ForEach(publisher.data.keyboardShortcuts, id: \.id) { keyShortcut in
-          WorkflowNotificationKeyView(keyShortcut: keyShortcut, glow: .readonly(false))
-          .transition(AnyTransition.moveAndFade.animation(Self.animation))
-        }
+          ForEach(publisher.data.keyboardShortcuts, id: \.id) { keyShortcut in
+            WorkflowNotificationKeyView(keyShortcut: keyShortcut, glow: .readonly(false))
+              .transition(AnyTransition.moveAndFade.animation(Self.animation))
+          }
 
-        if let workflow = publisher.data.workflow {
-          Text(workflow.name)
-            .allowsTightening(true)
-            .minimumScaleFactor(0.8)
-            .bold()
-            .font(.footnote)
-            .lineLimit(1)
-            .padding(4)
-            .background(Color(nsColor: .windowBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .transition(AnyTransition.moveAndFade.animation(Self.animation))
+          if let workflow = publisher.data.workflow {
+            Text(workflow.name)
+              .allowsTightening(true)
+              .minimumScaleFactor(0.8)
+              .bold()
+              .font(.footnote)
+              .lineLimit(1)
+              .padding(4)
+              .background(Color(nsColor: .windowBackgroundColor))
+              .clipShape(RoundedRectangle(cornerRadius: 8))
+              .transition(AnyTransition.moveAndFade.animation(Self.animation))
+          }
         }
+        .roundedContainer(padding: 6, margin: 0)
       }
-      .roundedContainer(padding: 6, margin: 0)
     }
     .padding(4)
     .onReceive(publisher.$data, perform: { newValue in
@@ -222,6 +224,13 @@ extension Command {
     case .menuBar: MenuIconView(size: size)
     case .windowManagement: WindowManagementIconView(size: size)
     case .uiElement: UIElementIconView(size: size)
+    case .script(let command):
+      switch command.kind {
+      case .shellScript:
+        ScriptIconView(size: size)
+      case .appleScript:
+        placeholderView(size)
+      }
     case .application(let command):
       IconView(
         icon: .init(command.application),

--- a/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
+++ b/App/Sources/UI/Views/Notifications/WorkflowNotificationView.swift
@@ -45,18 +45,16 @@ struct WorkflowNotificationView: View {
   var body: some View {
     NotificationView(notificationPlacement.alignment) {
       WorkflowNotificationMatchesView(publisher: publisher)
-        .frame(maxWidth: 250, maxHeight: 250, alignment: notificationPlacement.alignment)
+        .frame(maxWidth: 250, maxHeight: 500, alignment: notificationPlacement.alignment)
+        .fixedSize(horizontal: false, vertical: true)
       HStack {
         ForEach(publisher.data.keyboardShortcuts, id: \.id) { keyShortcut in
-          WorkflowNotificationKeyView(keyShortcut: keyShortcut, glow: Binding<Bool>(get: {
-            publisher.data.glow
-          }, set: { _ in }))
+          WorkflowNotificationKeyView(keyShortcut: keyShortcut, glow: .readonly(false))
           .transition(AnyTransition.moveAndFade.animation(Self.animation))
         }
 
         if let workflow = publisher.data.workflow {
           Text(workflow.name)
-            .textStyle(.zen)
             .allowsTightening(true)
             .minimumScaleFactor(0.8)
             .bold()
@@ -68,8 +66,9 @@ struct WorkflowNotificationView: View {
             .transition(AnyTransition.moveAndFade.animation(Self.animation))
         }
       }
-      .padding(4)
+      .roundedContainer(padding: 6, margin: 0)
     }
+    .padding(4)
     .onReceive(publisher.$data, perform: { newValue in
       guard let screen = NSScreen.main else { return }
 
@@ -103,15 +102,14 @@ struct WorkflowNotificationKeyView: View {
           : modifier == .shift ? .bottomTrailing : .topLeading,
           glow: $glow
         )
-        .frame(minWidth: modifier == .command || modifier == .shift ? 44 : 32, minHeight: 32)
+        .frame(minWidth: modifier == .command || modifier == .shift ? 40 : 28, minHeight: 28)
         .fixedSize(horizontal: true, vertical: true)
       }
-      RegularKeyIcon(letter: keyShortcut.key, width: 32, height: 32, glow: $glow)
+      RegularKeyIcon(letter: keyShortcut.key, width: 28, height: 28, glow: $glow)
         .fixedSize(horizontal: true, vertical: true)
     }
   }
 }
-
 
 struct WorkflowNotificationView_Previews: PreviewProvider {
   static let emptyModel = WorkflowNotificationViewModel(

--- a/App/Sources/UI/Views/SingleDetailBackgroundView.swift
+++ b/App/Sources/UI/Views/SingleDetailBackgroundView.swift
@@ -8,7 +8,7 @@ struct SingleDetailBackgroundView: View {
 
   var body: some View {
     let shouldShowCommandList = triggerPublisher.data != .empty ||
-    !commandsPublisher.data.commands.isEmpty
+                               !commandsPublisher.data.commands.isEmpty
 
     Rectangle()
       .fill(

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -24,6 +24,7 @@ struct SingleDetailView: View {
                                  holdDuration: Double?,
                                  keyboardShortcuts: [KeyShortcut])
     case updateName(workflowId: Workflow.ID, name: String)
+    case updateSnippet(workflowId: Workflow.ID, snippet: DetailViewModel.SnippetTrigger)
   }
 
   @Environment(\.openWindow) private var openWindow

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -64,7 +64,7 @@ struct SingleDetailView: View {
             case .keyboardShortcuts:
               focus.wrappedValue = .detail(.keyboardShortcuts)
             case .snippet:
-              focus.wrappedValue = .detail(.addAppTrigger)
+              focus.wrappedValue = .detail(.addSnippetTrigger)
             case .empty:
               focus.wrappedValue = .detail(.addAppTrigger)
             }

--- a/App/Sources/UI/Views/SingleDetailView.swift
+++ b/App/Sources/UI/Views/SingleDetailView.swift
@@ -62,6 +62,8 @@ struct SingleDetailView: View {
               focus.wrappedValue = .detail(.applicationTriggers)
             case .keyboardShortcuts:
               focus.wrappedValue = .detail(.keyboardShortcuts)
+            case .snippet:
+              focus.wrappedValue = .detail(.addAppTrigger)
             case .empty:
               focus.wrappedValue = .detail(.addAppTrigger)
             }
@@ -111,6 +113,7 @@ struct SingleDetailView: View {
           switch triggerPublisher.data {
           case .applications(let array): !array.isEmpty
           case .keyboardShortcuts(let keyboardTrigger): !keyboardTrigger.shortcuts.isEmpty
+          case .snippet: false
           case .empty: false
           }
         }, set: { _ in }),

--- a/App/Sources/UI/Views/UserModesView.swift
+++ b/App/Sources/UI/Views/UserModesView.swift
@@ -34,7 +34,7 @@ struct UserModesView: View {
         })
       }
 
-      FlowLayout(proposedViewSize: .unspecified) {
+      FlowLayout(itemSpacing: 2, lineSpacing: 2) {
         ForEach(publisher.data.userModes) { userMode in
           FlowItem(userMode: userMode, onAction: { }, onDelete: {
             onAction(.delete(userMode.id))
@@ -81,7 +81,7 @@ struct FlowItem: View {
       Button(action: {
         areYouSure = true
       }, label: {
-        Image(systemName: "xmark.circle")
+        Image(systemName: "xmark.circle.fill")
           .resizable()
           .aspectRatio(contentMode: .fit)
           .frame(width: 12)

--- a/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
+++ b/App/Sources/UI/Views/Windows/ReleaseNotesScene.swift
@@ -7,7 +7,7 @@ struct ReleaseNotesScene: Scene {
 
   var body: some Scene {
     WindowGroup(id: KeyboardCowboy.releaseNotesWindowIdentifier) {
-      Release3_22_2 { action in
+      Release3_23_0 { action in
         switch action {
         case .done:
           NSApplication.shared.keyWindow?.close()

--- a/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowApplicationTriggerView.swift
@@ -118,19 +118,19 @@ struct WorkflowApplicationTriggerView: View {
   }
 }
 
-//struct WorkflowApplicationTriggerView_Previews: PreviewProvider {
-//  @FocusState static var focus: AppFocus?
-//  static var previews: some View {
-//    WorkflowApplicationTriggerView(
-//      $focus,
-//      data: [
-//        .init(id: "1", name: "Application 1", application: .finder(),
-//              contexts: []),
-//      ],
-//      selectionManager: SelectionManager(),
-//      onTab: { },
-//      onAction: { _ in }
-//    )
-//    .environmentObject(ApplicationStore.shared)
-//  }
-//}
+struct WorkflowApplicationTriggerView_Previews: PreviewProvider {
+  @FocusState static var focus: AppFocus?
+  static var previews: some View {
+    WorkflowApplicationTriggerView(
+      $focus,
+      data: [
+        .init(id: "1", name: "Application 1", application: .finder(),
+              contexts: []),
+      ],
+      selectionManager: SelectionManager(),
+      onTab: { },
+      onAction: { _ in }
+    )
+    .environmentObject(ApplicationStore.shared)
+  }
+}

--- a/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
@@ -96,6 +96,8 @@ struct WorkflowCommandListScrollView: View {
             focus.wrappedValue = .detail(.applicationTriggers)
           case .keyboardShortcuts:
             focus.wrappedValue = .detail(.keyboardShortcuts)
+          case .snippet:
+            focus.wrappedValue = .detail(.addAppTrigger)
           case .empty:
             focus.wrappedValue = .detail(.addAppTrigger)
           }

--- a/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListScrollView.swift
@@ -97,7 +97,7 @@ struct WorkflowCommandListScrollView: View {
           case .keyboardShortcuts:
             focus.wrappedValue = .detail(.keyboardShortcuts)
           case .snippet:
-            focus.wrappedValue = .detail(.addAppTrigger)
+            focus.wrappedValue = .detail(.addSnippetTrigger)
           case .empty:
             focus.wrappedValue = .detail(.addAppTrigger)
           }

--- a/App/Sources/UI/Views/WorkflowCommandListView.swift
+++ b/App/Sources/UI/Views/WorkflowCommandListView.swift
@@ -7,7 +7,6 @@ struct WorkflowCommandListView: View {
 
   @Binding private var isPrimary: Bool
   @State var isTargeted: Bool = false
-  @Environment(\.openWindow) private var openWindow
   @ObservedObject private var selectionManager: SelectionManager<CommandViewModel>
   private let onAction: (SingleDetailView.Action) -> Void
   private let publisher: CommandsPublisher

--- a/App/Sources/UI/Views/WorkflowShortcutsView.swift
+++ b/App/Sources/UI/Views/WorkflowShortcutsView.swift
@@ -25,6 +25,7 @@ struct WorkflowShortcutsView: View {
                                             keyboardShortcuts: $data,
                                             draggableEnabled: true,
                                             selectionManager: selectionManager,
+                                            recordOnAppearIfEmpty: true,
                                             onTab: {
       if $0 {
         focus.wrappedValue = .detail(.commands)

--- a/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
@@ -16,14 +16,17 @@ struct WorkflowSnippetTriggerView: View {
   }
 
   var body: some View {
-    ZenTextEditor(
-      text: $snippet.text,
-      placeholder: "Snippet trigger",
-      font: Font.system(.body, design: .monospaced),
-      onFocusChange: { newValue in
-        snippetController.isEnabled = !newValue
-      }, onCommandReturnKey: { onUpdate(snippet) }
-    )
+    HStack(spacing: 4) {
+      SnippetIconView(size: 24)
+      ZenTextEditor(
+        text: $snippet.text,
+        placeholder: "Snippet trigger",
+        font: Font.system(.body, design: .monospaced),
+        onFocusChange: { newValue in
+          snippetController.isEnabled = !newValue
+        }, onCommandReturnKey: { onUpdate(snippet) }
+      )
+    }
     .onDisappear(perform: {
         snippetController.isEnabled = true
     })

--- a/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
@@ -19,7 +19,9 @@ struct WorkflowSnippetTriggerView: View {
       text: $snippet.text,
       placeholder: "Snippet trigger",
       font: Font.system(.body, design: .monospaced),
-      onCommandReturnKey: { onUpdate(snippet) }
+      onFocusChange: { newValue in
+        SnippetController.isEnabled = !newValue
+      }, onCommandReturnKey: { onUpdate(snippet) }
     )
     .onChange(of: snippet.text, perform: { value in
       onUpdate(snippet)

--- a/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
@@ -3,6 +3,7 @@ import Inject
 import SwiftUI
 
 struct WorkflowSnippetTriggerView: View {
+  @EnvironmentObject var snippetController: SnippetController
   @ObserveInjection var inject
   @State var snippet: DetailViewModel.SnippetTrigger
 
@@ -20,7 +21,7 @@ struct WorkflowSnippetTriggerView: View {
       placeholder: "Snippet trigger",
       font: Font.system(.body, design: .monospaced),
       onFocusChange: { newValue in
-        SnippetController.isEnabled = !newValue
+        snippetController.isEnabled = !newValue
       }, onCommandReturnKey: { onUpdate(snippet) }
     )
     .onChange(of: snippet.text, perform: { value in

--- a/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
@@ -1,0 +1,39 @@
+import Bonzai
+import Inject
+import SwiftUI
+
+struct WorkflowSnippetTriggerView: View {
+  @ObserveInjection var inject
+  @State var snippet: DetailViewModel.SnippetTrigger
+
+  let onUpdate: (DetailViewModel.SnippetTrigger) -> Void
+
+  init(_ snippet: DetailViewModel.SnippetTrigger,
+       onUpdate: @escaping (DetailViewModel.SnippetTrigger) -> Void) {
+    _snippet = .init(initialValue: snippet)
+    self.onUpdate = onUpdate
+  }
+
+  var body: some View {
+    ZenTextEditor(
+      text: $snippet.text,
+      placeholder: "Snippet trigger",
+      font: Font.system(.body, design: .monospaced),
+      onCommandReturnKey: { onUpdate(snippet) }
+    )
+    .onChange(of: snippet.text, perform: { value in
+      onUpdate(snippet)
+    })
+    .fixedSize(horizontal: false, vertical: true)
+    .roundedContainer(padding: 8, margin: 0)
+    .enableInjection()
+  }
+}
+
+struct WorkflowSnippetTriggerView_Previews: PreviewProvider {
+    static var previews: some View {
+      WorkflowSnippetTriggerView(
+        .init(id: UUID().uuidString, text: "hello world")
+      )  { _ in }
+    }
+}

--- a/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowSnippetTriggerView.swift
@@ -24,6 +24,9 @@ struct WorkflowSnippetTriggerView: View {
         snippetController.isEnabled = !newValue
       }, onCommandReturnKey: { onUpdate(snippet) }
     )
+    .onDisappear(perform: {
+        snippetController.isEnabled = true
+    })
     .onChange(of: snippet.text, perform: { value in
       onUpdate(snippet)
     })

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -78,6 +78,7 @@ struct WorkflowTriggerListView: View {
         WorkflowSnippetTriggerView(trigger) { snippet in
           onAction(.updateSnippet(workflowId: workflowId, snippet: snippet))
         }
+        .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
       case .empty:
         ZenLabel("Add Trigger")
           .padding([.leading, .trailing], 8)

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -1,8 +1,10 @@
 import Bonzai
 import Combine
+import Inject
 import SwiftUI
 
 struct WorkflowTriggerListView: View {
+  @ObserveInjection var inject
   @Namespace private var namespace
   @ObservedObject private var publisher: TriggerPublisher
   private let applicationTriggerSelectionManager: SelectionManager<DetailViewModel.ApplicationTrigger>
@@ -60,8 +62,22 @@ struct WorkflowTriggerListView: View {
           onAction(.applicationTrigger(workflowId: workflowId, action: action))
         }
         .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
-      case .snippet:
-        ZenLabel("Add snippet")
+      case .snippet(let trigger):
+        HStack {
+          ZenLabel("Add Snippet")
+          Spacer()
+          Button(action: { onAction(.removeTrigger(workflowId: workflowId)) },
+                 label: {
+            Image(systemName: "xmark")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 10, height: 10)
+          })
+          .buttonStyle(.calm(color: .systemRed, padding: .medium))
+        }
+        WorkflowSnippetTriggerView(trigger) { snippet in
+          onAction(.updateSnippet(workflowId: workflowId, snippet: snippet))
+        }
       case .empty:
         ZenLabel("Add Trigger")
           .padding([.leading, .trailing], 8)
@@ -73,6 +89,7 @@ struct WorkflowTriggerListView: View {
       }
     }
     .animation(.spring(response: 0.3, dampingFraction: 0.65, blendDuration: 0.2), value: publisher.data)
+    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -63,22 +63,26 @@ struct WorkflowTriggerListView: View {
         }
         .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
       case .snippet(let trigger):
-        HStack {
-          ZenLabel("Add Snippet")
-          Spacer()
-          Button(action: { onAction(.removeTrigger(workflowId: workflowId)) },
-                 label: {
-            Image(systemName: "xmark")
-              .resizable()
-              .aspectRatio(contentMode: .fit)
-              .frame(width: 10, height: 10)
-          })
-          .buttonStyle(.calm(color: .systemRed, padding: .medium))
+        Group {
+          HStack {
+            ZenLabel("Add Snippet")
+            Spacer()
+            Button(action: { onAction(.removeTrigger(workflowId: workflowId)) },
+                   label: {
+              Image(systemName: "xmark")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 10, height: 10)
+            })
+            .buttonStyle(.calm(color: .systemRed, padding: .medium))
+          }
+          .padding(.horizontal, 8)
+          WorkflowSnippetTriggerView(trigger) { snippet in
+            onAction(.updateSnippet(workflowId: workflowId, snippet: snippet))
+          }
+          .padding(.horizontal, 8)
+          .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
         }
-        WorkflowSnippetTriggerView(trigger) { snippet in
-          onAction(.updateSnippet(workflowId: workflowId, snippet: snippet))
-        }
-        .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
       case .empty:
         ZenLabel("Add Trigger")
           .padding([.leading, .trailing], 8)

--- a/App/Sources/UI/Views/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerListView.swift
@@ -60,6 +60,8 @@ struct WorkflowTriggerListView: View {
           onAction(.applicationTrigger(workflowId: workflowId, action: action))
         }
         .matchedGeometryEffect(id: "workflow-triggers", in: namespace)
+      case .snippet:
+        ZenLabel("Add snippet")
       case .empty:
         ZenLabel("Add Trigger")
           .padding([.leading, .trailing], 8)

--- a/App/Sources/UI/Views/WorkflowTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerView.swift
@@ -1,13 +1,16 @@
 import Bonzai
+import Inject
 import SwiftUI
 
 struct WorkflowTriggerView: View {
   enum Action {
     case addApplication
     case addKeyboardShortcut
+    case addSnippet
     case removeKeyboardShortcut
   }
 
+  @ObserveInjection var inject
   @Binding private var isGrayscale: Bool
   private let onAction: (Action) -> Void
   private var focus: FocusState<AppFocus?>.Binding
@@ -47,17 +50,15 @@ struct WorkflowTriggerView: View {
           switch direction {
           case .right:
             focus.wrappedValue = .detail(.addKeyboardTrigger)
-          default:
-            break
+          default: break
           }
         })
 
-        Spacer()
 
         FocusableButton(
           focus,
           identity: .detail(.addKeyboardTrigger),
-          variant: .zen(.init(color: .systemCyan,
+          variant: .zen(.init(color: .systemIndigo,
                               focusEffect: .constant(true),
                               grayscaleEffect: $isGrayscale)),
           action: {
@@ -79,8 +80,36 @@ struct WorkflowTriggerView: View {
           switch direction {
           case .left:
             focus.wrappedValue = .detail(.addAppTrigger)
-          default:
-            break
+          case .right:
+            focus.wrappedValue = .detail(.addSnippetTrigger)
+          default: break
+          }
+        })
+
+        FocusableButton(
+          focus,
+          identity: .detail(.addSnippetTrigger),
+          variant: .zen(.init(color: .systemPurple,
+                              focusEffect: .constant(true),
+                              grayscaleEffect: $isGrayscale)),
+          action: { onAction(.addSnippet) }
+        ) {
+          HStack(spacing: 8) {
+            Image(systemName: "heart.text.square.fill")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 12)
+            Text("Snippet")
+              .lineLimit(1)
+          }
+          .padding(6)
+          .frame(maxWidth: .infinity)
+        }
+        .onMoveCommand(perform: { direction in
+          switch direction {
+          case .left:
+            focus.wrappedValue = .detail(.addKeyboardTrigger)
+          default: break
           }
         })
       }
@@ -96,6 +125,7 @@ struct WorkflowTriggerView: View {
       .cornerRadius(8)
     }
     .buttonStyle(.regular)
+    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowTriggerView.swift
@@ -35,10 +35,11 @@ struct WorkflowTriggerView: View {
                               grayscaleEffect: $isGrayscale)),
           action: { onAction(.addApplication) }
         ) {
-          HStack(spacing: 8) {
-            Image(systemName: "app.dashed")
+          HStack(spacing: 6) {
+            Image(systemName: "appclip")
               .resizable()
               .aspectRatio(contentMode: .fit)
+              .foregroundColor(Color(nsColor: .systemBlue.withSystemEffect(.deepPressed)))
               .frame(width: 12)
             Text("Application")
               .lineLimit(1)
@@ -65,10 +66,11 @@ struct WorkflowTriggerView: View {
             onAction(.addKeyboardShortcut)
           }
         ) {
-          HStack(spacing: 8) {
-            Image(systemName: "command")
+          HStack(spacing: 6) {
+            Image(systemName: "command.square.fill")
               .resizable()
               .aspectRatio(contentMode: .fit)
+              .foregroundColor(Color(nsColor: .systemIndigo.withSystemEffect(.deepPressed)))
               .frame(width: 12)
             Text("Keyboard Shortcut")
               .lineLimit(1)
@@ -86,6 +88,8 @@ struct WorkflowTriggerView: View {
           }
         })
 
+        
+
         FocusableButton(
           focus,
           identity: .detail(.addSnippetTrigger),
@@ -94,10 +98,13 @@ struct WorkflowTriggerView: View {
                               grayscaleEffect: $isGrayscale)),
           action: { onAction(.addSnippet) }
         ) {
-          HStack(spacing: 8) {
+
+          
+          HStack(spacing: 6) {
             Image(systemName: "heart.text.square.fill")
               .resizable()
               .aspectRatio(contentMode: .fit)
+              .foregroundColor(Color(nsColor: .systemPurple.withSystemEffect(.deepPressed)))
               .frame(width: 12)
             Text("Snippet")
               .lineLimit(1)

--- a/App/Sources/UI/Windows/MainWindow.swift
+++ b/App/Sources/UI/Windows/MainWindow.swift
@@ -32,6 +32,7 @@ struct MainWindow: Scene {
       .environmentObject(core.detailCoordinator.infoPublisher)
       .environmentObject(core.detailCoordinator.triggerPublisher)
       .environmentObject(core.detailCoordinator.commandsPublisher)
+      .environmentObject(core.snippetController)
       .environmentObject(OpenPanelController())
       .animation(.easeInOut, value: core.contentStore.state)
       .onAppear { NSWindow.allowsAutomaticWindowTabbing = false }

--- a/App/Sources/UI/Windows/MainWindow.swift
+++ b/App/Sources/UI/Windows/MainWindow.swift
@@ -62,9 +62,14 @@ struct MainWindow: Scene {
             core.contentCoordinator.handle(action)
             core.detailCoordinator.handle(action)
             focus = .detail(.name)
+          },
+          onNewCommand: { id in
+            onScene(.addCommand(id))
           }
         )
         .environmentObject(core.contentStore.groupStore)
+        .environmentObject(core.detailCoordinator.statePublisher)
+        .environmentObject(core.detailCoordinator.infoPublisher)
       }
 
       CommandGroup(replacing: .toolbar) {

--- a/Project.swift
+++ b/Project.swift
@@ -47,10 +47,10 @@ let mainAppTarget = Target.target(
         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
         "CODE_SIGN_IDENTITY": "Apple Development",
         "CODE_SIGN_STYLE": "Automatic",
-        "CURRENT_PROJECT_VERSION": "544",
+        "CURRENT_PROJECT_VERSION": "576",
         "DEVELOPMENT_TEAM": env["TEAM_ID"],
         "ENABLE_HARDENED_RUNTIME": true,
-        "MARKETING_VERSION": "3.22.2",
+        "MARKETING_VERSION": "3.23.0",
         "PRODUCT_NAME": "Keyboard Cowboy"
       ],
       configurations: [

--- a/Project.swift
+++ b/Project.swift
@@ -172,14 +172,14 @@ public enum PackageResolver {
         .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.1.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
         .package(url: "https://github.com/zenangst/AXEssibility.git", from: "0.1.2"),
-        .package(url: "https://github.com/zenangst/Bonzai.git", .revision("cd94e615fa183c82395a783881c211c26255ad40")),
+        .package(url: "https://github.com/zenangst/Bonzai.git", .revision("f4f59c6bddf96c113cc9f9e33782525118d89992")),
         .package(url: "https://github.com/zenangst/Apps.git", from: "1.4.2"),
         .package(url: "https://github.com/zenangst/Dock.git", from: "1.0.1"),
         .package(url: "https://github.com/zenangst/InputSources.git", from: "1.0.1"),
         .package(url: "https://github.com/zenangst/Intercom.git", .revision("5a340e185e571d058c09ab8b8ad8716098282443")),
         .package(url: "https://github.com/zenangst/KeyCodes.git", from: "4.1.0"),
         .package(url: "https://github.com/zenangst/LaunchArguments.git", from: "1.0.1"),
-        .package(url: "https://github.com/zenangst/MachPort.git", from: "4.1.2"),
+        .package(url: "https://github.com/zenangst/MachPort.git", from: "4.1.3"),
         .package(url: "https://github.com/zenangst/Windows.git", from: "1.1.0"),
       ]
     }


### PR DESCRIPTION
- **Initial feature commit**
- **Continue snippet implementation**
- **Add initial UI for snippets**
- **Trigger snippets properly**
- **Improve CommandRunner restoring pasteboard**
- **Add some safe-guard to not have snippets collide**
- **Use the coordinator event instead (this is translated when using rebindings) Refactor receiveMachPortEvent to receiveCGEvent**
- **Improve reliability of the pasteboard implementation Improve snippet controller by sending both up and down keys Change the icons of the different trigger buttons Capture `originalPasteboardContents` in the command runner to make sure that the value jumped properly between threads Improve the text command runner by sending `keyUp` Fix warning related to the static propery on `SnippetController`**
- **Minor refactoring of the snippet controller**
- **Refactor SnippetController**
- **Lower the time intervall for snippet**
- **Set snippet controller to enabled when the view disappears**
- **Remove whitespace**
- **Properly dismiss the bundle notification view when the command runs**
- **Various improvements**
- **Fix notification not showing for commands because the notification controller was reset instantly Improve performance of the workflow notification controller by not posting duplicates Show snippets in the content list (like we show keyboard shortcuts) Add icon for snippets Add icons to the notification workflow view Various under-the-hood improvements**
- **Dump dependencies**
- **Make UI element capture more reliable in Electron-based apps**
- **Bump application version**
- **Bundled improvements - Add $PASTEBOARD as a magic variable - Add GenericAppIconView - Add additional icons to the workflow notification view - Add UserMode icon - Improve Snippet icon - Fix some warnings**
- **Add icons to the edit group view Fix using Safari Web Apps as group rules Tweak icons Improve add user mode by adding icon and using the correct textfield style**
- **Add `New Command` menu item to File Menu**
- **Fix SwiftUI runtime issue**
- **Fix bug in SnippetController (ran commands when it shouldn't Go into record mode when adding a keyboard trigger**
- **Fix bug where you couldn't update the built-in command name Fix using the command name for the notification output**
- **Refactor KeyboartShortcutsController to handle plural user modes properly**
- **Fix bug with display value in the builtin command view Use the user mode icon in the built in command view**
- **Use the user mode in the content list and builtin command UI**
- **Dismiss bundles after a match has been found**
- **Fix race condition in dismissing conditions Add more icons to the workflow notification view**
- **Improve copying Workflows with snippet triggers Fix duplicate matches in the bundle notification**
- **Improve the look and feel of the workflow notification matches view Add script command icon to the workflow notification view**
- **Refactor the window management icon**
- **Refactor WorkflowRunner to not hold a `workItem` Add `scheduleDimiss` to `WorkflowNotificationController` Fix focus value in `WorkflowCommandListScrollView`**
- **Fix focus value in SingleDetailVIew (.addSnippetTrigger)**
- **Add icons to the new builtin command view**
- **Add icons to the buildin command view**
- **Make the project compile with Xcode 15.3 RC**
