### PR TITLE
Add subrole support for UI elements

### DIFF
--- a/App/Sources/Core/Models/Commands/UIElementCommand.swift
+++ b/App/Sources/Core/Models/Commands/UIElementCommand.swift
@@ -96,6 +96,7 @@ struct UIElementCommand: MetaDataProviding {
       case identifier
       case title
       case value
+      case subrole
 
       var displayName: String {
         switch self {
@@ -103,6 +104,7 @@ struct UIElementCommand: MetaDataProviding {
         case .description: "Description"
         case .title: "Title"
         case .value: "Value"
+        case .subrole: "Subrole"
         }
       }
 
@@ -112,6 +114,7 @@ struct UIElementCommand: MetaDataProviding {
         case .description: kAXDescriptionAttribute
         case .title: kAXTitleAttribute
         case .value: kAXValueAttribute
+        case .subrole: kAXSubroleAttribute
         }
       }
     }

--- a/App/Sources/Core/Runners/UIElementCommandRunner.swift
+++ b/App/Sources/Core/Runners/UIElementCommandRunner.swift
@@ -87,6 +87,12 @@ final class UIElementCommandRunner {
            predicate.compare.run(lhs: value, rhs: predicate.value) {
           return true
         }
+        
+        if predicate.properties.contains(.subrole),
+           let value = values[.subrole] as? String,
+           predicate.compare.run(lhs: value, rhs: predicate.value) {
+          return true
+        }
       }
       
       return false

--- a/App/Sources/UI/Stores/UIElementCaptureStore.swift
+++ b/App/Sources/UI/Stores/UIElementCaptureStore.swift
@@ -153,7 +153,8 @@ final class UIElementCaptureStore: ObservableObject {
           identifier: element.identifier,
           title: element.title,
           value: element.value,
-          role: element.role
+          role: element.role,
+          subrole: element.subrole
         )
         self.capturedElement = capturedElement
 
@@ -175,6 +176,7 @@ struct UIElementCaptureItem {
   let title: String?
   let value: String?
   let role: String?
+  let subrole: String?
 }
 
 final class WindowBorderViewPublisher: ObservableObject {

--- a/App/Sources/UI/Views/NewCommand/NewCommandUIElementView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandUIElementView.swift
@@ -177,6 +177,11 @@ struct NewCommandUIElementView: View {
               .foregroundColor(.secondary)
             Text(element.role ?? "No value")
               .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Subrole:")
+              .font(.system(.caption, design: .monospaced))
+              .foregroundColor(.secondary)
+            Text(element.subrole ?? "No value")
+              .frame(maxWidth: .infinity, alignment: .leading)
           }
         }
         .padding(8)
@@ -201,6 +206,9 @@ struct NewCommandUIElementView: View {
       } else if let elementTitle = element.title, !elementTitle.isEmpty {
         predicate.properties = [.title]
         predicate.value = elementTitle
+      } else if let elementSubrole = element.subrole, !elementSubrole.isEmpty {
+        predicate.properties = [.subrole]
+        predicate.value = elementSubrole
       }
 
       if let role = element.role {
@@ -275,7 +283,7 @@ struct NewCommandUIElementView: View {
     .environmentObject(
       UIElementCaptureStore(
         isCapturing: false,
-        capturedElement: .init(description: nil, identifier: nil, title: nil, value: nil, role: nil)
+        capturedElement: .init(description: nil, identifier: nil, title: nil, value: nil, role: nil, subrole: nil)
       )
     )
 }


### PR DESCRIPTION
The current capture UI element functionality cannot filter elements by subrole, but there are some UI elements without a title, description, or similar properties. For example, the close button, minimize button, and fullscreen button. These elements can only be identified by their subrole: the close button's subrole is AXCloseButton, the minimize button is AXMinimizeButton, and the fullscreen button is AXFullScreenButton. 

Use case, I have some cross-platform software that does not follow macOS conventions, where Cmd+W serves a different function. Therefore, I can use Keyboard Cowboy along with the newly added subrole feature to close a window with Cmd+W without quitting the application. I believe there are some other UI elements only can be identified by their subrole.

Of course, the ideal solution in the future would be to add support for multiple conditions, such as executing an action only when both role and subrole are satisfied.

<img width="439" alt="image" src="https://github.com/user-attachments/assets/5110d675-3a52-47cf-a66f-536ee0b5c9b5" />

