### PR TITLE
Add support for a new development target using tuist

### DIFF
--- a/App/Entitlements/com.zenangst.Keyboard-Cowboy.development.entitlements
+++ b/App/Entitlements/com.zenangst.Keyboard-Cowboy.development.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/App/Sources/UI/Views/Onboarding/PermissionsView.swift
+++ b/App/Sources/UI/Views/Onboarding/PermissionsView.swift
@@ -16,7 +16,7 @@ struct PermissionsView: View {
   var body: some View {
     VStack(spacing: 0) {
       HStack(spacing: 16) {
-        KeyboardCowboyAsset.applicationIcon.swiftUIImage
+        Image(.applicationIcon)
           .resizable()
           .frame(width: 84, height: 84)
         Text("Accessibility Permissions are required for Keyboard Cowboy application to function properly.")

--- a/Project.swift
+++ b/Project.swift
@@ -3,14 +3,26 @@ import ProjectDescriptionHelpers
 import Foundation
 
 // MARK: - Project
-let bundleId = "com.zenangst.Keyboard-Cowboy"
 let env = EnvHelper(Router.envPath)
 let shell = Shell(path: Router.sourceRoot)
 
-let assetGeneratorTarget = Target.assetGenerator(bundleId, env: env)
-let mainAppTarget = Target.mainApp(bundleId, shell: shell, env: env)
-let unitTestTarget = Target.unitTest(bundleId, env: env)
-let xpcTarget = Target.xpcTarget(env)
+let production = ApplicationProperties(
+  name: "Keyboard-Cowboy",
+  bundleIdentifier: "com.zenangst.Keyboard-Cowboy",
+  hardendRuntime: true
+)
+
+let development = ApplicationProperties(
+  name: "Keyboard-Cowboy-Development",
+  bundleIdentifier: "com.zenangst.Keyboard-Cowboy.development",
+  hardendRuntime: false
+)
+
+let assetGeneratorTarget = Target.assetGenerator(production.bundleIdentifier, env: env)
+let mainAppTarget = Target.app(production, shell: shell, env: env)
+let developmentAppTarget = Target.app(development, shell: shell, env: env)
+let unitTestTarget = Target.unitTest(production.bundleIdentifier, env: env)
+let xpcTarget = Target.xpc(env)
 
 let project = Project(
   name: "Keyboard Cowboy",
@@ -24,12 +36,14 @@ let project = Project(
   ], defaultSettings: .recommended),
   targets: [
     mainAppTarget,
+    developmentAppTarget,
     unitTestTarget,
     assetGeneratorTarget,
     xpcTarget,
   ],
   schemes: [
-    Scheme.mainApp(mainAppTarget, unitTestTarget: unitTestTarget),
+    Scheme.app(.production, appTarget: mainAppTarget, unitTestTarget: unitTestTarget),
+    Scheme.app(.development, appTarget: developmentAppTarget, unitTestTarget: unitTestTarget),
     Scheme.assetGenerator(assetGeneratorTarget)
   ],
   additionalFiles: [

--- a/Tuist/ProjectDescriptionHelpers/Scheme+MainApp.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+MainApp.swift
@@ -1,12 +1,46 @@
 import ProjectDescription
 
 public extension Scheme {
-  static func mainApp(_ mainAppTarget: Target, unitTestTarget: Target) -> Scheme {
+  enum Kind {
+    case production
+    case development
+
+    var appEnvironmentOverride: Bool {
+      switch self {
+      case .production: false
+      case .development: true
+      }
+    }
+
+    var disableMachPorts: Bool {
+      switch self {
+      case .production: false
+      case .development: true
+      }
+    }
+
+    var injection: Bool {
+      switch self {
+      case .production: false
+      case .development: true
+      }
+    }
+
+    var openWindowAtLaunch: Bool {
+      switch self {
+      case .production: false
+      case .development: true
+      }
+    }
+
+  }
+
+  static func app(_ kind: Kind, appTarget: Target, unitTestTarget: Target) -> Scheme {
     Scheme.scheme(
-      name: mainAppTarget.name,
+      name: appTarget.name,
       shared: true,
       hidden: false,
-      buildAction: .buildAction(targets: [.target(mainAppTarget.name)]),
+      buildAction: .buildAction(targets: [.target(appTarget.name)]),
       testAction: .targets(
         [.testableTarget(target: .target(unitTestTarget.name))],
         arguments: .arguments(
@@ -20,22 +54,22 @@ public extension Scheme {
         ,
         options: .options(
           coverage: true,
-          codeCoverageTargets: [.target(mainAppTarget.name)]
+          codeCoverageTargets: [.target(appTarget.name)]
         )
       ),
       runAction: .runAction(
-        executable: .target(mainAppTarget.name),
+        executable: .target(appTarget.name),
         arguments: .arguments(
           environmentVariables: [
-            "APP_ENVIRONMENT_OVERRIDE": .environmentVariable(value: "development", isEnabled: true),
+            "APP_ENVIRONMENT_OVERRIDE": .environmentVariable(value: "development", isEnabled: kind.appEnvironmentOverride),
             "SOURCE_ROOT": .environmentVariable(value: Router.sourceRoot, isEnabled: true),
           ],
           launchArguments: [
             .launchArgument(name: "-benchmark", isEnabled: false),
             .launchArgument(name: "-debugEditing", isEnabled: false),
-            .launchArgument(name: "-injection", isEnabled: false),
-            .launchArgument(name: "-disableMachPorts", isEnabled: false),
-            .launchArgument(name: "-openWindowAtLaunch", isEnabled: true)
+            .launchArgument(name: "-injection", isEnabled: kind.injection),
+            .launchArgument(name: "-disableMachPorts", isEnabled: kind.disableMachPorts),
+            .launchArgument(name: "-openWindowAtLaunch", isEnabled: kind.openWindowAtLaunch)
           ]
         )
       )

--- a/Tuist/ProjectDescriptionHelpers/Target+MainApp.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+MainApp.swift
@@ -1,19 +1,30 @@
 import ProjectDescription
 
+public struct ApplicationProperties: Sendable {
+  public let name: String
+  public let bundleIdentifier: String
+  public let hardendRuntime: SettingValue
+
+  public init(name: String, bundleIdentifier: String, hardendRuntime: SettingValue) {
+    self.name = name
+    self.bundleIdentifier = bundleIdentifier
+    self.hardendRuntime = hardendRuntime
+  }
+}
 
 extension Target {
-  public static func mainApp(_ bundleId: String, shell: Shell, env: EnvHelper) -> Target {
+  public static func app(_ properties: ApplicationProperties, shell: Shell, env: EnvHelper) -> Target {
     let buildNumber = ((try? shell.run("git rev-list --count HEAD")) ?? "x.x.x").trimmingCharacters(in: .whitespacesAndNewlines)
     let target = Target.target(
-      name: "Keyboard-Cowboy",
+      name: properties.name,
       destinations: .macOS,
       product: .app,
-      bundleId: "com.zenangst.Keyboard-Cowboy",
+      bundleId: properties.bundleIdentifier,
       deploymentTargets: .macOS("13.0"),
       infoPlist: .file(path: .relativeToRoot("App/Info.plist")),
       sources: SourceFilesList(arrayLiteral: sources("App"), xpcSources()),
       resources: resources("App"),
-      entitlements: "App/Entitlements/com.zenangst.Keyboard-Cowboy.entitlements",
+      entitlements: "App/Entitlements/\(properties.bundleIdentifier).entitlements",
       dependencies: [
         .package(product: "AXEssibility"),
         .package(product: "Apps"),
@@ -38,7 +49,7 @@ extension Target {
             "CODE_SIGN_STYLE": "Automatic",
             "CURRENT_PROJECT_VERSION": SettingValue(stringLiteral: buildNumber),
             "DEVELOPMENT_TEAM": env["TEAM_ID"],
-            "ENABLE_HARDENED_RUNTIME": true,
+            "ENABLE_HARDENED_RUNTIME": properties.hardendRuntime,
             "MARKETING_VERSION": "3.28.0",
             "PRODUCT_NAME": "Keyboard Cowboy",
             "SWIFT_STRICT_CONCURRENCY": "complete",

--- a/Tuist/ProjectDescriptionHelpers/Target+XPCTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+XPCTarget.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 public extension Target {
-  static func xpcTarget(_ env: EnvHelper) -> Target {
+  static func xpc(_ env: EnvHelper) -> Target {
     Target.target(
       name: "LassoService",
       destinations: .macOS,


### PR DESCRIPTION
Generate a development application target to make it easier to develop
and try out new features using a separate application.
