### PR TITLE
fix(main-window): rehydrate selection on reopen

### DIFF
--- a/App/Sources/Core/AppDelegate.swift
+++ b/App/Sources/Core/AppDelegate.swift
@@ -24,8 +24,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 //    }
   }
 
-  func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows: Bool) -> Bool {
-    if !hasVisibleWindows {
+  func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+    if KeyboardCowboyApp.mainWindow?.isVisible != true {
       openWindow?.openMainWindow()
     }
     return true

--- a/App/Sources/Core/Core.swift
+++ b/App/Sources/Core/Core.swift
@@ -173,5 +173,34 @@ final class Core {
     },
   )
 
+  func rehydrateMainWindowSelection() {
+    guard contentStore.state == .initialized else { return }
+
+    let configurationId = configSelection.lastSelection
+      ?? configSelection.selections.first
+      ?? configurationStore.selectedConfiguration.id
+
+    if !configurationId.isEmpty {
+      let action = SidebarView.Action.selectConfiguration(configurationId)
+      configCoordinator.handle(action)
+      sidebarCoordinator.handle(action)
+      groupCoordinator.handle(action)
+      workflowCoordinator.handle(action)
+      return
+    }
+
+    let groupIds = groupSelection.selections.isEmpty
+      ? Set(groupStore.groups.prefix(1).map(\.id))
+      : groupSelection.selections
+
+    guard !groupIds.isEmpty else { return }
+
+    let action = SidebarView.Action.selectGroups(groupIds)
+    configCoordinator.handle(action)
+    sidebarCoordinator.handle(action)
+    groupCoordinator.handle(action)
+    workflowCoordinator.handle(action)
+  }
+
   init() {}
 }

--- a/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
+++ b/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
@@ -48,7 +48,6 @@ extension KeyboardCowboyApp {
       app.setActivationPolicy(.regular)
     }
     app.activate(ignoringOtherApps: true)
