### PR TITLE
Improve SwiftUI performance

### DIFF
--- a/App/Sources/Core/MachPort/LeaderKeyCoordinator.swift
+++ b/App/Sources/Core/MachPort/LeaderKeyCoordinator.swift
@@ -178,7 +178,7 @@ final class LeaderKeyCoordinator: @unchecked Sendable {
       case .leader:
         let currentTimestamp = Self.convertTimestampToMilliseconds(DispatchTime.now().uptimeNanoseconds)
         let elapsedTime = currentTimestamp - lastEventTime
-        let threshold = CGFloat(max(Int(holdDuration * 2 * 1_000), 125))
+        let threshold = CGFloat(max(Int(holdDuration * 2 * 1_000), 100))
 
         if threshold <= elapsedTime { } else  {
           postKeyDownAndUp(newEvent)

--- a/App/Sources/Core/Runners/Bundled/BundledCommandRunner.swift
+++ b/App/Sources/Core/Runners/Bundled/BundledCommandRunner.swift
@@ -140,11 +140,21 @@ final class BundledCommandRunner: Sendable {
     // This should only be true if it comes from `activatePreviousWorkspace`.
     // It is set to true in order to keep the last focused application the same as when the
     // workspace was previously active.
-    if onlyUnhide || (workspaceCommand.isDynamic && workspaceCommand.tiling == nil) {
+    let dynamicWorkspaceWithoutTiling = (workspaceCommand.isDynamic && workspaceCommand.tiling == nil)
+    if onlyUnhide || dynamicWorkspaceWithoutTiling {
+      let indexOfLast = commands.lastIndex(where: {
+        if case .application = $0 { return true }
+        return false
+      })
       for (offset, command) in commands.enumerated() {
-        if case .application(var application) = command {
-          application.action = .unhide
-          commands[offset] = .application(application)
+        if case .application(var applicationCommand) = command {
+          if dynamicWorkspaceWithoutTiling {
+            applicationCommand.action = offset == indexOfLast ? .open : .unhide
+          } else {
+            applicationCommand.action = .unhide
+          }
+
+          commands[offset] = .application(applicationCommand)
         }
       }
     }

--- a/App/Sources/Core/Runners/Bundled/BundledCommandRunner.swift
+++ b/App/Sources/Core/Runners/Bundled/BundledCommandRunner.swift
@@ -140,7 +140,7 @@ final class BundledCommandRunner: Sendable {
     // This should only be true if it comes from `activatePreviousWorkspace`.
     // It is set to true in order to keep the last focused application the same as when the
     // workspace was previously active.
-    if onlyUnhide {
+    if onlyUnhide || (workspaceCommand.isDynamic && workspaceCommand.tiling == nil) {
       for (offset, command) in commands.enumerated() {
         if case .application(var application) = command {
           application.action = .unhide

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -88,33 +88,33 @@ final class KeyboardCowboyEngine {
         eventsOfInterest: keyboardEvents,
         signature: "com.zenangst.Keyboard-Cowboy",
         autoStartMode: .commonModes,
-        onFlagsChanged: { [machPortCoordinator, modifierTriggerController, leaderKey] in
-          let allowsEscapeFallback: Bool
-          if machPortCoordinator.mode == .intercept ||
-             machPortCoordinator.mode == .recordMacro {
-            allowsEscapeFallback = !modifierTriggerController.handleIfApplicable($0)
-          } else {
-            allowsEscapeFallback = true
-          }
+        onFlagsChanged: { [machPortCoordinator, leaderKey] in
+//          let allowsEscapeFallback: Bool
+//          if machPortCoordinator.mode == .intercept ||
+//             machPortCoordinator.mode == .recordMacro {
+//            allowsEscapeFallback = !modifierTriggerController.handleIfApplicable($0)
+//          } else {
+//            allowsEscapeFallback = true
+//          }
 
           _ = leaderKey.handlePartialMatchIfApplicable(nil, machPortEvent: $0)
-          machPortCoordinator.receiveFlagsChanged($0, allowsEscapeFallback: allowsEscapeFallback)
+          machPortCoordinator.receiveFlagsChanged($0, allowsEscapeFallback: true)
           keyCache.handle($0.event)
         },
-        onEventChange: { [machPortCoordinator, modifierTriggerController, leaderKey] in
-          let allowsEscapeFallback: Bool
-          if machPortCoordinator.mode == .intercept ||
-             machPortCoordinator.mode == .recordMacro {
-            allowsEscapeFallback = !modifierTriggerController.handleIfApplicable($0)
-          } else {
-            allowsEscapeFallback = false
-          }
+        onEventChange: { [machPortCoordinator, leaderKey] in
+//          let allowsEscapeFallback: Bool
+//          if machPortCoordinator.mode == .intercept ||
+//             machPortCoordinator.mode == .recordMacro {
+//            allowsEscapeFallback = !modifierTriggerController.handleIfApplicable($0)
+//          } else {
+//            allowsEscapeFallback = false
+//          }
 
           _ = leaderKey.handlePartialMatchIfApplicable(nil, machPortEvent: $0)
 
           if $0.event.type == .flagsChanged {
             if $0.isRepeat { return }
-            machPortCoordinator.receiveFlagsChanged($0, allowsEscapeFallback: allowsEscapeFallback)
+            machPortCoordinator.receiveFlagsChanged($0, allowsEscapeFallback: true)
           } else {
             machPortCoordinator.receiveEvent($0)
           }

--- a/App/Sources/UI/Compat/LegacyOnTapFix.swift
+++ b/App/Sources/UI/Compat/LegacyOnTapFix.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct LegacyOnTapFix: ViewModifier {
   let onTap: () -> Void
 
-  @ViewBuilder
   func body(content: Content) -> some View {
     if #available(macOS 14.0, *) {
       content

--- a/App/Sources/UI/Releases/Release3_27.swift
+++ b/App/Sources/UI/Releases/Release3_27.swift
@@ -232,7 +232,6 @@ private struct ChangesView: View {
            version: .v3270),
   ]
 
-  @ViewBuilder
   var body: some View {
     VStack(spacing: 8) {
       Text("Changes")

--- a/App/Sources/UI/Views/ContentScriptImageView.swift
+++ b/App/Sources/UI/Views/ContentScriptImageView.swift
@@ -5,7 +5,6 @@ struct ContentScriptImageView: View {
   let source: ScriptCommand.Source
   let size: CGFloat
 
-  @ViewBuilder
   var body: some View {
     switch source {
     case .inline:

--- a/App/Sources/UI/Views/DropDestination/TargetedDropView.swift
+++ b/App/Sources/UI/Views/DropDestination/TargetedDropView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 extension View {
-  @ViewBuilder
   func dropDestination<T: Transferable & Equatable>(_ type: T.Type,
                                         alignment: TargetedAlignment = .vertical,
                                         color: Color, kind: TargetedKind = .reorder,
@@ -55,7 +54,6 @@ private struct TargetedDropView<T: Transferable & Equatable>: View, Equatable, S
     self.onDrop = onDrop
   }
 
-  @ViewBuilder
   var body: some View {
     if LocalEventMonitor.shared.mouseDown {
       containerView(alignment,

--- a/App/Sources/UI/Views/EditableKeyboardShortcutsView.swift
+++ b/App/Sources/UI/Views/EditableKeyboardShortcutsView.swift
@@ -221,7 +221,6 @@ struct EditableKeyboardShortcutsView<T: Hashable>: View {
     }
   }
 
-  @ViewBuilder
   private func overlay(_ proxy: ScrollViewProxy) -> some View {
     ZStack {
       RoundedRectangle(cornerRadius: 6)
@@ -374,7 +373,6 @@ private struct DraggableToggle<T: Transferable>: ViewModifier {
   let isEnabled: Bool
   let model: T
 
-  @ViewBuilder
   func body(content: Content) -> some View {
     if isEnabled {
       content

--- a/App/Sources/UI/Views/Extensions/View+Extensions.swift
+++ b/App/Sources/UI/Views/Extensions/View+Extensions.swift
@@ -1,35 +1,19 @@
 import SwiftUI
 
 extension View {
-  @ViewBuilder
-  func stacked(_ stacked: Binding<Bool>, color: Color, size: CGFloat) -> some View {
-    let angle = Angle.degrees(stacked.wrappedValue ? 45 : 0)
-    let cosineOfAngle = cos(angle.radians)
-    let adjustmentFactor: CGFloat = 1.0
-    let scale = (1.0 / cosineOfAngle) * adjustmentFactor
-    self
-      .rotation3DEffect(
-        angle,
-        axis: (x: 1, y: 0, z: 0)
-      )
-      .scaleEffect(x: scale, y: 1, anchor: .center)
-      .animation(.easeInOut(duration: 3.0), value: stacked.wrappedValue)
-  }
-
   func iconShape(_ size: CGFloat) -> some View {
     self
       .clipShape(RoundedRectangle(cornerRadius: size * 0.2))
   }
 
-  @ViewBuilder
   func iconOverlay() -> some View {
     IconOverlayView()
   }
+
   func iconBorder(_ size: CGFloat) -> some View {
     IconBorderView(size)
   }
 
-  @ViewBuilder
   func transform<Transform: View>(_ transform: (Self) -> Transform) -> some View {
     transform(self)
   }
@@ -38,11 +22,6 @@ extension View {
     onHover(perform: { hovering in
       if hovering { cursor.push() } else { NSCursor.pop() }
     })
-  }
-
-  @ViewBuilder
-  func `if`<Transform: View>(_ condition: Bool, transform: (Self) -> Transform) -> some View {
-    if condition { transform(self) } else { self }
   }
 
   @MainActor @ViewBuilder
@@ -54,7 +33,6 @@ extension View {
     }
   }
 
-  @ViewBuilder
   func debugID<Element: Identifiable>(_ element: Element) -> some View where Element.ID == String {
     self
       .overlay(content: {

--- a/App/Sources/UI/Views/GroupDetail/GroupDetailView.swift
+++ b/App/Sources/UI/Views/GroupDetail/GroupDetailView.swift
@@ -47,7 +47,6 @@ struct GroupDetailView: View {
     case addWorkflow(workflowId: Workflow.ID)
   }
 
-  @ObserveInjection var inject
   @FocusState var focus: LocalFocus<GroupDetailViewModel>?
   @EnvironmentObject private var updater: ConfigurationUpdater
   @EnvironmentObject private var transaction: UpdateTransaction
@@ -159,7 +158,6 @@ struct GroupDetailView: View {
     }
   }
 
-  @ViewBuilder
   var body: some View {
     ScrollViewReader { proxy in
       GroupDetailHeaderView()
@@ -330,7 +328,6 @@ struct GroupDetailView: View {
           })
         }
     }
-    .enableInjection()
   }
 
   private func toolbarContent() -> some ToolbarContent {

--- a/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandImageView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct NewCommandImageView: View {
   let kind: NewCommandView.Kind
 
-  @ViewBuilder
   var body: some View {
     Group {
       switch kind {

--- a/App/Sources/UI/Views/NewCommand/NewCommandMenuBarView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandMenuBarView.swift
@@ -23,7 +23,6 @@ struct NewCommandMenuBarView: View {
 
   private let wikiUrl = URL(string: "https://github.com/zenangst/KeyboardCowboy/wiki/Commands#menu-bar-commands")!
 
-  @ObserveInjection var inject
   @Namespace var namespace
   @FocusState var focus: Focus?
   @Environment(\.resetFocus) var resetFocus
@@ -54,7 +53,6 @@ struct NewCommandMenuBarView: View {
     }
   }
 
-  @ViewBuilder
   var body: some View {
     VStack(alignment: .leading) {
       HStack {
@@ -130,7 +128,6 @@ struct NewCommandMenuBarView: View {
     }
     .focusScope(namespace)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .enableInjection()
   }
 
   @discardableResult

--- a/App/Sources/UI/Views/NewCommand/NewCommandView.swift
+++ b/App/Sources/UI/Views/NewCommand/NewCommandView.swift
@@ -244,7 +244,7 @@ struct NewCommandView: View {
     .enableInjection()
   }
 
-  @ViewBuilder @MainActor
+  @MainActor
   private func selectedView(_ selection: Kind) -> some View {
     VStack(alignment: .leading) {
       switch selection {

--- a/App/Sources/UI/Views/PromoView.swift
+++ b/App/Sources/UI/Views/PromoView.swift
@@ -434,7 +434,6 @@ private struct KeyboardCowboyView: View {
     .padding(16)
     .background {
       BackgroundView()
-        .drawingGroup()
     }
     .background(
       LinearGradient(stops: [

--- a/App/Sources/UI/Views/WorkflowDetail/Commands/CommandList.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Commands/CommandList.swift
@@ -35,7 +35,6 @@ struct CommandList: View {
     self.scrollViewProxy = scrollViewProxy
   }
 
-  @ViewBuilder
   var body: some View {
     VStack(spacing: 0) {
       CommandListHeader(namespace: namespace)

--- a/App/Sources/UI/Views/WorkflowDetail/Commands/CommandListHeader.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Commands/CommandListHeader.swift
@@ -3,7 +3,6 @@ import Inject
 import SwiftUI
 
 struct CommandListHeader: View {
-  @ObserveInjection var inject
   @EnvironmentObject var updater: ConfigurationUpdater
   @EnvironmentObject var transaction: UpdateTransaction
   @EnvironmentObject var publisher: CommandsPublisher
@@ -47,7 +46,6 @@ struct CommandListHeader: View {
         .environment(\.menuHoverEffect, publisher.data.commands.isEmpty ? false : true)
       }
     }
-    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowDetail/Commands/CommandListScrollView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Commands/CommandListScrollView.swift
@@ -3,7 +3,6 @@ import Bonzai
 import SwiftUI
 
 struct CommandListScrollView: View {
-  @ObserveInjection var inject
   @EnvironmentObject private var updater: ConfigurationUpdater
   @EnvironmentObject private var transaction: UpdateTransaction
   @EnvironmentObject private var applicationStore: ApplicationStore
@@ -121,6 +120,5 @@ struct CommandListScrollView: View {
     }
     .focused(focus, equals: .detail(.commands))
     .matchedGeometryEffect(id: "command-list", in: namespace)
-    .enableInjection()
   }
 }

--- a/App/Sources/UI/Views/WorkflowDetail/Commands/CommandTypes/CommandContainerView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Commands/CommandTypes/CommandContainerView.swift
@@ -9,9 +9,9 @@ struct CommandContainerView<IconContent, Content, SubContent>: View where IconCo
   private let placeholder: String
 
   @State private var metaData: CommandViewModel.MetaData
-  @ViewBuilder private let icon: () -> IconContent
-  @ViewBuilder private let content: () -> Content
-  @ViewBuilder private let subContent: () -> SubContent
+  private let icon: () -> IconContent
+  private let content: () -> Content
+  private let subContent: () -> SubContent
 
   init(_ metaData: CommandViewModel.MetaData,
        placeholder: String,
@@ -88,8 +88,8 @@ private struct HeaderView: View {
 }
 
 private struct ContentView<IconContent, Content>: View where IconContent: View, Content: View {
-  @ViewBuilder private let icon: () -> IconContent
-  @ViewBuilder private let content: () -> Content
+  private let icon: () -> IconContent
+  private let content: () -> Content
 
   init(icon: @escaping () -> IconContent,
        content: @escaping () -> Content) {

--- a/App/Sources/UI/Views/WorkflowDetail/DetailView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/DetailView.swift
@@ -2,7 +2,6 @@ import Inject
 import SwiftUI
 
 struct DetailView: View {
-  @ObserveInjection var inject
   @EnvironmentObject var statePublisher: DetailStatePublisher
   private let applicationTriggerSelection: SelectionManager<DetailViewModel.ApplicationTrigger>
   private let commandPublisher: CommandsPublisher
@@ -28,45 +27,37 @@ struct DetailView: View {
     self.commandPublisher = commandPublisher
   }
 
-  @ViewBuilder
   var body: some View {
-    Group {
-      switch statePublisher.data {
-      case .empty:
-        DetailEmptyView()
-          .allowsHitTesting(false)
-          .animation(.easeInOut(duration: 0.375), value: statePublisher.data)
-          .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
-      case .single(let viewModel):
-        SingleDetailView(
-          viewModel,
-          focus: focus,
-          applicationTriggerSelectionManager: applicationTriggerSelection,
-          commandSelectionManager: commandSelection,
-          keyboardShortcutSelectionManager: keyboardShortcutSelection,
-          triggerPublisher: triggerPublisher,
-          infoPublisher: infoPublisher,
-          commandPublisher: commandPublisher)
-        .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
-        .overlay(alignment: .topTrailing, content: {
-          DevTagView()
-        })
+    switch statePublisher.data {
+    case .empty:
+      DetailEmptyView()
+        .allowsHitTesting(false)
         .animation(.easeInOut(duration: 0.375), value: statePublisher.data)
-        .id(viewModel.id)
-      case .multiple(let viewModels):
-        let limit = 5
-        let count = viewModels.count
-        MultiDetailView( count > limit ? Array(viewModels[0...limit-1]) : viewModels, count: count)
-          .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
-      }
+        .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
+    case .single(let viewModel):
+      SingleDetailView(
+        viewModel,
+        focus: focus,
+        applicationTriggerSelectionManager: applicationTriggerSelection,
+        commandSelectionManager: commandSelection,
+        keyboardShortcutSelectionManager: keyboardShortcutSelection,
+        triggerPublisher: triggerPublisher,
+        infoPublisher: infoPublisher,
+        commandPublisher: commandPublisher)
+      .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
+      .overlay(alignment: .topTrailing, content: {
+        DevTagView()
+      })
+    case .multiple(let viewModels):
+      let limit = 5
+      let count = viewModels.count
+      MultiDetailView( count > limit ? Array(viewModels[0...limit-1]) : viewModels, count: count)
+        .edgesIgnoringSafeArea(isRunningPreview ? [] : [.top])
     }
-    .enableInjection()
   }
 }
 
 private struct DevTagView: View {
-  @ObserveInjection var inject
-  @ViewBuilder
   var body: some View {
     if KeyboardCowboyApp.env() != .production {
       Rectangle()
@@ -87,7 +78,6 @@ private struct DevTagView: View {
         .rotationEffect(.degrees(45), anchor: .trailing)
         .offset(x: 8, y: -4)
         .fixedSize()
-        .enableInjection()
     }
   }
 }

--- a/App/Sources/UI/Views/WorkflowDetail/SingleDetailView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/SingleDetailView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import Apps
 
 struct SingleDetailView: View {
-  @ObserveInjection var inject
   @Namespace var namespace
 
   @EnvironmentObject private var commandPublisher: CommandsPublisher
@@ -63,7 +62,6 @@ struct SingleDetailView: View {
                 focus.wrappedValue = .detail(.commands)
               }
             })
-          .id(infoPublisher.data.id)
         }
         .padding(.top, 12)
         .padding(.bottom, 24)
@@ -90,7 +88,6 @@ struct SingleDetailView: View {
     }
     .focusScope(namespace)
     .frame(maxHeight: .infinity, alignment: .top)
-    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowDetail/Triggers/WorkflowApplicationTrigger.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Triggers/WorkflowApplicationTrigger.swift
@@ -67,7 +67,7 @@ struct WorkflowApplicationTrigger: View {
 
       if !data.isEmpty {
         let count = data.count
-        let itemHeight: CGFloat = 55
+        let itemHeight: CGFloat = 60
 
         ScrollView {
           LazyVStack {

--- a/App/Sources/UI/Views/WorkflowDetail/Triggers/WorkflowApplicationTrigger.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/Triggers/WorkflowApplicationTrigger.swift
@@ -35,6 +35,7 @@ struct WorkflowApplicationTrigger: View {
             withAnimation(CommandList.animation) {
               data.append(.init(id: uuid.uuidString, name: anyApplication.displayName,
                                 application: anyApplication, contexts: []))
+              updateApplicationTriggers(data)
             }
           }, label: {
             Text("Any Application")
@@ -48,6 +49,7 @@ struct WorkflowApplicationTrigger: View {
               withAnimation(CommandList.animation) {
                 data.append(.init(id: uuid.uuidString, name: application.displayName,
                                   application: application, contexts: []))
+                updateApplicationTriggers(data)
               }
             }, label: {
               Text(application.displayName)
@@ -81,6 +83,7 @@ struct WorkflowApplicationTrigger: View {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.65, blendDuration: 0.2)) {
                   data.move(fromOffsets: IndexSet(from), toOffset: destination)
                 }
+                updateApplicationTriggers(data)
                 return false
               })
               .focusable(focus, as: .detail(.applicationTrigger(element.id))) {
@@ -103,6 +106,7 @@ struct WorkflowApplicationTrigger: View {
               withAnimation {
                 data.remove(atOffsets: IndexSet(offsets))
               }
+              updateApplicationTriggers(data)
             }
           }
           .onChange(of: data, perform: { newValue in
@@ -149,7 +153,7 @@ struct WorkflowApplicationTrigger: View {
   }
 }
 
-fileprivate extension DetailViewModel.ApplicationTrigger.Context {
+extension DetailViewModel.ApplicationTrigger.Context {
   var appTriggerContext: ApplicationTrigger.Context {
     switch self {
     case .launched:        .launched

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowInfoView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowInfoView.swift
@@ -45,6 +45,10 @@ struct WorkflowInfoView: View {
         .switchStyle()
         .environment(\.switchStyle, .regular)
     }
+    .onChange(of: publisher.data.name) { newValue in
+      guard newValue != name else { return }
+      name = newValue
+    }
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowInfoView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowInfoView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 struct WorkflowInfoView: View {
   @EnvironmentObject private var transaction: UpdateTransaction
   @EnvironmentObject private var updater: ConfigurationUpdater
-  @ObserveInjection var inject
   @ObservedObject private var publisher: InfoPublisher
   @State var name: String
 
@@ -46,7 +45,6 @@ struct WorkflowInfoView: View {
         .switchStyle()
         .environment(\.switchStyle, .regular)
     }
-    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowKeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowKeyboardTriggerView.swift
@@ -116,7 +116,7 @@ struct WorkflowKeyboardTriggerView: View {
         .environment(\.textFieldBackgroundColor, Color(nsColor: .controlColor).opacity(0.5))
         .environment(\.textFieldFont, .caption)
         .environment(\.textFieldPadding, .small)
-        .frame(maxWidth: 32)
+        .frame(minWidth: 32, maxWidth: min(20 + CGFloat(4 * holdDurationText.count), 64))
         Text("seconds")
       }
       .font(.caption)
@@ -128,6 +128,13 @@ struct WorkflowKeyboardTriggerView: View {
          trigger != self.trigger else { return }
 
       self.trigger = trigger
+
+      if let holdDuration = trigger.holdDuration {
+        holdDurationText = "\(holdDuration)"
+      }
+      keepLastPartialMatch = trigger.keepLastPartialMatch
+      passthrough = trigger.passthrough
+      allowRepeat = trigger.allowRepeat
     })
     .textStyle { text in
       text.font = .caption

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowKeyboardTriggerView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowKeyboardTriggerView.swift
@@ -4,6 +4,7 @@ import Inject
 import SwiftUI
 
 struct WorkflowKeyboardTriggerView: View {
+  @EnvironmentObject private var publisher: TriggerPublisher
   @EnvironmentObject var updater: ConfigurationUpdater
   @EnvironmentObject var transaction: UpdateTransaction
   @ObserveInjection var inject
@@ -122,6 +123,12 @@ struct WorkflowKeyboardTriggerView: View {
       .environment(\.toggleStyle, .small)
       .environment(\.toggleFont, .caption)
     }
+    .onChange(of: publisher.data, perform: { newValue in
+      guard case .keyboardShortcuts(let trigger) = newValue,
+         trigger != self.trigger else { return }
+
+      self.trigger = trigger
+    })
     .textStyle { text in
       text.font = .caption
     }

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowTriggerListView.swift
@@ -4,7 +4,6 @@ import Inject
 import SwiftUI
 
 struct WorkflowTriggerListView: View {
-  @ObserveInjection var inject
   @Namespace private var namespace
   @ObservedObject private var publisher: TriggerPublisher
   private let applicationTriggerSelectionManager: SelectionManager<DetailViewModel.ApplicationTrigger>
@@ -62,7 +61,6 @@ struct WorkflowTriggerListView: View {
     }
     .style(.derived)
     .animation(.spring(response: 0.3, dampingFraction: 0.65, blendDuration: 0.2), value: publisher.data)
-    .enableInjection()
   }
 }
 

--- a/App/Sources/UI/Views/WorkflowDetail/WorkflowTriggerListView.swift
+++ b/App/Sources/UI/Views/WorkflowDetail/WorkflowTriggerListView.swift
@@ -60,7 +60,6 @@ struct WorkflowTriggerListView: View {
       }
     }
     .style(.derived)
-    .animation(.spring(response: 0.3, dampingFraction: 0.65, blendDuration: 0.2), value: publisher.data)
   }
 }
 


### PR DESCRIPTION
This PR aims to improve the SwiftUI performance by not relying too much on `@ViewBuilder` and `@ObserveInjection`. It also fixes some bugs related to keyboard shortcuts and dynamic workspaces.

But the biggest culprit was probably the use of `id` in the workflow detail, which basically meant that we had to recreate the entire view hierarchy when you selected a new workflow.

- **Remove use of `@ViewBuilder` & `@ObserveInjection` and `.enableInjection()`**
- **Add `onChange` inside the WorkflowInfoView the publisher name changes**
- **Remove the use of Group and enableInjection in the detail view**
- **Fix updating application triggers**
- **Remove animation for the workflow trigger list view**
- **Increase the item height of the workflow application triggers**
- **Fix bug with keyboard shortcuts not updating properly when switching between workflows**
- **Sort dynamic workspace applications based on activity to keep the order when you switch back**
- **Unhide apps on dynamic workspaces without tiling**
- **Improve focusing on the correct application when using dynamic workspaces & multiple screens**
- **Skip delay when tiling is disabled for a dynamic workspace**
- **Decrease leader key minimum Disable the modifier trigger controller**
- **Fix bug that key trigger modifiers didn't update properly when switching workflows**
