### PR TITLE
Improve window focus reliability when using macOS Spaces

### DIFF
--- a/App/Sources/Core/Runners/WindowFocus/WindowCommandFocusRunner.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowCommandFocusRunner.swift
@@ -15,6 +15,7 @@ final class WindowCommandFocusRunner {
   private let quarterFocus: WindowFocusQuarter
   private let workspace: WorkspaceProviding
 
+  private var activeSpaceDidChangeSubscription: AnyCancellable?
   private var flagsChangedSubscription: AnyCancellable?
   private var frontmostIndex: Int = 0
 
@@ -28,6 +29,13 @@ final class WindowCommandFocusRunner {
     self.relativeFocus = relativeFocus
     self.quarterFocus = quarterFocus
     self.workspace = workspace
+
+    activeSpaceDidChangeSubscription = NSWorkspace.shared
+      .notificationCenter
+      .publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
+      .sink { [weak self] _ in
+        self?.resetFocusComponents()
+      }
   }
 
   func resetFocusComponents() {
@@ -41,23 +49,31 @@ final class WindowCommandFocusRunner {
     case .moveFocusToNextWindowUpwards:
       try await relativeFocus.run(.up, snapshot: snapshot)
       quarterFocus.reset()
+      centerFocus.reset()
     case .moveFocusToNextWindowDownwards:
       try await relativeFocus.run(.down, snapshot: snapshot)
       quarterFocus.reset()
+      centerFocus.reset()
     case .moveFocusToNextWindowOnLeft:
       try await relativeFocus.run(.left, snapshot: snapshot)
       quarterFocus.reset()
+      centerFocus.reset()
     case .moveFocusToNextWindowOnRight:
       try await relativeFocus.run(.right, snapshot: snapshot)
       quarterFocus.reset()
+      centerFocus.reset()
     case .moveFocusToNextWindowUpperLeftQuarter:
       try quarterFocus.run(.upperLeft, snapshot: snapshot)
+      centerFocus.reset()
     case .moveFocusToNextWindowUpperRightQuarter:
       try quarterFocus.run(.upperRight, snapshot: snapshot)
+      centerFocus.reset()
     case .moveFocusToNextWindowLowerLeftQuarter:
       try quarterFocus.run(.lowerLeft, snapshot: snapshot)
+      centerFocus.reset()
     case .moveFocusToNextWindowLowerRightQuarter:
       try quarterFocus.run(.lowerRight, snapshot: snapshot)
+      centerFocus.reset()
     case .moveFocusToNextWindowCenter:
       try await centerFocus.run(snapshot: snapshot)
     case .moveFocusToNextWindow, .moveFocusToPreviousWindow,
@@ -69,6 +85,7 @@ final class WindowCommandFocusRunner {
         applicationStore: applicationStore,
         workspace: workspace,
       )
+      centerFocus.reset()
     }
   }
 }

--- a/App/Sources/Core/Runners/WindowFocus/WindowFocusCenter.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocusCenter.swift
@@ -93,6 +93,10 @@ final class WindowFocusCenter: @unchecked Sendable {
       consumedWindows.removeAll()
     }
 
+    validQuarterWindows = validQuarterWindows.filter {
+      NSRunningApplication(processIdentifier: pid_t($0.ownerPid.rawValue))?.isHidden == false
+    }
+
     FocusBorder.shared.dismiss()
     guard let matchedWindow = validQuarterWindows.first(where: quarterFilter) ?? activeWindow else {
       return

--- a/App/Sources/Core/Runners/WindowFocus/WindowFocusQuarter.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocusQuarter.swift
@@ -97,7 +97,12 @@ final class WindowFocusQuarter: @unchecked Sendable {
       consumedWindows.removeAll()
     }
 
-    guard let matchedWindow = validQuarterWindows.first(where: quarterFilter) ?? activeWindow else { return }
+    validQuarterWindows = validQuarterWindows.filter {
+      NSRunningApplication(processIdentifier: pid_t($0.ownerPid.rawValue))?.isHidden == false
+    }
+
+    guard let matchedWindow = validQuarterWindows
+      .first(where: quarterFilter) ?? activeWindow else { return }
 
     FocusBorder.shared.show(matchedWindow.rect.mainDisplayFlipped)
 


### PR DESCRIPTION
- Reset the center focus component when the active space changes
- Improve center focus by checking if the application is hidden or not
- Reset center focus when calling `resetFocusComponents`
