### PR TITLE
refactor: streamline AppEnvironment cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ name: Test
 jobs:
   test:
     name: Test
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
         matrix:
-          xcode: ['15.2']
+          xcode: ['15.3']
     steps:
       - name: Set Xcode ${{ matrix.xcode }}
         run: |

--- a/App/Sources/Core/AppEnvironment.swift
+++ b/App/Sources/Core/AppEnvironment.swift
@@ -1,7 +1,4 @@
 enum AppEnvironment: String, Hashable, Identifiable {
   var id: String { rawValue }
-
-  case development
-  case production
-  case previews
+  case development, production, previews
 }

--- a/App/Sources/Core/KeyboardCowboy.swift
+++ b/App/Sources/Core/KeyboardCowboy.swift
@@ -41,12 +41,12 @@ struct KeyboardCowboy: App {
 
     Task {
       await MainActor.run {
-        Inject.animation = .spring()
+        InjectConfiguration.animation = .spring()
         Benchmark.shared.isEnabled = launchArguments.isEnabled(.benchmark)
       }
     }
 
-    if launchArguments.isEnabled(.injection) { _ = Inject.load }
+    if launchArguments.isEnabled(.injection) { _ = InjectConfiguration.load }
   }
 
   var body: some Scene {

--- a/Project.swift
+++ b/Project.swift
@@ -155,7 +155,7 @@ public enum PackageResolver {
     let packages: [Package]
     if env["PACKAGE_DEVELOPMENT"] == "true" {
       packages = [
-        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.1.0"),
+        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
         .package(path: "../AXEssibility"),
         .package(path: "../Bonzai"),
@@ -170,7 +170,7 @@ public enum PackageResolver {
       ]
     } else {
       packages = [
-        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.1.0"),
+        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
         .package(url: "https://github.com/zenangst/AXEssibility.git", from: "0.1.3"),
         .package(url: "https://github.com/zenangst/Bonzai.git", .revision("e8bb0b48cce45ab33de90982ce107ca5cad51c02")),


### PR DESCRIPTION
Simplify the enumeration of environment cases in
AppEnvironment.swift by combining them into a single line. This change improves readability and conciseness in the codebase, making it easier to add or remove environment states in the future.