### PR TITLE
fix(window-focus): realign focus ring before cycling

### DIFF
--- a/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
@@ -14,7 +14,7 @@ enum WindowFocus {
   static var appRing = RingBuffer<WindowModel>()
   static var globalRing = RingBuffer<WindowModel>()
   static var stageRing = RingBuffer<WindowModel>()
-  static var skipNextApplicationChange = false
+  static var pendingFocusWindowId: CGWindowID?
   static var currentWindow: WindowModel?
 
   static func frontMostApplicationChanged() {
@@ -46,11 +46,11 @@ enum WindowFocus {
 
     currentWindow = window
 
-    if skipNextApplicationChange {
+    if pendingFocusWindowId == id {
       appRing.setCursor(to: window)
       globalRing.setCursor(to: window)
       stageRing.setCursor(to: window)
-      skipNextApplicationChange = false
+      pendingFocusWindowId = nil
     } else {
       appRing.moveEntryToCursor(window)
       globalRing.moveEntryToCursor(window)
@@ -86,6 +86,8 @@ enum WindowFocus {
     }
 
     guard !newCollection.isEmpty else { return }
+    syncCursor(with: newCollection, in: ring)
+
     guard let nextWindow = ring.navigate(direction, entries: newCollection) else {
       return
     }
@@ -94,6 +96,9 @@ enum WindowFocus {
     let processIdentifier = pid_t(nextWindow.ownerPid.rawValue)
     let runningApplication = NSRunningApplication(processIdentifier: processIdentifier)
     let app = AppAccessibilityElement(processIdentifier)
+    let axWindow = try app.windows().first(where: { $0.id == windowId })
+
+    pendingFocusWindowId = windowId
 
     if let runningApplication {
       let options: NSApplication.ActivationOptions = [.activateIgnoringOtherApps]
@@ -111,10 +116,40 @@ enum WindowFocus {
       }
     }
 
-    let axWindow = try app.windows().first(where: { $0.id == windowId })
+    axWindow?.main = true
     axWindow?.performAction(.raise)
+  }
 
-    skipNextApplicationChange = true
+  private static func syncCursor(with windows: [WindowModel], in ring: RingBuffer<WindowModel>) {
+    ring.update(windows)
+
+    guard let focusedWindow = focusedWindow(in: windows) else { return }
+
+    ring.setCursor(to: focusedWindow)
+  }
+
+  private static func focusedWindow(in windows: [WindowModel]) -> WindowModel? {
+    if let frontmostApplication = NSWorkspace.shared.frontmostApplication {
+      let app = AppAccessibilityElement(frontmostApplication.processIdentifier)
+
+      if let id = try? app.focusedWindow()?.id,
+         let window = windows.first(where: { $0.id == id }) {
+        return window
+      }
+
+      if let currentWindow,
+         let window = windows.first(where: { $0.id == currentWindow.id }) {
+        return window
+      }
+
+      return windows.first(where: { $0.ownerPid.rawValue == frontmostApplication.processIdentifier })
+    }
+
+    if let currentWindow {
+      return windows.first(where: { $0.id == currentWindow.id })
+    }
+
+    return nil
   }
 }
 

--- a/Packages/RingBuffer/Sources/RingBuffer/RingBuffer.swift
+++ b/Packages/RingBuffer/Sources/RingBuffer/RingBuffer.swift
@@ -70,14 +70,16 @@ public final class RingBuffer<T: Identifiable & Hashable> {
   }
 
   public func setCursor(to entry: T) {
-    if let match = currentEntries.firstIndex(of: entry) {
+    if let match = currentEntries.firstIndex(where: { $0.id == entry.id }) {
       cursor = match
     }
   }
 
   public func moveEntryToCursor(_ entry: T) {
     currentEntries.removeAll { $0.id == entry.id }
-    currentEntries.insert(entry, at: max(cursor, currentEntries.count - 1))
+    let insertIndex = min(cursor, currentEntries.count)
+    currentEntries.insert(entry, at: insertIndex)
+    cursor = insertIndex
   }
 
   public func navigate(_ direction: RingBufferDirection, entries: [T]) -> T? {

--- a/Packages/RingBuffer/Tests/RingBufferTests/RingBufferTests.swift
+++ b/Packages/RingBuffer/Tests/RingBufferTests/RingBufferTests.swift
@@ -131,6 +131,28 @@ struct RingBufferTests {
     #expect(ring.cursor == 1)
     #expect(ring.currentEntries == windows)
   }
+
+  @Test func movingFocusedWindowToCursorDoesNotRepeatItOnNextNavigation() {
+    let windows = [Window("A"), Window("B"), Window("C")]
+    let ring = RingBuffer<Window>(cursor: 0)
+
+    ring.update(windows)
+    ring.moveEntryToCursor(Window("B"))
+
+    #expect(ring.cursor == 0)
+    #expect(ring.currentEntries == [Window("B"), Window("A"), Window("C")])
+    #expect(ring.navigate(.right, entries: windows) == Window("A"))
+  }
+
+  @Test func setCursorMatchesEntriesByIdentifier() {
+    let windows = [VersionedWindow(id: "A", version: 1), VersionedWindow(id: "B", version: 1)]
+    let ring = RingBuffer<VersionedWindow>()
+
+    ring.update(windows)
+    ring.setCursor(to: VersionedWindow(id: "B", version: 2))
+
+    #expect(ring.cursor == 1)
+  }
 }
 
 struct Window: Identifiable, Hashable {
@@ -139,4 +161,9 @@ struct Window: Identifiable, Hashable {
   init(_ id: String) {
     self.id = id
   }
+}
+
+private struct VersionedWindow: Identifiable, Hashable {
+  let id: String
+  let version: Int
 }


### PR DESCRIPTION
Re-sync the window ring with the currently focused AX window before advancing, so next/previous doesn’t get stuck returning the already-focused window.

Also replace the coarse skip flag with a pending window id and make ring cursor updates use window identity, which improves stability when focus events arrive out of order.
