### PR TITLE
fix(app): unify test-mode detection and cursor sync

### DIFF
--- a/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
+++ b/App/Sources/Core/Extensions/KeyboardCowboyApp+Extensions.swift
@@ -16,6 +16,12 @@ extension KeyboardCowboyApp {
   static func env() -> AppEnvironment { .production }
   #endif
 
+  static var isRunningTests: Bool {
+    launchArguments.isEnabled(.runningUnitTests) ||
+      ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil ||
+      NSClassFromString("XCTestCase") != nil
+  }
+
   static let mainWindowIdentifier = "MainWindow"
   static let permissionsSettingsWindowIdentifier = "PermissionsSettingsWindow"
   static let emptyConfigurationWindowIdentifier = "EmptyConfigurationWindow"

--- a/App/Sources/Core/Preferences/AppPreferences.swift
+++ b/App/Sources/Core/Preferences/AppPreferences.swift
@@ -3,7 +3,7 @@ import Cocoa
 @MainActor
 struct AppPreferences {
   static var config: AppPreferences {
-    if launchArguments.isEnabled(.runningUnitTests) {
+    if KeyboardCowboyApp.isRunningTests {
       return AppPreferences.unitTests()
     }
 

--- a/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
+++ b/App/Sources/Core/Runners/KeyboardCowboyEngine.swift
@@ -76,7 +76,7 @@ final class KeyboardCowboyEngine {
   }
 
   func setupMachPortAndSubscriptions(_ workspace: NSWorkspace) {
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
 
     do {
       let keyboardEvents: CGEventMask = (1 << CGEventType.keyDown.rawValue)

--- a/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
+++ b/App/Sources/Core/Runners/WindowFocus/WindowFocus.swift
@@ -236,7 +236,7 @@ enum WindowFocus {
   private static func syncCursor(with windows: [WindowModel], in ring: RingBuffer<WindowModel>) {
     ring.update(windows)
 
-    guard let focusedWindow = focusedWindow(in: windows) else { return }
+    guard let focusedWindow = focusedWindow(in: windows) ?? windows.first else { return }
 
     ring.setCursor(to: focusedWindow)
   }

--- a/App/Sources/Core/Stores/ContentStore.swift
+++ b/App/Sources/Core/Stores/ContentStore.swift
@@ -47,7 +47,7 @@ final class ContentStore: ObservableObject {
     self.recorderStore = recorderStore
 
     guard KeyboardCowboyApp.env() != .previews else { return }
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
 
     UserSpace.shared.subscribe(to: configurationStore.$selectedConfiguration)
 

--- a/App/Sources/UI/AppExtraCoordinator.swift
+++ b/App/Sources/UI/AppExtraCoordinator.swift
@@ -12,7 +12,7 @@ final class AppExtraCoordinator {
   }
 
   func handle(_ action: AppMenuBarExtras.Action) {
-    guard !launchArguments.isEnabled(.runningUnitTests) else { return }
+    guard !KeyboardCowboyApp.isRunningTests else { return }
     guard !isRunningPreview else { return }
 
     switch action {

--- a/App/Sources/UI/Stores/AppStorageContainer.swift
+++ b/App/Sources/UI/Stores/AppStorageContainer.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @MainActor
 final class AppStorageContainer: @unchecked Sendable {
   static let store: UserDefaults = {
-    if launchArguments.isEnabled(.runningUnitTests) {
+    if KeyboardCowboyApp.isRunningTests {
       return UserDefaults(suiteName: "com.zenangst.Keyboard-Cowboy.unit-tests") ?? .standard
     }
 

--- a/App/Sources/UI/Views/AppMenuBarExtras.swift
+++ b/App/Sources/UI/Views/AppMenuBarExtras.swift
@@ -88,7 +88,7 @@ struct AppMenuBarExtras: Scene {
     var body: some View {
       if isRunningPreview {
         Image(systemName: "theatermask.and.paintbrush")
-      } else if launchArguments.isEnabled(.runningUnitTests) {
+      } else if KeyboardCowboyApp.isRunningTests {
         Image(systemName: "testtube.2")
       } else if KeyboardCowboyApp.env() == .production {
         Image(systemName: "command")

--- a/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
+++ b/UnitTests/Sources/Models/ContentViewActionReducerTests.swift
@@ -295,6 +295,30 @@ final class ContentViewActionReducerTests: XCTestCase {
     XCTAssertNil(WindowFocus.pendingFocusWindowId)
   }
 
+  func testKeyboardCowboyAppDetectsUnitTests() {
+    XCTAssertTrue(KeyboardCowboyApp.isRunningTests)
+  }
+
+  func testAppPreferencesUsesUnitTestConfigurationLocation() {
+    XCTAssertEqual(AppPreferences.config.configLocation, .unitTests)
+  }
+
+  func testAppStorageContainerUsesDedicatedUnitTestDefaultsSuite() {
+    let key = UUID().uuidString
+    let value = UUID().uuidString
+
+    AppStorageContainer.store.removeObject(forKey: key)
+    UserDefaults.standard.removeObject(forKey: key)
+
+    AppStorageContainer.store.set(value, forKey: key)
+
+    XCTAssertEqual(AppStorageContainer.store.string(forKey: key), value)
+    XCTAssertNil(UserDefaults.standard.string(forKey: key))
+
+    AppStorageContainer.store.removeObject(forKey: key)
+    UserDefaults.standard.removeObject(forKey: key)
+  }
+
   // MARK: Private methods
 
   private func subject(_ id: String) -> (original: WorkflowGroup, copy: WorkflowGroup) {


### PR DESCRIPTION
Introduce a shared `KeyboardCowboyApp.isRunningTests` check so preferences, storage, engine setup, and menu-bar handling all use the same test-detection logic.
Also make window focus cursor syncing fall back to the first window when no focused window is available, and add unit tests covering the new behavior.
