### PR TITLE
feat: Enhance FileWatcher with dependency injection

### DIFF
--- a/App/Sources/Core/FileWatcher.swift
+++ b/App/Sources/Core/FileWatcher.swift
@@ -5,11 +5,18 @@ enum FileWatcherError: Error {
   case fileNotFound
 }
 
-final class FileWatcher {
-  let fileSystemMonitor: DispatchSourceFileSystemObject
+protocol FileManaging {
+  func fileExists(atPath path: String) -> Bool
+}
 
-  init(_ fileURL: URL, handler: @escaping (URL) -> Void) throws {
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+extension FileManager: FileManaging {}
+
+final class FileWatcher {
+  private let fileSystemMonitor: DispatchSourceFileSystemObject
+
+  init(_ fileURL: URL, fileManager: FileManaging = FileManager.default,
+       handler: @escaping (URL) -> Void) throws {
+    guard fileManager.fileExists(atPath: fileURL.path) else {
       throw FileWatcherError.fileNotFound
     }
 


### PR DESCRIPTION
Replace direct FileManager.default usage in FileWatcher's initializer with a protocol, FileManaging, allowing for dependency injection. This makes FileWatcher more flexible and testable by enabling the use of mocks or different file manager implementations. Additionally, make the fileSystemMonitor property private to encapsulate FileWatcher's internal workings better.