### PR TITLE
Refactor tuist setup

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -1,141 +1,16 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 import Foundation
 
 // MARK: - Project
 let bundleId = "com.zenangst.Keyboard-Cowboy"
+let env = EnvHelper(Router.envPath)
+let shell = Shell(path: Router.sourceRoot)
 
-func xcconfig(_ targetName: String) -> String { "Configurations/\(targetName).xcconfig" }
-func sources(_ folder: String) -> SourceFileGlob { "\(folder)/Sources/**" }
-func xpcSources() -> SourceFileGlob { "XPC/Sources/**" }
-func resources(_ folder: String) -> ResourceFileElements { "\(folder)/Resources/**" }
-
-let rootPath = URL(fileURLWithPath: String(#filePath))
-  .deletingLastPathComponent()
-  .absoluteString
-  .replacingOccurrences(of: "file://", with: "")
-let assetPath = rootPath.appending("Assets")
-let envPath = rootPath.appending(".env")
-let env = EnvHelper(envPath)
-let shell = Shell(path: rootPath)
-let buildNumber = ((try? shell.run("git rev-list --count HEAD")) ?? "x.x.x").trimmingCharacters(in: .whitespacesAndNewlines)
-
-// Main application target
-let mainAppTarget = Target.target(
-  name: "Keyboard-Cowboy",
-  destinations: .macOS,
-  product: .app,
-  bundleId: "com.zenangst.Keyboard-Cowboy",
-  deploymentTargets: .macOS("13.0"),
-  infoPlist: .file(path: .relativeToRoot("App/Info.plist")),
-  sources: SourceFilesList(arrayLiteral: sources("App"), xpcSources()),
-  resources: resources("App"),
-  entitlements: "App/Entitlements/com.zenangst.Keyboard-Cowboy.entitlements",
-  dependencies: [
-    .package(product: "AXEssibility"),
-    .package(product: "Apps"),
-    .package(product: "Bonzai"),
-    .package(product: "Dock"),
-    .package(product: "DynamicNotchKit"),
-    .package(product: "Inject"),
-    .package(product: "InputSources"),
-    .package(product: "Intercom"),
-    .package(product: "KeyCodes"),
-    .package(product: "LaunchArguments"),
-    .package(product: "MachPort"),
-    .package(product: "Sparkle"),
-    .package(product: "Windows"),
-//    .target(name: "LassoService")
-  ],
-  settings:
-    Settings.settings(
-      base: [
-        "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-        "CODE_SIGN_IDENTITY": "Apple Development",
-        "CODE_SIGN_STYLE": "Automatic",
-        "CURRENT_PROJECT_VERSION": SettingValue(stringLiteral: buildNumber),
-        "DEVELOPMENT_TEAM": env["TEAM_ID"],
-        "ENABLE_HARDENED_RUNTIME": true,
-        "MARKETING_VERSION": "3.28.0",
-        "PRODUCT_NAME": "Keyboard Cowboy",
-        "SWIFT_STRICT_CONCURRENCY": "complete",
-        "SWIFT_VERSION": "6.0",
-      ],
-      configurations: [
-        .debug(name: "Debug", xcconfig: "\(xcconfig("Debug"))"),
-        .release(name: "Release", xcconfig: "\(xcconfig("Release"))")
-      ],
-      defaultSettings: .recommended)
-)
-// Unit Tests
-let unitTestTarget = Target.target(
-  name: "UnitTests",
-  destinations: .macOS,
-  product: .unitTests,
-  bundleId: bundleId.appending(".unit-tests"),
-  deploymentTargets: .macOS("13.0"),
-  infoPlist: .file(path: .relativeToRoot("UnitTests/Info.plist")),
-  sources: SourceFilesList(arrayLiteral: sources("UnitTests")),
-  dependencies: [
-    .target(name: "Keyboard-Cowboy")
-  ],
-  settings:
-    Settings.settings(base: [
-      "BUNDLE_LOADER": "$(TEST_HOST)",
-      "CODE_SIGN_IDENTITY": "Apple Development",
-      "CODE_SIGN_STYLE": "-",
-      "DEVELOPMENT_TEAM": env["TEAM_ID"],
-      "PRODUCT_BUNDLE_IDENTIFIER": "\(bundleId).UnitTests",
-      "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/Keyboard Cowboy.app/Contents/MacOS/Keyboard Cowboy",
-    ])
-)
-
-let assetGeneratorTarget = Target.target(
-  name: "AssetGenerator",
-  destinations: .macOS,
-  product: .unitTests,
-  bundleId: bundleId.appending(".asset-generator"),
-  deploymentTargets: .macOS("13.0"),
-  infoPlist: .file(path: .relativeToRoot("AssetGenerator/Info.plist")),
-  sources: SourceFilesList(arrayLiteral: sources("AssetGenerator")),
-  dependencies: [
-    .target(name: "Keyboard-Cowboy")
-  ],
-  settings:
-    Settings.settings(base: [
-      "BUNDLE_LOADER": "$(TEST_HOST)",
-      "CODE_SIGN_IDENTITY": "Apple Development",
-      "CODE_SIGN_STYLE": "-",
-      "DEVELOPMENT_TEAM": env["TEAM_ID"],
-      "PRODUCT_BUNDLE_IDENTIFIER": "\(bundleId).AssetGenerator",
-      "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/Keyboard Cowboy.app/Contents/MacOS/Keyboard Cowboy",
-    ])
-)
-
-let xpcTarget = Target.target(
-    name: "LassoService",
-    destinations: .macOS,
-    product: .xpc,
-    bundleId: "com.zenangst.Keyboard-Cowboy.LassoService",
-    deploymentTargets: .macOS("13.0"),
-    infoPlist: .file(path: .relativeToRoot("LassoService/Info.plist")),
-    sources: SourceFilesList(arrayLiteral: sources("LassoService"), xpcSources()),
-    entitlements: "LassoService/Entitlements/com.zenangst.Keyboard-Cowboy.LassoService.entitlements",
-    dependencies: [
-        .package(product: "Apps"),
-        .package(product: "KeyCodes"),
-        .package(product: "InputSources"),
-        .package(product: "MachPort"),
-    ],
-    settings: Settings.settings(base: [
-        "CODE_SIGN_IDENTITY": "Apple Development",
-        "CODE_SIGN_STYLE": "Automatic",
-        "DEVELOPMENT_TEAM": env["TEAM_ID"],
-        "ENABLE_HARDENED_RUNTIME": true,
-        "PRODUCT_NAME": "LassoService",
-        "SWIFT_STRICT_CONCURRENCY": "complete",
-        "SWIFT_VERSION": "6.0",
-    ])
-)
+let assetGeneratorTarget = Target.assetGenerator(bundleId, env: env)
+let mainAppTarget = Target.mainApp(bundleId, shell: shell, env: env)
+let unitTestTarget = Target.unitTest(bundleId, env: env)
+let xpcTarget = Target.xpcTarget(env)
 
 let project = Project(
   name: "Keyboard Cowboy",
@@ -144,8 +19,8 @@ let project = Project(
                                 tabWidth: 2)),
   packages: PackageResolver.packages(env),
   settings: Settings.settings(configurations: [
-    .debug(name: "Debug", xcconfig: "\(xcconfig("Debug"))"),
-    .release(name: "Release", xcconfig: "\(xcconfig("Release"))")
+    .debug(name: "Debug", xcconfig: "\(Target.xcconfig("Debug"))"),
+    .release(name: "Release", xcconfig: "\(Target.xcconfig("Release"))")
   ], defaultSettings: .recommended),
   targets: [
     mainAppTarget,
@@ -154,60 +29,8 @@ let project = Project(
     xpcTarget,
   ],
   schemes: [
-    Scheme.scheme(
-      name: mainAppTarget.name,
-      shared: true,
-      hidden: false,
-      buildAction: .buildAction(targets: [.target(mainAppTarget.name)]),
-      testAction: .targets(
-        [.testableTarget(target: .target(unitTestTarget.name))],
-        arguments: .arguments(
-          environmentVariables: [
-            "ASSET_PATH": .environmentVariable(value: assetPath, isEnabled: true),
-            "SOURCE_ROOT": .environmentVariable(value: rootPath, isEnabled: true),
-          ],
-          launchArguments: [
-            .launchArgument(name: "-running-unit-tests", isEnabled: true)
-          ])
-        ,
-        options: .options(
-          coverage: true,
-          codeCoverageTargets: [.target(mainAppTarget.name)]
-        )
-      ),
-      runAction: .runAction(
-        executable: .target(mainAppTarget.name),
-        arguments: .arguments(
-          environmentVariables: [
-            "APP_ENVIRONMENT_OVERRIDE": .environmentVariable(value: "development", isEnabled: true),
-            "SOURCE_ROOT": .environmentVariable(value: rootPath, isEnabled: true),
-          ],
-          launchArguments: [
-            .launchArgument(name: "-benchmark", isEnabled: false),
-            .launchArgument(name: "-debugEditing", isEnabled: false),
-            .launchArgument(name: "-injection", isEnabled: false),
-            .launchArgument(name: "-disableMachPorts", isEnabled: false),
-            .launchArgument(name: "-openWindowAtLaunch", isEnabled: true)
-          ]
-        )
-      )
-    ),
-    Scheme.scheme(
-      name: "AssetGenerator",
-      shared: true,
-      hidden: false,
-      testAction: .targets(
-        [.testableTarget(target: .target(assetGeneratorTarget.name))],
-        arguments: .arguments(
-          environmentVariables: [
-            "ASSET_PATH": .environmentVariable(value: assetPath, isEnabled: true),
-            "SOURCE_ROOT": .environmentVariable(value: rootPath, isEnabled: true),
-          ],
-          launchArguments: [
-            .launchArgument(name: "-running-unit-tests", isEnabled: true)
-          ])
-      )
-    )
+    Scheme.mainApp(mainAppTarget, unitTestTarget: unitTestTarget),
+    Scheme.assetGenerator(assetGeneratorTarget)
   ],
   additionalFiles: [
     .glob(pattern: .path( ".env")),
@@ -223,108 +46,3 @@ let project = Project(
     .glob(pattern: .path( "_RELEASE_NOTES.md")),
   ]
 )
-
-public enum PackageResolver {
-  public static func packages(_ env: EnvHelper) -> [Package] {
-    let packages: [Package]
-    if env["PACKAGE_DEVELOPMENT"] == "true" {
-      packages = [
-        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.2"),
-        .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
-        .package(path: "../AXEssibility"),
-        .package(path: "../Apps"),
-        .package(path: "../Bonzai"),
-        .package(path: "../Dock"),
-        .package(path: "../DynamicNotchKit"),
-        .package(path: "../InputSources"),
-        .package(path: "../Intercom"),
-        .package(path: "../KeyCodes"),
-        .package(path: "../LaunchArguments"),
-        .package(path: "../MachPort"),
-        .package(path: "../Windows"),
-      ]
-    } else {
-      packages = [
-        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.2"),
-        .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
-        .package(url: "https://github.com/zenangst/AXEssibility.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/Apps.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/Bonzai.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/Dock.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/DynamicNotchKit", .branch("main")),
-        .package(url: "https://github.com/zenangst/InputSources.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/Intercom.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/KeyCodes.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/LaunchArguments.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/MachPort.git", .branch("main")),
-        .package(url: "https://github.com/zenangst/Windows.git", .branch("main")),
-      ]
-    }
-    return packages
-  }
-}
-
-public struct EnvHelper: Sendable {
-  private let dictionary: [String: String]
-
-  public subscript(key: String) -> SettingValue { SettingValue(stringLiteral: dictionary[key]!) }
-
-  public init(_ path: String) {
-    let fileManager = FileManager.default
-    guard fileManager.fileExists(atPath: path) else { fatalError("🌈 \(path) does not exist") }
-    guard let data = fileManager.contents(atPath: path) else { fatalError("🌈 .env files is missing at path: \(path)") }
-    guard let contents = String(data: data, encoding: .utf8) else { fatalError("🌈 Unable to read data at path: \(path)") }
-
-    var env = [String: String]()
-    let lines = contents
-      .components(separatedBy: .newlines)
-      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      .filter { !$0.isEmpty }
-      .filter { $0.first != "#" }
-      .filter { $0.contains("=") }
-
-    lines.forEach { line in
-      let components = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
-      if components.count == 2 {
-        let name = String(components[0])
-        let value = String(components[1])
-        env[name] = value
-      }
-    }
-
-    self.dictionary = env
-  }
-}
-
-public final class Shell: Sendable {
-  private let path: String
-
-  public init(path: String) {
-    self.path = path
-  }
-
-  public func run(_ command: String) throws -> String {
-    let standardOutput = Pipe()
-    let standardError = Pipe()
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-    process.currentDirectoryURL = URL(filePath: path)
-    process.arguments = ["-c", command]
-    process.standardOutput = standardOutput
-    process.standardError = standardError
-
-    try process.run()
-    let output: String
-    if let data = try standardOutput.fileHandleForReading.readToEnd() {
-      output = String(data: data, encoding: .utf8)!
-    } else if let data = try standardError.fileHandleForReading.readToEnd() {
-      output = String(data: data, encoding: .utf8)!
-    } else {
-      output = ""
-    }
-
-    process.waitUntilExit()
-
-    return output
-  }
-}

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.0
+import PackageDescription
+import ProjectDescriptionHelpers
+
+#if TUIST
+import struct ProjectDescription.PackageSettings
+
+let packageSettings = PackageSettings(
+  // Customize the product types for specific package product
+  // Default is .staticFramework
+  // productTypes: ["Alamofire": .framework,]
+  productTypes: [:]
+)
+#endif
+
+let package = Package(
+  name: "Keyboard Cowboy",
+  dependencies: [
+    .package(url: "https://github.com/zenangst/AXEssibility.git", branch: "main"),
+    .package(url: "https://github.com/zenangst/Bonzai.git", branch: "main"),
+    .package(url: "https://github.com/zenangst/MachPort.git", branch: "main"),
+    .package(url: "https://github.com/zenangst/Windows.git", branch: "main"),
+    .package(url: "https://github.com/krzysztofzablocki/Inject", branch: "main"),
+  ]
+)

--- a/Tuist/ProjectDescriptionHelpers/EnvHelper.swift
+++ b/Tuist/ProjectDescriptionHelpers/EnvHelper.swift
@@ -1,0 +1,34 @@
+import Foundation
+import ProjectDescription
+
+public struct EnvHelper: Sendable {
+  private let dictionary: [String: String]
+
+  public subscript(key: String) -> SettingValue { SettingValue(stringLiteral: dictionary[key]!) }
+
+  public init(_ path: String) {
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: path) else { fatalError("🌈 \(path) does not exist") }
+    guard let data = fileManager.contents(atPath: path) else { fatalError("🌈 .env files is missing at path: \(path)") }
+    guard let contents = String(data: data, encoding: .utf8) else { fatalError("🌈 Unable to read data at path: \(path)") }
+
+    var env = [String: String]()
+    let lines = contents
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+      .filter { $0.first != "#" }
+      .filter { $0.contains("=") }
+
+    lines.forEach { line in
+      let components = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
+      if components.count == 2 {
+        let name = String(components[0])
+        let value = String(components[1])
+        env[name] = value
+      }
+    }
+
+    self.dictionary = env
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/PackageResolver.swift
+++ b/Tuist/ProjectDescriptionHelpers/PackageResolver.swift
@@ -1,0 +1,41 @@
+import ProjectDescription
+
+public enum PackageResolver {
+  public static func packages(_ env: EnvHelper) -> [Package] {
+    let packages: [Package]
+    if env["PACKAGE_DEVELOPMENT"] == "true" {
+      packages = [
+        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.2"),
+        .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
+        .package(path: "../AXEssibility"),
+        .package(path: "../Apps"),
+        .package(path: "../Bonzai"),
+        .package(path: "../Dock"),
+        .package(path: "../DynamicNotchKit"),
+        .package(path: "../InputSources"),
+        .package(path: "../Intercom"),
+        .package(path: "../KeyCodes"),
+        .package(path: "../LaunchArguments"),
+        .package(path: "../MachPort"),
+        .package(path: "../Windows"),
+      ]
+    } else {
+      packages = [
+        .package(url: "https://github.com/krzysztofzablocki/Inject.git", from: "1.5.2"),
+        .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.4.1"),
+        .package(url: "https://github.com/zenangst/AXEssibility.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/Apps.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/Bonzai.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/Dock.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/DynamicNotchKit", .branch("main")),
+        .package(url: "https://github.com/zenangst/InputSources.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/Intercom.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/KeyCodes.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/LaunchArguments.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/MachPort.git", .branch("main")),
+        .package(url: "https://github.com/zenangst/Windows.git", .branch("main")),
+      ]
+    }
+    return packages
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Router.swift
+++ b/Tuist/ProjectDescriptionHelpers/Router.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct Router {
+  public static let sourceRoot = URL(fileURLWithPath: String(#filePath))
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .absoluteString
+    .replacingOccurrences(of: "file://", with: "")
+  public static let assetPath = sourceRoot.appending("Assets")
+  public static let envPath = sourceRoot.appending(".env")
+}

--- a/Tuist/ProjectDescriptionHelpers/Scheme+AssetGenerator.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+AssetGenerator.swift
@@ -1,0 +1,22 @@
+import ProjectDescription
+
+public extension Scheme {
+  static func assetGenerator(_ assetGeneratorTarget: Target) -> Scheme {
+    Scheme.scheme(
+      name: "AssetGenerator",
+      shared: true,
+      hidden: false,
+      testAction: .targets(
+        [.testableTarget(target: .target(assetGeneratorTarget.name))],
+        arguments: .arguments(
+          environmentVariables: [
+            "ASSET_PATH": .environmentVariable(value: Router.assetPath, isEnabled: true),
+            "SOURCE_ROOT": .environmentVariable(value: Router.sourceRoot, isEnabled: true),
+          ],
+          launchArguments: [
+            .launchArgument(name: "-running-unit-tests", isEnabled: true)
+          ])
+      )
+    )
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Scheme+MainApp.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+MainApp.swift
@@ -1,0 +1,44 @@
+import ProjectDescription
+
+public extension Scheme {
+  static func mainApp(_ mainAppTarget: Target, unitTestTarget: Target) -> Scheme {
+    Scheme.scheme(
+      name: mainAppTarget.name,
+      shared: true,
+      hidden: false,
+      buildAction: .buildAction(targets: [.target(mainAppTarget.name)]),
+      testAction: .targets(
+        [.testableTarget(target: .target(unitTestTarget.name))],
+        arguments: .arguments(
+          environmentVariables: [
+            "ASSET_PATH": .environmentVariable(value: Router.assetPath, isEnabled: true),
+            "SOURCE_ROOT": .environmentVariable(value: Router.sourceRoot, isEnabled: true),
+          ],
+          launchArguments: [
+            .launchArgument(name: "-running-unit-tests", isEnabled: true)
+          ])
+        ,
+        options: .options(
+          coverage: true,
+          codeCoverageTargets: [.target(mainAppTarget.name)]
+        )
+      ),
+      runAction: .runAction(
+        executable: .target(mainAppTarget.name),
+        arguments: .arguments(
+          environmentVariables: [
+            "APP_ENVIRONMENT_OVERRIDE": .environmentVariable(value: "development", isEnabled: true),
+            "SOURCE_ROOT": .environmentVariable(value: Router.sourceRoot, isEnabled: true),
+          ],
+          launchArguments: [
+            .launchArgument(name: "-benchmark", isEnabled: false),
+            .launchArgument(name: "-debugEditing", isEnabled: false),
+            .launchArgument(name: "-injection", isEnabled: false),
+            .launchArgument(name: "-disableMachPorts", isEnabled: false),
+            .launchArgument(name: "-openWindowAtLaunch", isEnabled: true)
+          ]
+        )
+      )
+    )
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Shell.swift
+++ b/Tuist/ProjectDescriptionHelpers/Shell.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public final class Shell: Sendable {
+  private let path: String
+
+  public init(path: String) {
+    self.path = path
+  }
+
+  public func run(_ command: String) throws -> String {
+    let standardOutput = Pipe()
+    let standardError = Pipe()
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+    process.currentDirectoryURL = URL(filePath: path)
+    process.arguments = ["-c", command]
+    process.standardOutput = standardOutput
+    process.standardError = standardError
+
+    try process.run()
+    let output: String
+    if let data = try standardOutput.fileHandleForReading.readToEnd() {
+      output = String(data: data, encoding: .utf8)!
+    } else if let data = try standardError.fileHandleForReading.readToEnd() {
+      output = String(data: data, encoding: .utf8)!
+    } else {
+      output = ""
+    }
+
+    process.waitUntilExit()
+
+    return output
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Target+AssetGenerator.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+AssetGenerator.swift
@@ -1,0 +1,27 @@
+import ProjectDescription
+
+public extension Target {
+  static func assetGenerator(_ bundleId: String, env: EnvHelper) -> Target {
+    Target.target(
+      name: "AssetGenerator",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: bundleId.appending(".asset-generator"),
+      deploymentTargets: .macOS("13.0"),
+      infoPlist: .file(path: .relativeToRoot("AssetGenerator/Info.plist")),
+      sources: SourceFilesList(arrayLiteral: sources("AssetGenerator")),
+      dependencies: [
+        .target(name: "Keyboard-Cowboy")
+      ],
+      settings:
+        Settings.settings(base: [
+          "BUNDLE_LOADER": "$(TEST_HOST)",
+          "CODE_SIGN_IDENTITY": "Apple Development",
+          "CODE_SIGN_STYLE": "-",
+          "DEVELOPMENT_TEAM": env["TEAM_ID"],
+          "PRODUCT_BUNDLE_IDENTIFIER": "\(bundleId).AssetGenerator",
+          "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/Keyboard Cowboy.app/Contents/MacOS/Keyboard Cowboy",
+        ])
+    )
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Target+MainApp.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+MainApp.swift
@@ -1,0 +1,56 @@
+import ProjectDescription
+
+
+extension Target {
+  public static func mainApp(_ bundleId: String, shell: Shell, env: EnvHelper) -> Target {
+    let buildNumber = ((try? shell.run("git rev-list --count HEAD")) ?? "x.x.x").trimmingCharacters(in: .whitespacesAndNewlines)
+    let target = Target.target(
+      name: "Keyboard-Cowboy",
+      destinations: .macOS,
+      product: .app,
+      bundleId: "com.zenangst.Keyboard-Cowboy",
+      deploymentTargets: .macOS("13.0"),
+      infoPlist: .file(path: .relativeToRoot("App/Info.plist")),
+      sources: SourceFilesList(arrayLiteral: sources("App"), xpcSources()),
+      resources: resources("App"),
+      entitlements: "App/Entitlements/com.zenangst.Keyboard-Cowboy.entitlements",
+      dependencies: [
+        .package(product: "AXEssibility"),
+        .package(product: "Apps"),
+        .package(product: "Bonzai"),
+        .package(product: "Dock"),
+        .package(product: "DynamicNotchKit"),
+        .package(product: "Inject"),
+        .package(product: "InputSources"),
+        .package(product: "Intercom"),
+        .package(product: "KeyCodes"),
+        .package(product: "LaunchArguments"),
+        .package(product: "MachPort"),
+        .package(product: "Sparkle"),
+        .package(product: "Windows"),
+        //    .target(name: "LassoService")
+      ],
+      settings:
+        Settings.settings(
+          base: [
+            "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
+            "CODE_SIGN_IDENTITY": "Apple Development",
+            "CODE_SIGN_STYLE": "Automatic",
+            "CURRENT_PROJECT_VERSION": SettingValue(stringLiteral: buildNumber),
+            "DEVELOPMENT_TEAM": env["TEAM_ID"],
+            "ENABLE_HARDENED_RUNTIME": true,
+            "MARKETING_VERSION": "3.28.0",
+            "PRODUCT_NAME": "Keyboard Cowboy",
+            "SWIFT_STRICT_CONCURRENCY": "complete",
+            "SWIFT_VERSION": "6.0",
+          ],
+          configurations: [
+            .debug(name: "Debug", xcconfig: "\(xcconfig("Debug"))"),
+            .release(name: "Release", xcconfig: "\(xcconfig("Release"))")
+          ],
+          defaultSettings: .recommended)
+    )
+
+    return target
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Target+Paths.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Paths.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+public extension Target {
+  static func xcconfig(_ targetName: String) -> String { "Configurations/\(targetName).xcconfig" }
+
+  internal static func sources(_ folder: String) -> SourceFileGlob { "\(folder)/Sources/**" }
+  internal static func resources(_ folder: String) -> ResourceFileElements { "\(folder)/Resources/**" }
+  internal static func xpcSources() -> SourceFileGlob { "XPC/Sources/**" }
+}

--- a/Tuist/ProjectDescriptionHelpers/Target+UnitTest.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+UnitTest.swift
@@ -1,0 +1,28 @@
+import ProjectDescription
+
+public extension Target {
+  static func unitTest(_ bundleId: String, env: EnvHelper) -> Target {
+    Target.target(
+      name: "UnitTests",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: bundleId.appending(".unit-tests"),
+      deploymentTargets: .macOS("13.0"),
+      infoPlist: .file(path: .relativeToRoot("UnitTests/Info.plist")),
+      sources: SourceFilesList(arrayLiteral: sources("UnitTests")),
+      dependencies: [
+        .target(name: "Keyboard-Cowboy")
+      ],
+      settings:
+        Settings.settings(base: [
+          "BUNDLE_LOADER": "$(TEST_HOST)",
+          "CODE_SIGN_IDENTITY": "Apple Development",
+          "CODE_SIGN_STYLE": "-",
+          "DEVELOPMENT_TEAM": env["TEAM_ID"],
+          "PRODUCT_BUNDLE_IDENTIFIER": "\(bundleId).UnitTests",
+          "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/Keyboard Cowboy.app/Contents/MacOS/Keyboard Cowboy",
+        ])
+    )
+
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Target+XPCTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+XPCTarget.swift
@@ -1,0 +1,31 @@
+import ProjectDescription
+
+public extension Target {
+  static func xpcTarget(_ env: EnvHelper) -> Target {
+    Target.target(
+      name: "LassoService",
+      destinations: .macOS,
+      product: .xpc,
+      bundleId: "com.zenangst.Keyboard-Cowboy.LassoService",
+      deploymentTargets: .macOS("13.0"),
+      infoPlist: .file(path: .relativeToRoot("LassoService/Info.plist")),
+      sources: SourceFilesList(arrayLiteral: sources("LassoService"), xpcSources()),
+      entitlements: "LassoService/Entitlements/com.zenangst.Keyboard-Cowboy.LassoService.entitlements",
+      dependencies: [
+        .package(product: "Apps"),
+        .package(product: "KeyCodes"),
+        .package(product: "InputSources"),
+        .package(product: "MachPort"),
+      ],
+      settings: Settings.settings(base: [
+        "CODE_SIGN_IDENTITY": "Apple Development",
+        "CODE_SIGN_STYLE": "Automatic",
+        "DEVELOPMENT_TEAM": env["TEAM_ID"],
+        "ENABLE_HARDENED_RUNTIME": true,
+        "PRODUCT_NAME": "LassoService",
+        "SWIFT_STRICT_CONCURRENCY": "complete",
+        "SWIFT_VERSION": "6.0",
+      ])
+    )
+  }
+}

--- a/Tuist/Tuist.swift
+++ b/Tuist/Tuist.swift
@@ -1,8 +1,0 @@
-import ProjectDescription
-
-let config = Config(
-    swiftVersion: "5.6.1",
-    plugins: [
-        .local(path: .relativeToManifest("../../Plugins/Tuist")),
-    ]
-)


### PR DESCRIPTION
Split Project.swift into extensions to make it easier to create multiple targets in the future.

Will make a dedicated development target for the app and a production target for the app,
which will make it easier to test new features without affecting the production app.
Also, you could have both installed on the same machine, which is useful for testing.