### PR TITLE
fix(shellscript): trim whitespace from shell command input

### DIFF
--- a/App/Sources/Core/Runners/Scripting/Plugins/ShellScriptPlugin.swift
+++ b/App/Sources/Core/Runners/Scripting/Plugins/ShellScriptPlugin.swift
@@ -49,6 +49,8 @@ final class ShellScriptPlugin: @unchecked Sendable {
       }
     }
 
+    shell = shell.trimmingCharacters(in: .whitespacesAndNewlines)
+
     let (process, pipe, errorPipe) = createProcess(shell: shell)
 
     process.arguments = ["-i", "-l", command]


### PR DESCRIPTION
Remove leading and trailing whitespaces from the shell command  input to ensure proper execution and prevent potential errors.  This fixes an issue where commands with inconspicuous whitespace  caused process failures.