### PR TITLE
fix(window-focus): reset ring state on Space changes

### DIFF
--- a/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
+++ b/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
@@ -16,6 +16,12 @@ extension KeyboardCowboyApp {
   static func env() -> AppEnvironment { .production }
   #endif
 
+  static var isRunningTests: Bool {
+    launchArguments.isEnabled(.runningUnitTests) ||
+      ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||
+      NSClassFromString("XCTestCase") != nil
+  }
+
   static let mainWindowIdentifier = "MainWindow"
   static let permissionsSettingsWindowIdentifier = "PermissionsSettingsWindow"
   static let emptyConfigurationWindowIdentifier = "EmptyConfigurationWindow"

--- a/App/Sources/Core/Preferences/AppPreferences.swift
+++ b/App/Sources/Core/Preferences/AppPreferences.swift
@@ -3,7 +3,7 @@ import Cocoa
 @MainActor
 struct AppPreferences {
   static var config: AppPreferences {
-    if launchArguments.isEnabled(.runningUnitTests) {
+    if KeyboardCowboyApp.isRunningTests {
       return AppPreferences.unitTests()
     }
 

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -76,7 +76,7 @@ final class KeyboardCowboyEngine {
   }
 
   func setupMachPortAndSubscriptions(_ workspace: NSWorkspace) {
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
 
     do {
       let keyboardEvents: CGEventMask = (1 << CGEventType.keyDown.rawValue)

--- a/App/Sources/Core/Runners/WindowFocus/WindowCommandFocusRunner.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowCommandFocusRunner.swift
@@ -34,6 +34,7 @@ final class WindowCommandFocusRunner {
       .publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
       .sink { [weak self] _ in
         self?.resetFocusComponents()
+        WindowFocus.handleActiveSpaceDidChange()
       }
   }
 

--- a/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
@@ -236,7 +236,7 @@ enum WindowFocus {
   private static func syncCursor(with windows: [WindowModel], in ring: RingBuffer<WindowModel>) {
     ring.update(windows)
 
-    guard let focusedWindow = focusedWindow(in: windows) else { return }
+    guard let focusedWindow = focusedWindow(in: windows) ?? windows.first else { return }
 
     ring.setCursor(to: focusedWindow)
   }

--- a/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
@@ -21,6 +21,15 @@ enum WindowFocus {
     updateRings()
   }
 
+  static func handleActiveSpaceDidChange() {
+    resetState()
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+      WindowStore.shared.index()
+      WindowFocus.updateRings()
+    }
+  }
+
   static func updateRings(_ windowId: CGWindowID? = nil) {
     guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else { return }
 
@@ -32,6 +41,8 @@ enum WindowFocus {
       .filter { $0.ownerPid.rawValue == frontmostApplication.processIdentifier }
 
     appRing.update(newAppWindows)
+    globalRing.update(visibleWindowsInSpace)
+    stageRing.update(visibleWindowsInStage)
 
     let processIdentifier = frontmostApplication.processIdentifier
     let app = AppAccessibilityElement(processIdentifier)
@@ -77,7 +88,6 @@ enum WindowFocus {
     guard let (newCollection, ringKind, ring) = collection(for: kind, snapshot: snapshot) else {
       return
     }
-
     guard !newCollection.isEmpty else { return }
 
     if isPrevious(kind),
@@ -124,11 +134,15 @@ enum WindowFocus {
     if stageWindowIds.contains(previousWindowId),
        stageWindowIds.contains(currentWindowId) {
       previousWindowIds[.stage] = previousWindowId
+    } else {
+      previousWindowIds[.stage] = nil
     }
 
     if globalWindowIds.contains(previousWindowId),
        globalWindowIds.contains(currentWindowId) {
       previousWindowIds[.global] = previousWindowId
+    } else {
+      previousWindowIds[.global] = nil
     }
   }
 
@@ -225,6 +239,16 @@ enum WindowFocus {
     guard let focusedWindow = focusedWindow(in: windows) else { return }
 
     ring.setCursor(to: focusedWindow)
+  }
+
+  static func resetState() {
+    visibleMostIndexByRing.removeAll()
+    previousWindowIds.removeAll()
+    appRing = RingBuffer<WindowModel>()
+    globalRing = RingBuffer<WindowModel>()
+    stageRing = RingBuffer<WindowModel>()
+    pendingFocusWindowId = nil
+    currentWindow = nil
   }
 
   private static func focusedWindow(in windows: [WindowModel]) -> WindowModel? {

--- a/App/Sources/Core/Stores/ContentStore.swift
+++ b/App/Sources/Core/Stores/ContentStore.swift
@@ -47,7 +47,7 @@ final class ContentStore: ObservableObject {
     self.recorderStore = recorderStore
 
     guard KeyboardCowboyApp.env() != .previews else { return }
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
 
     UserSpace.shared.subscribe(to: configurationStore.$selectedConfiguration)
 

--- a/App/Sources/UI/AppExtraCoordinator.swift
+++ b/App/Sources/UI/AppExtraCoordinator.swift
@@ -12,7 +12,7 @@ final class AppExtraCoordinator {
   }
 
   func handle(_ action: AppMenuBarExtras.Action) {
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
     guard !isRunningPreview else { return }
 
     switch action {

--- a/App/Sources/UI/Stores/AppStorageContainer.swift
+++ b/App/Sources/UI/Stores/AppStorageContainer.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @MainActor
 final class AppStorageContainer: @unchecked Sendable {
   static let store: UserDefaults = {
-    if launchArguments.isEnabled(.runningUnitTests) {
+    if KeyboardCowboyApp.isRunningTests {
       return UserDefaults(suiteName: "com.zenangst.Keyboard-Cowboy.unit-tests") ?? .standard
     }
 

--- a/App/Sources/UI/Views/AppMenuBarExtras.swift
+++ b/App/Sources/UI/Views/AppMenuBarExtras.swift
@@ -88,7 +88,7 @@ struct AppMenuBarExtras: Scene {
     var body: some View {
       if isRunningPreview {
         Image(systemName: "theatermask.and.paintbrush")
-      } else if launchArguments.isEnabled(.runningUnitTests) {
+      } else if KeyboardCowboyApp.isRunningTests {
         Image(systemName: "testtube.2")
       } else if KeyboardCowboyApp.env() == .production {
         Image(systemName: "command")

--- a/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
+++ b/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
@@ -295,6 +295,30 @@ final class ContentViewActionReducerTests: XCTestCase {
     XCTAssertNil(WindowFocus.pendingFocusWindowId)
   }
 
+  func testKeyboardCowboyAppDetectsUnitTests() {
+    XCTAssertTrue(KeyboardCowboyApp.isRunningTests)
+  }
+
+  func testAppPreferencesUsesUnitTestConfigurationLocation() {
+    XCTAssertEqual(AppPreferences.config.configLocation, .unitTests)
+  }
+
+  func testAppStorageContainerUsesDedicatedUnitTestDefaultsSuite() {
+    let key = UUID().uuidString
+    let value = UUID().uuidString
+
+    AppStorageContainer.store.removeObject(forKey: key)
+    UserDefaults.standard.removeObject(forKey: key)
+
+    AppStorageContainer.store.set(value, forKey: key)
+
+    XCTAssertEqual(AppStorageContainer.store.string(forKey: key), value)
+    XCTAssertNil(UserDefaults.standard.string(forKey: key))
+
+    AppStorageContainer.store.removeObject(forKey: key)
+    UserDefaults.standard.removeObject(forKey: key)
+  }
+
   // MARK: Private methods
 
   private func subject(_ id: String) -> (original: WorkflowGroup, copy: WorkflowGroup) {

--- a/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
+++ b/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
@@ -267,6 +267,34 @@ final class ContentViewActionReducerTests: XCTestCase {
     XCTAssertNil(WindowFocus.previousWindowIds[.global])
   }
 
+  func testWindowFocusPreviousWindowIdClearsInvalidStageAndGlobalScope() {
+    WindowFocus.previousWindowIds = [.stage: 10, .global: 10]
+
+    WindowFocus.updatePreviousWindowIds(
+      previousWindowId: 10,
+      previousOwnerPid: 100,
+      currentWindowId: 20,
+      currentOwnerPid: 100,
+      appWindowIds: [10, 20],
+      stageWindowIds: [20, 30],
+      globalWindowIds: [20, 30],
+    )
+
+    XCTAssertEqual(WindowFocus.previousWindowIds[.app], 10)
+    XCTAssertNil(WindowFocus.previousWindowIds[.stage])
+    XCTAssertNil(WindowFocus.previousWindowIds[.global])
+  }
+
+  func testWindowFocusResetStateClearsCachedNavigationState() {
+    WindowFocus.previousWindowIds = [.app: 10, .stage: 20, .global: 30]
+    WindowFocus.pendingFocusWindowId = 42
+
+    WindowFocus.resetState()
+
+    XCTAssertTrue(WindowFocus.previousWindowIds.isEmpty)
+    XCTAssertNil(WindowFocus.pendingFocusWindowId)
+  }
+
   // MARK: Private methods
 
   private func subject(_ id: String) -> (original: WorkflowGroup, copy: WorkflowGroup) {


### PR DESCRIPTION
Clear stale focus-ring state when macOS changes Spaces, then reindex and rebuild the window collections from the current screen before the next focus command runs.
Also improve previous-window invalidation.