-    NSWorkspace.shared.open(Bundle.main.bundleURL)
   }
 
   static func deactivate() {

--- a/App/Sources/Core/Runners/Open/OpenCommandRunner.swift
+++ b/App/Sources/Core/Runners/Open/OpenCommandRunner.swift
@@ -26,6 +26,13 @@ final class OpenCommandRunner: Sendable {
   }
 
   func run(_ path: String, checkCancellation: Bool, application: Application?) async throws {
+    if resolvesToKeyboardCowboy(path, application: application) {
+      await MainActor.run {
+        NotificationCenter.default.post(name: .openKeyboardCowboy, object: nil)
+      }
+      return
+    }
+
     do {
       if plugins.finderFolder.validate(application?.bundleIdentifier) {
         try await plugins.finderFolder.execute(path, checkCancellation: checkCancellation)
@@ -56,6 +63,27 @@ final class OpenCommandRunner: Sendable {
         try await plugins.open.execute(path, application: application)
       }
     }
+  }
+
+  private func resolvesToKeyboardCowboy(_ path: String, application: Application?) -> Bool {
+    if application?.bundleIdentifier == KeyboardCowboyApp.bundleIdentifier {
+      return true
+    }
+
+    guard !path.isUrl else { return false }
+
+    let expandedPath = (path as NSString).expandingTildeInPath
+    let resolvedPath = URL(fileURLWithPath: expandedPath)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+
+    let bundlePath = Bundle.main.bundleURL
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+
+    return resolvedPath == bundlePath
   }
 }
 

--- a/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
+++ b/App/Sources/UI/Coordinators/ConfigurationCoordinator.swift
@@ -75,6 +75,8 @@ final class ConfigurationCoordinator {
       if let firstConfiguration = contentStore.configurationStore.configurations.first {
         contentStore.use(firstConfiguration)
         render(selectedConfiguration: firstConfiguration)
+      } else {
+        selectionManager.publish([])
       }
     case let .userMode(action):
       switch action {
@@ -123,5 +125,11 @@ final class ConfigurationCoordinator {
       }
 
     configurationsPublisher.publish(configurations)
+
+    if let selectedConfiguration {
+      selectionManager.publish([selectedConfiguration.id])
+    } else {
+      selectionManager.publish([])
+    }
   }
 }

--- a/App/Sources/UI/Coordinators/GroupCoordinator.swift
+++ b/App/Sources/UI/Coordinators/GroupCoordinator.swift
@@ -30,10 +30,11 @@ final class GroupCoordinator {
 
   func handle(_ action: SidebarView.Action) {
     switch action {
-    case .refresh, .openScene, .addConfiguration, .updateConfiguration,
-         .moveGroups, .removeGroups, .deleteConfiguration, .userMode:
+    case .openScene, .updateConfiguration, .moveGroups, .userMode:
       // NOOP
       break
+    case .refresh, .addConfiguration, .removeGroups, .deleteConfiguration:
+      render(groupSelectionManager.selections, calculateSelections: true)
     case .moveWorkflows, .copyWorkflows:
       render(groupSelectionManager.selections)
     case .selectConfiguration:

--- a/App/Sources/UI/Coordinators/SidebarCoordinator.swift
+++ b/App/Sources/UI/Coordinators/SidebarCoordinator.swift
@@ -57,30 +57,12 @@ final class SidebarCoordinator {
       break
     case .refresh:
       render(store.groups)
-    case let .selectConfiguration(id):
-      if let firstGroup = store.groups.first(where: { $0.id == id }) {
-        selectionManager.publish([firstGroup.id])
-        ColorPublisher.shared.publish(Color(hex: firstGroup.color))
-      } else {
-        selectionManager.publish([])
-      }
+    case .selectConfiguration:
       render(store.groups)
     case .deleteConfiguration:
-      if let firstGroup = store.groups.first {
-        selectionManager.publish([firstGroup.id])
-        ColorPublisher.shared.publish(Color(hex: firstGroup.color))
-      } else {
-        selectionManager.publish([])
-      }
       render(store.groups)
     case let .selectGroups(ids):
-      if ids.count == 1, let id = ids.first, let group = store.group(withId: id) {
-        let nsColor = NSColor(hex: group.color).blended(withFraction: 0.4, of: .black)!
-        ColorPublisher.shared.publish(Color(nsColor: nsColor))
-        selectionManager.publish([id])
-      } else {
-        ColorPublisher.shared.publish(.accentColor)
-      }
+      synchronizeSelection(with: store.groups, preferredSelections: ids)
     case .addConfiguration:
       render(store.groups)
     case let .removeGroups(ids):
@@ -127,10 +109,6 @@ final class SidebarCoordinator {
   // MARK: Private methods
 
   func initialLoad(_ groups: [WorkflowGroup]) {
-    if let match = groups.first(where: { $0.id == selectionManager.lastSelection }) {
-      ColorPublisher.shared.publish(Color(hex: match.color))
-    }
-
     render(groups)
     if groups.isEmpty {
       subscription = nil
@@ -151,31 +129,57 @@ final class SidebarCoordinator {
 
     var groups = [GroupViewModel]()
     groups.reserveCapacity(workflowGroups.count)
-    var newSelections: Set<GroupViewModel.ID>?
-    let publisherIsEmpty = publisher.data.isEmpty
 
-    for (offset, workflowGroup) in workflowGroups.enumerated() {
+    for workflowGroup in workflowGroups {
       let group = SidebarMapper.map(workflowGroup, applicationStore: applicationStore)
 
       groups.append(group)
-
-      if publisherIsEmpty {
-        if newSelections == nil || selectionManager.selections.contains(group.id) {
-          newSelections = []
-        }
-
-        if selectionManager.selections.contains(group.id) {
-          newSelections?.insert(group.id)
-        } else if offset == 0 {
-          newSelections?.insert(group.id)
-        }
-      }
-    }
-
-    if groups.isEmpty {
-      newSelections = []
     }
 
     publisher.publish(groups)
+    synchronizeSelection(with: workflowGroups)
+  }
+
+  private func synchronizeSelection(with workflowGroups: [WorkflowGroup], preferredSelections: Set<GroupViewModel.ID>? = nil) {
+    let validIds = Set(workflowGroups.map(\.id))
+    let currentSelections = preferredSelections ?? selectionManager.selections
+    let normalizedSelections = currentSelections.intersection(validIds)
+
+    if workflowGroups.isEmpty {
+      selectionManager.publish([])
+      ColorPublisher.shared.publish(.accentColor)
+      return
+    }
+
+    if !normalizedSelections.isEmpty {
+      selectionManager.publish(normalizedSelections)
+      updateColor(using: workflowGroups, selections: normalizedSelections)
+      return
+    }
+
+    if let lastSelection = selectionManager.lastSelection,
+       validIds.contains(lastSelection) {
+      selectionManager.publish([lastSelection])
+      updateColor(using: workflowGroups, selections: [lastSelection])
+      return
+    }
+
+    guard let firstGroup = workflowGroups.first else { return }
+
+    selectionManager.publish([firstGroup.id])
+    updateColor(using: workflowGroups, selections: [firstGroup.id])
+  }
+
+  private func updateColor(using workflowGroups: [WorkflowGroup], selections: Set<GroupViewModel.ID>) {
+    guard selections.count == 1,
+          let id = selections.first,
+          let group = workflowGroups.first(where: { $0.id == id }),
+          let nsColor = NSColor(hex: group.color).blended(withFraction: 0.4, of: .black)
+    else {
+      ColorPublisher.shared.publish(.accentColor)
+      return
+    }
+
+    ColorPublisher.shared.publish(Color(nsColor: nsColor))
   }
 }

--- a/App/Sources/UI/Coordinators/WorkflowCoordinator.swift
+++ b/App/Sources/UI/Coordinators/WorkflowCoordinator.swift
@@ -53,18 +53,26 @@ final class WorkflowCoordinator {
     case .addConfiguration:
       render(workflowsSelection.selections,
              groupIds: groupSelection.selections)
-    case .refresh, .updateConfiguration, .openScene, .deleteConfiguration, .userMode:
+      clearNestedSelections()
+    case .refresh, .updateConfiguration, .openScene, .userMode:
       // NOOP
       break
     case .moveWorkflows, .copyWorkflows:
       render(workflowsSelection.selections,
-             groupIds: groupSelection.selections)
+              groupIds: groupSelection.selections)
+      clearNestedSelections()
     case .moveGroups, .removeGroups:
       render(workflowsSelection.selections,
              groupIds: groupSelection.selections)
+      clearNestedSelections()
     case .selectConfiguration:
       render(workflowsSelection.selections,
              groupIds: groupSelection.selections)
+      clearNestedSelections()
+    case .deleteConfiguration:
+      render(workflowsSelection.selections,
+             groupIds: groupSelection.selections)
+      clearNestedSelections()
     case let .selectGroups(ids):
       if let firstId = ids.first,
          let group = groupStore.group(withId: firstId) {
@@ -80,11 +88,11 @@ final class WorkflowCoordinator {
           workflowIds.insert(firstId)
         }
         render(workflowIds, groupIds: Set(ids))
-
-        applicationTriggerSelection.removeLastSelection()
-        keyboardShortcutSelection.removeLastSelection()
-        commandSelection.removeLastSelection()
+      } else {
+        render([], groupIds: [])
       }
+
+      clearNestedSelections()
     }
   }
 
@@ -139,9 +147,11 @@ final class WorkflowCoordinator {
     let state: DetailViewState
 
     updateTransaction.groupID = groupIds.first ?? ""
+    updateTransaction.workflowID = ""
 
     if viewModels.count > 1 {
       state = .multiple(viewModels)
+      clearDetailPublishers()
     } else if let viewModel = viewModels.first {
       state = .single(viewModel)
 
@@ -166,6 +176,7 @@ final class WorkflowCoordinator {
       }
     } else {
       state = .empty
+      clearDetailPublishers()
     }
 
     guard statePublisher.data != state else { return }
@@ -177,5 +188,17 @@ final class WorkflowCoordinator {
     } else {
       statePublisher.publish(state)
     }
+  }
+
+  private func clearDetailPublishers() {
+    infoPublisher.publish(.init(id: "empty", name: "", isEnabled: false))
+    triggerPublisher.publish(.empty)
+    commandsPublisher.publish(.init(id: "empty", commands: [], execution: .concurrent))
+  }
+
+  private func clearNestedSelections() {
+    applicationTriggerSelection.publish([])
+    keyboardShortcutSelection.publish([])
+    commandSelection.publish([])
   }
 }

--- a/App/Sources/UI/Views/ContainerView.swift
+++ b/App/Sources/UI/Views/ContainerView.swift
@@ -72,9 +72,12 @@ struct ContainerView: View {
         )
         .onChange(of: contentState, perform: { newValue in
           guard newValue == .initialized else { return }
-          guard let groupId = groupsSelection.lastSelection else { return }
 
-          onAction(.sidebar(.selectGroups([groupId])), undoManager)
+          if let configId = configSelection.lastSelection ?? configSelection.selections.first {
+            onAction(.sidebar(.selectConfiguration(configId)), undoManager)
+          } else if let groupId = groupsSelection.lastSelection ?? groupsSelection.selections.first {
+            onAction(.sidebar(.selectGroups([groupId])), undoManager)
+          }
         })
         .style(.section(.sidebar))
         .navigationSplitViewColumnWidth(ideal: 250)

--- a/App/Sources/UI/Views/GroupDetail/GroupDetailView.swift
+++ b/App/Sources/UI/Views/GroupDetail/GroupDetailView.swift
@@ -312,15 +312,18 @@ struct GroupDetailView: View {
       }
       .focused(appFocus, equals: .workflows)
       .onChange(of: searchTerm, perform: { _ in
-        if !searchTerm.isEmpty {
-          if let firstSelection = publisher.data.filter({ search($0) }).first {
-            workflowSelection.publish([firstSelection.id])
-          } else {
-            workflowSelection.publish([])
-          }
+        let visibleItems = publisher.data.filter { search($0) }
 
-          debounce.process(.init(workflows: workflowSelection.selections))
+        if let lastSelection = workflowSelection.lastSelection,
+           visibleItems.contains(where: { $0.id == lastSelection }) {
+          workflowSelection.publish([lastSelection])
+        } else if let firstSelection = visibleItems.first {
+          workflowSelection.publish([firstSelection.id])
+        } else {
+          workflowSelection.publish([])
         }
+
+        debounce.process(.init(workflows: workflowSelection.selections))
       })
       .onReceive(NotificationCenter.default.publisher(for: .newWorkflow), perform: { _ in
         proxy.scrollTo("bottom")

--- a/App/Sources/UI/Views/Managers/SelectionManager.swift
+++ b/App/Sources/UI/Views/Managers/SelectionManager.swift
@@ -48,6 +48,7 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
 
   func removeLastSelection() {
     lastSelection = nil
+    initialSelection = nil
   }
 
   func setLastSelection(_ selection: T.ID) {
@@ -63,6 +64,19 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
     if selections != newSelections {
       selections = newSelections
     }
+
+    if newSelections.isEmpty {
+      lastSelection = nil
+      initialSelection = nil
+    } else if let lastSelection, newSelections.contains(lastSelection) {
+      initialSelection = lastSelection
+    } else if let initialSelection, newSelections.contains(initialSelection) {
+      lastSelection = initialSelection
+    } else if let firstSelection = newSelections.first {
+      lastSelection = firstSelection
+      initialSelection = firstSelection
+    }
+
     store(selections)
   }
 
@@ -105,7 +119,7 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
       newSelections = onTap(element)
     }
     store(newSelections)
-    initialSelection = newSelections.first
+    initialSelection = lastSelection ?? newSelections.first
     selections = newSelections
   }
 
@@ -136,6 +150,7 @@ final class SelectionManager<T>: ObservableObject where T: Identifiable,
 
       selections = newSelections
       lastSelection = nextElementID
+      initialSelection = nextElementID
 
       defer {
         proxy?.scrollTo(nextElementID)

--- a/App/Sources/UI/Windows/MainWindow.swift
+++ b/App/Sources/UI/Windows/MainWindow.swift
@@ -22,6 +22,9 @@ final class MainWindow: NSObject, NSWindowDelegate {
       window.orderFrontRegardless()
       window.makeKeyAndOrderFront(nil)
       KeyboardCowboyApp.activate(setActivationPolicy: true)
+      Task { @MainActor [core] in
+        core.rehydrateMainWindowSelection()
+      }
       return
     }
 
@@ -50,6 +53,10 @@ final class MainWindow: NSObject, NSWindowDelegate {
 
     KeyboardCowboyApp.activate(setActivationPolicy: true)
     self.window = window
+
+    Task { @MainActor [core] in
+      core.rehydrateMainWindowSelection()
+    }
   }
 
   func windowWillClose(_: Notification) {

--- a/UnitTests/Sources/Controllers/DropCommandsControllerTests.swift
+++ b/UnitTests/Sources/Controllers/DropCommandsControllerTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Apps
 @testable import Keyboard_Cowboy
 import XCTest
@@ -90,4 +91,43 @@ class DropCommandsControllerTests: XCTestCase {
 
     XCTAssertEqual(openCommand.name, "www.apple.com")
   }
+
+  @MainActor
+  func testOpenCommandRunnerOpensKeyboardCowboyWithoutWorkspace() async throws {
+    let workspace = WorkspaceMock()
+    let subject = OpenCommandRunner(ScriptCommandRunner(), workspace: workspace)
+    let expectation = expectation(forNotification: .openKeyboardCowboy, object: nil)
+
+    try await subject.run(Bundle.main.bundleURL.path, checkCancellation: false, application: nil)
+
+    await fulfillment(of: [expectation], timeout: 1.0)
+    XCTAssertEqual(workspace.openURLCallCount, 0)
+    XCTAssertEqual(workspace.openURLsCallCount, 0)
+    XCTAssertEqual(workspace.openApplicationCallCount, 0)
+  }
+}
+
+private final class WorkspaceMock: WorkspaceProviding, @unchecked Sendable {
+  var applications: [RunningApplication] = []
+  var frontApplication: RunningApplication?
+  var openApplicationCallCount = 0
+  var openURLCallCount = 0
+  var openURLsCallCount = 0
+
+  func openApplication(at _: URL, configuration _: NSWorkspace.OpenConfiguration) async throws -> NSRunningApplication {
+    openApplicationCallCount += 1
+    return NSRunningApplication.current
+  }
+
+  func open(_ _: [URL], withApplicationAt _: URL, configuration _: NSWorkspace.OpenConfiguration) async throws -> NSRunningApplication {
+    openURLsCallCount += 1
+    return NSRunningApplication.current
+  }
+
+  func open(_ _: URL, configuration _: NSWorkspace.OpenConfiguration) async throws -> NSRunningApplication {
+    openURLCallCount += 1
+    return NSRunningApplication.current
+  }
+
+  func reveal(_: String) {}
 }

--- a/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
+++ b/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
@@ -127,6 +127,99 @@ final class ContentViewActionReducerTests: XCTestCase {
     ])
   }
 
+  func testSelectionManagerPublishSynchronizesAnchors() {
+    let subject = SelectionManager<GroupViewModel>()
+
+    subject.publish(["group-1-id"])
+
+    XCTAssertEqual(subject.selections, ["group-1-id"])
+    XCTAssertEqual(subject.lastSelection, "group-1-id")
+    XCTAssertEqual(subject.initialSelection, "group-1-id")
+
+    subject.publish([])
+
+    XCTAssertTrue(subject.selections.isEmpty)
+    XCTAssertNil(subject.lastSelection)
+    XCTAssertNil(subject.initialSelection)
+  }
+
+  func testSelectionManagerPublishPreservesExistingAnchor() {
+    let subject = SelectionManager<GroupViewModel>()
+
+    subject.publish(["group-1-id", "group-2-id"])
+    subject.setLastSelection("group-2-id")
+
+    subject.publish(["group-1-id", "group-2-id"])
+
+    XCTAssertEqual(subject.lastSelection, "group-2-id")
+    XCTAssertEqual(subject.initialSelection, "group-2-id")
+  }
+
+  func testSidebarConfigurationSelectionFallsBackToFirstGroup() {
+    let store = GroupStore(selectionGroups())
+    let selectionManager = SelectionManager<GroupViewModel>()
+    let subject = SidebarCoordinator(
+      store,
+      applicationStore: ApplicationStore.shared,
+      groupSelectionManager: selectionManager,
+    )
+
+    selectionManager.publish(["missing-group-id"])
+
+    subject.handle(.selectConfiguration("configuration-id"))
+
+    XCTAssertEqual(selectionManager.selections, ["group-1-id"])
+    XCTAssertEqual(selectionManager.lastSelection, "group-1-id")
+  }
+
+  func testDeleteConfigurationRefreshesContentSelection() {
+    let store = GroupStore(selectionGroups())
+    let groupSelection = SelectionManager<GroupViewModel>()
+    let workflowSelection = SelectionManager<GroupDetailViewModel>()
+    let subject = GroupCoordinator(
+      store,
+      applicationStore: ApplicationStore.shared,
+      groupSelectionManager: groupSelection,
+      workflowsSelectionManager: workflowSelection,
+    )
+
+    groupSelection.publish(["group-1-id"])
+    workflowSelection.publish(["workflow-1-id"])
+    subject.handle(.selectConfiguration("configuration-id"))
+
+    XCTAssertEqual(subject.contentPublisher.data.map(\.id), ["workflow-1-id", "workflow-2-id"])
+
+    store.groups = []
+    subject.handle(.deleteConfiguration(id: "configuration-id"))
+
+    XCTAssertTrue(subject.contentPublisher.data.isEmpty)
+    XCTAssertTrue(workflowSelection.selections.isEmpty)
+  }
+
+  func testCoreRehydratesMainWindowSelectionFromSelectedConfiguration() {
+    let core = Core()
+    let configuration = KeyboardCowboyConfiguration(
+      id: "config-1-id",
+      name: "Config 1",
+      userModes: [],
+      groups: selectionGroups(),
+    )
+
+    core.contentStore.handle(.empty)
+    core.configurationStore.updateConfigurations([configuration])
+    core.contentStore.use(configuration)
+    core.configSelection.publish([])
+    core.groupSelection.publish([])
+    core.workflowsSelection.publish([])
+
+    core.rehydrateMainWindowSelection()
+
+    XCTAssertEqual(core.configSelection.selections, ["config-1-id"])
+    XCTAssertEqual(core.groupSelection.selections, ["group-1-id"])
+    XCTAssertEqual(core.workflowsSelection.selections, ["workflow-1-id"])
+    XCTAssertEqual(core.groupCoordinator.contentPublisher.data.map(\.id), ["workflow-1-id", "workflow-2-id"])
+  }
+
   // MARK: Private methods
 
   private func subject(_ id: String) -> (original: WorkflowGroup, copy: WorkflowGroup) {
@@ -134,8 +227,20 @@ final class ContentViewActionReducerTests: XCTestCase {
     return (original: group, copy: group)
   }
 
+  private func selectionGroups() -> [WorkflowGroup] {
+    [
+      .init(id: "group-1-id", name: "group-1-name", workflows: [
+        .init(id: "workflow-1-id", name: "workflow-1-name"),
+        .init(id: "workflow-2-id", name: "workflow-2-name"),
+      ]),
+      .init(id: "group-2-id", name: "group-2-name", workflows: [
+        .init(id: "workflow-3-id", name: "workflow-3-name"),
+      ]),
+    ]
+  }
+
   private func context(_ groups: [WorkflowGroup] = []) -> (store: GroupStore,
-                                                           selector: SelectionManager<GroupDetailViewModel>) {
+                                                            selector: SelectionManager<GroupDetailViewModel>) {
     (store: GroupStore(groups), selector: SelectionManager())
   }
 }


### PR DESCRIPTION
Rebuild the sidebar, content, and detail selections when the main window opens so reopening the window restores a valid selected configuration and its dependent views instead of leaving the content area empty