### PR TITLE
simplify window focus logic and streamline call

### DIFF
--- a/App/Sources/Core/Runners/System/SystemFrontmostWindowFocus.swift
+++ b/App/Sources/Core/Runners/System/SystemFrontmostWindowFocus.swift
@@ -5,13 +5,14 @@ import Foundation
 import Windows
 
 enum SystemFrontmostWindowFocus {
-  static func run(_ frontMostIndex: inout Int, kind: SystemCommand.Kind, snapshot: UserSpace.Snapshot) {
-    var windows = snapshot.windows.frontMostApplicationWindows
+  static func run(kind: SystemCommand.Kind, snapshot: UserSpace.Snapshot) {
+    var frontMostIndex = 0
+    let windows = snapshot.windows.frontMostApplicationWindows
     let frontMostApplication = snapshot.frontMostApplication
     let frontMostAppElement = AppAccessibilityElement(frontMostApplication.ref.processIdentifier)
     if let focusedWindow = try? frontMostAppElement.focusedWindow(),
        let index = windows.firstIndex(where: { $0.id == focusedWindow.id }){
-      windows.remove(at: index)
+      frontMostIndex = index
     }
 
     guard !windows.isEmpty else {

--- a/App/Sources/Core/Runners/SystemCommandRunner.swift
+++ b/App/Sources/Core/Runners/SystemCommandRunner.swift
@@ -60,11 +60,7 @@ final class SystemCommandRunner: @unchecked Sendable {
           workspace: workspace
         )
       case .moveFocusToNextWindowFront, .moveFocusToPreviousWindowFront:
-        SystemFrontmostWindowFocus.run(
-          &frontMostIndex,
-          kind: command.kind,
-          snapshot: snapshot
-        )
+        SystemFrontmostWindowFocus.run(kind: command.kind, snapshot: snapshot)
       case .minimizeAllOpenWindows:
         guard let machPort else { return }
         try SystemMinimizeAllWindows.run(snapshot, machPort: machPort)


### PR DESCRIPTION
Remove inout parameter in SystemFrontmostWindowFocus.run, assign frontMostIndex within the function, and streamline call in SystemCommandRunner for better maintainability.